### PR TITLE
fix: 修正 desktop 文件 Exec 字段指向的可执行文件名称

### DIFF
--- a/app/channels/oss/dev.warp.OpenWarp.desktop
+++ b/app/channels/oss/dev.warp.OpenWarp.desktop
@@ -7,7 +7,7 @@ Type=Application
 Name=OpenWarp
 GenericName=TerminalEmulator
 
-Exec=warp-oss %U
+Exec=warp-terminal-oss %U
 StartupWMClass=dev.warp.OpenWarp
 
 Keywords=shell;prompt;command;commandline;cmd;


### PR DESCRIPTION
## Description

修正 desktop 文件 Exec 字段指向的可执行文件名称。打包被安装到系统的是 warp-terminal-oss，Exec 里之前写的 warp-oss，会导致点击图标后无法实际启动程序。

## Linked Issue

https://github.com/zerx-lab/warp/issues/8 （只是相关，并不解决此 issue。详情也请见此 issue）
