### PR TITLE
Update GitHub links to remove openWarp branch references

### DIFF
--- a/website/src/components/CTA.astro
+++ b/website/src/components/CTA.astro
@@ -43,7 +43,7 @@ const d = t(locale);
       </div>
 
       <div class="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
-        <a href="https://github.com/zerx-lab/warp/tree/openWarp" target="_blank" rel="noreferrer" class="btn-primary w-full sm:w-auto">
+        <a href="https://github.com/zerx-lab/warp" target="_blank" rel="noreferrer" class="btn-primary w-full sm:w-auto">
           <svg viewBox="0 0 24 24" class="h-4 w-4" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.18c-3.2.7-3.87-1.37-3.87-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.39.97.01 1.95.14 2.86.39 2.19-1.48 3.15-1.17 3.15-1.17.62 1.59.23 2.76.11 3.05.74.8 1.18 1.82 1.18 3.08 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
           {d.cta.button}
         </a>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -34,7 +34,7 @@ const roadmapHref = localizedPath(locale, '/roadmap');
         <div>
           <h4 class="text-xs font-semibold uppercase tracking-[0.22em] text-zinc-500">{dict.footer.community}</h4>
           <ul class="mt-4 space-y-3 text-sm">
-            <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp/tree/openWarp">GitHub</a></li>
+            <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp">GitHub</a></li>
             <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp/discussions">{dict.footer.discussions}</a></li>
             <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp/issues">{dict.footer.issues}</a></li>
           </ul>
@@ -43,7 +43,7 @@ const roadmapHref = localizedPath(locale, '/roadmap');
         <div>
           <h4 class="text-xs font-semibold uppercase tracking-[0.22em] text-zinc-500">{dict.footer.legal}</h4>
           <ul class="mt-4 space-y-3 text-sm">
-            <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp/blob/openWarp/LICENSE-AGPL">{dict.footer.license}</a></li>
+            <li><a class="text-zinc-400 transition hover:text-white" href="https://github.com/zerx-lab/warp">{dict.footer.license}</a></li>
             <li><a class="text-zinc-400 transition hover:text-white" href="#faq">{dict.footer.privacy}</a></li>
             <li><a class="text-zinc-400 transition hover:text-white" href="#cta">{dict.cta.button}</a></li>
           </ul>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -14,7 +14,7 @@ const dict = t(locale);
       <span class="inline-flex h-1.5 w-1.5 rounded-full bg-accent-lime shadow-[0_0_16px_rgba(185,255,90,0.75)]"></span>
       <span class="text-zinc-300">{dict.hero.badge}</span>
       <span class="text-zinc-600">·</span>
-      <a href="https://github.com/zerx-lab/warp/tree/openWarp" target="_blank" rel="noreferrer" class="transition hover:text-white">
+      <a href="https://github.com/zerx-lab/warp" target="_blank" rel="noreferrer" class="transition hover:text-white">
         {dict.hero.note}
       </a>
     </div>
@@ -52,7 +52,7 @@ const dict = t(locale);
         ))}
       </div>
       <a
-        href="https://github.com/zerx-lab/warp/tree/openWarp"
+        href="https://github.com/zerx-lab/warp"
         target="_blank"
         rel="noreferrer"
         class="btn-ghost !px-4 !py-2"

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -31,7 +31,7 @@ const trustLogos = ['OpenAI', 'Anthropic', 'DeepSeek', 'Qwen', 'Ollama', 'Groq']
       </p>
 
       <div class="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
-        <a href="https://github.com/zerx-lab/warp/tree/openWarp" target="_blank" rel="noreferrer" class="btn-primary group w-full sm:w-auto">
+        <a href="https://github.com/zerx-lab/warp" target="_blank" rel="noreferrer" class="btn-primary group w-full sm:w-auto">
           <svg viewBox="0 0 24 24" class="h-4 w-4" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.18c-3.2.7-3.87-1.37-3.87-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.39.97.01 1.95.14 2.86.39 2.19-1.48 3.15-1.17 3.15-1.17.62 1.59.23 2.76.11 3.05.74.8 1.18 1.82 1.18 3.08 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
           {d.hero.cta_primary}
         </a>

--- a/website/src/components/Roadmap.astro
+++ b/website/src/components/Roadmap.astro
@@ -89,7 +89,7 @@ const statusStyles: Record<string, { dot: string; chip: string; label: string }>
       <p class="mt-3 text-[13.5px] leading-relaxed text-zinc-400">{r.footnote_body}</p>
       <div class="mt-5 flex flex-wrap gap-3">
         <a
-          href="https://github.com/zerx-lab/warp/tree/openWarp"
+          href="https://github.com/zerx-lab/warp"
           target="_blank"
           rel="noreferrer"
           class="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-4 py-2 text-[13px] text-white transition hover:bg-white/[0.07]"

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -213,7 +213,7 @@ export const en: Dict = {
     desc: "Clone the repo and build locally, or watch GitHub for the next release.",
     button: "Go to GitHub",
     command_label: "Clone the repo",
-    command: "git clone -b openWarp https://github.com/zerx-lab/warp",
+    command: "git clone https://github.com/zerx-lab/warp",
     copy: "Copy",
     copied: "Copied",
     steps: [

--- a/website/src/i18n/zh-CN.ts
+++ b/website/src/i18n/zh-CN.ts
@@ -211,7 +211,7 @@ export const zhCN = {
     desc: "克隆仓库本地构建,或关注 GitHub 接收每次发布更新。",
     button: "前往 GitHub",
     command_label: "克隆仓库",
-    command: "git clone -b openWarp https://github.com/zerx-lab/warp",
+    command: "git clone https://github.com/zerx-lab/warp",
     copy: "复制",
     copied: "已复制",
     steps: [


### PR DESCRIPTION
## Description

This PR updates all GitHub repository links throughout the website to point to the main repository instead of the `openWarp` branch. The changes include:

- Updated GitHub links in Footer, Header, CTA, Hero, and Roadmap components to use `https://github.com/zerx-lab/warp` instead of `https://github.com/zerx-lab/warp/tree/openWarp`
- Updated the license link in the Footer to point to the main repository
- Removed the `-b openWarp` branch specification from git clone commands in both English and Chinese localization files

These changes consolidate the repository references to the main branch, simplifying the user experience and ensuring all links point to the primary repository location.

## Testing

No testing needed. These are straightforward URL and text updates that don't affect functionality. The changes can be verified by checking that all links render correctly and point to the expected GitHub repository URLs.

## Changelog Entries for Stable

N/A - This is a documentation/link update with no user-facing feature changes.

https://claude.ai/code/session_018dU4dHM1zvxubZURUKRLc8