### PR TITLE
fix: 禁用 OpenWarp 的 macOS App Group 状态目录

### DIFF
--- a/crates/warp_core/src/paths.rs
+++ b/crates/warp_core/src/paths.rs
@@ -160,7 +160,7 @@ pub fn state_dir() -> PathBuf {
 /// On macOS, this will use the App Group container directory if available.
 pub fn secure_state_dir() -> Option<PathBuf> {
     // Do not use the secure state directory in integration tests, which have a temporary home directory instead.
-    if ChannelState::channel() == Channel::Integration {
+    if matches!(ChannelState::channel(), Channel::Integration | Channel::Oss) {
         return None;
     }
 

--- a/crates/warp_core/src/paths_tests.rs
+++ b/crates/warp_core/src/paths_tests.rs
@@ -97,6 +97,12 @@ fn test_state_dir_path() {
 }
 
 #[test]
+#[cfg(target_os = "macos")]
+fn test_oss_secure_state_dir_is_disabled() {
+    assert_eq!(secure_state_dir(), None);
+}
+
+#[test]
 fn test_project_path_for_warp_app_id() {
     let project_dirs = project_dirs_for_app_id(AppId::new("dev", "warp", "Warp"), None)
         .expect("should be able to compute project dirs");


### PR DESCRIPTION
## Description

修复 OpenWarp macOS 启动时反复弹出“想访问其他 App 的数据”的权限请求。

根因是 OpenWarp 已使用独立 bundle id `dev.openwarp.OpenWarp`,但 `secure_state_dir()` 仍会优先探测官方 Warp 的 App Group container `2BBY89MBSN.dev.warp`。macOS 会把这类访问识别为访问其他 App 的数据,因此每次启动都可能弹权限提示。

本 PR 做两件事:

1. OSS channel 禁用 App Group secure state dir,让 OpenWarp 回退到自己的 `state_dir()`。
2. 修复 review P1:如果旧版本已经把 `warp.sqlite`、`warp.sqlite-wal`、`warp.sqlite-shm` 迁进官方 App Group,启动时会把较新的旧 App Group SQLite 复制回 OpenWarp 自己的 state dir；如果本地 state dir 数据更新,则保留本地数据。迁移检查完成后写 marker,避免后续启动重复访问旧 App Group。

## Testing

- `rustfmt --check app/src/persistence/sqlite.rs app/src/persistence/sqlite_tests.rs crates/warp_core/src/paths.rs crates/warp_core/src/paths_tests.rs`
- `cargo check -p warp --lib`
- `cargo test -p warp_core paths`

已尝试运行 `cargo test -p warp --lib test_openwarp_app_group_sqlite`,但当前仓库的 `warp` lib test 目标被无关既有编译错误阻塞,未执行到新增测试:

- `app/src/ai/blocklist/context_model_test.rs`: `AgentViewController::new` 调用参数仍是旧签名
- `app/src/test_util/terminal.rs` / `app/src/terminal/input_test.rs` / `app/src/workspace/view_test.rs`: `RestoredAgentConversations::new(vec![])` 返回类型不满足 `SingletonEntity`

此前尝试过全量 `cargo fmt -- --check`,失败点来自本 PR 未触碰的既有文件 `app/src/ai/agent_providers/chat_stream.rs`。

## Server API dependencies

无服务端 API 依赖。

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed OpenWarp repeatedly prompting for macOS permission to access other app data on launch.

Co-Authored-By: Warp <agent@warp.dev>
