### PR TITLE
feat(i18n): 为 workspace 主面板添加国际化支持

### DIFF
--- a/app/i18n/PROGRESS.md
+++ b/app/i18n/PROGRESS.md
@@ -31,7 +31,7 @@
 | 3 | command_palette | `app/src/command_palette.rs`, `app/src/palette/**` | ⬜ | ⬜ | ⬜ | (free) | |
 | 4 | drive | `app/src/drive/**` | ⬜ | ⬜ | ⬜ | (free) | |
 | 5 | onboarding | `crates/onboarding/**`, `app/src/coding_entrypoints/**` | ⬜ | ⬜ | ⬜ | (free) | 跨 crate 注意:`onboarding` 是独立 crate,要看是否单独建 i18n |
-| 6 | workspace | `app/src/workspace/**`, `app/src/workspaces/**` | ⬜ | ⬜ | ⬜ | (free) | |
+| 6 | workspace | `app/src/workspace/**`, `app/src/workspaces/**` | 🟡 (view.rs + delete_conversation_confirmation_dialog.rs + vertical_tabs.rs) | 🟡 | 20+ | agent-workspace-i18n | workspace-runtime section 已有基础 key；新增版本更新(workspace-version-*)、worktree(workspace-worktree-*)、对话框(workspace-dialog-*)、toast(workspace-toast-*)、溢出计数(workspace-overflow-*)相关 key。call sites:view.rs(版本更新3处+worktree4处+对话框1处+toast8处)、delete_conversation_confirmation_dialog.rs(3处)、vertical_tabs.rs(溢出计数3处)。需验证 cargo check。
 | 7 | modal & prompt | `app/src/modal/**`, `app/src/prompt/**`, `app/src/quit_warning/**` | 🟡 | 🟡 | 14 | agent-quit-warning | quit_warning ✅,modal/prompt 待办 |
 | 7a | quit_warning | `app/src/quit_warning/mod.rs` | ✅ | ✅ | 14 | agent-quit-warning | 退出/关闭确认对话框 |
 | 1b | settings-warpify | `app/src/settings_view/warpify_page.rs` | ✅ | ✅ | 17 | agent-settings-warpify | Warpify 子页(subshell + SSH 配置)。19 key:page-title / description-prefix / learn-more / section-subshells(+subtitle)/ section-ssh(+subtitle)/ added-commands / denylisted-commands / denylisted-hosts / command-placeholder / host-placeholder / enable-ssh / install-ssh-extension(+description)/ use-tmux / tmux-description / ssh-tmux-toggle-binding-label。Category 要求 'static 用 Box::leak 提升 |

--- a/app/i18n/en/warp.ftl
+++ b/app/i18n/en/warp.ftl
@@ -177,6 +177,44 @@ workspace-view-all-cloud-runs = View all cloud runs
 pane-get-started-title = Get started
 pane-new-tab-title = New tab
 
+# Version update related
+workspace-version-current = Current version is { $version }
+workspace-version-install-update = Install update ({ $version })
+workspace-version-updating-to = Updating to ({ $version })
+
+# Worktree related
+workspace-worktree-new-with-name = New worktree: { $repo }, { $name }
+workspace-worktree-new-with-branch = New worktree: { $repo }, { $branch }
+workspace-worktree-new-default = New worktree: { $repo }
+workspace-worktree-title = Worktree: { $repo }
+
+# Dialog titles
+workspace-dialog-open-title = Open: { $name }
+workspace-dialog-delete-title = Delete '{ $title }'?
+workspace-dialog-delete-generic = Delete conversation?
+
+# Dialog body text
+workspace-dialog-delete-body = This conversation will be permanently deleted. This action cannot be undone.
+
+# Toast messages
+workspace-toast-forked-conversation = Forked "{ $title }"
+workspace-toast-mouse-reporting = You { $verb } mouse reporting.
+workspace-toast-mouse-reporting-with-undo = You { $verb } mouse reporting. Press { $keystroke } to undo.
+workspace-toast-synchronized-inputs-all-tabs = You { $verb } synchronized inputs in all tabs.
+workspace-toast-synchronized-inputs-all-tabs-with-undo = You { $verb } synchronized inputs in all tabs. Press { $keystroke } to undo.
+workspace-toast-synchronized-inputs-current-tab = You { $verb } synchronized inputs in this tab.
+workspace-toast-synchronized-inputs-current-tab-with-undo = You { $verb } synchronized inputs in this tab. Press { $keystroke } to undo.
+workspace-toast-install-cli-success = Successfully installed the Oz CLI! You can now run '{ $command }' from the command line.
+workspace-toast-install-cli-failed = Failed to install Oz command: { $error }
+workspace-toast-uninstall-cli-failed = Failed to uninstall Oz command: { $error }
+workspace-toast-remove-config-failed = Failed to remove tab config: { $error }
+workspace-toast-create-log-bundle-failed = Failed to create log bundle: { $error }
+workspace-toast-process-sample-saved = Process sample saved to { $path }
+
+# Overflow count
+workspace-overflow-more-items = + { $count } more
+workspace-overflow-and-more-items = and { $count } more
+
 # =============================================================================
 # SECTION: terminal-runtime (Owner: agent-i18n-remaining)
 # Files: app/src/terminal/view.rs

--- a/app/i18n/zh-CN/warp.ftl
+++ b/app/i18n/zh-CN/warp.ftl
@@ -172,6 +172,44 @@ workspace-view-all-cloud-runs = 查看所有云端运行
 pane-get-started-title = 开始使用
 pane-new-tab-title = 新建标签页
 
+# 版本更新相关
+workspace-version-current = 当前版本是 { $version }
+workspace-version-install-update = 安装更新 ({ $version })
+workspace-version-updating-to = 正在更新到 ({ $version })
+
+# Worktree 相关
+workspace-worktree-new-with-name = 新建 worktree: { $repo }, { $name }
+workspace-worktree-new-with-branch = 新建 worktree: { $repo }, { $branch }
+workspace-worktree-new-default = 新建 worktree: { $repo }
+workspace-worktree-title = Worktree: { $repo }
+
+# 对话框标题
+workspace-dialog-open-title = 打开: { $name }
+workspace-dialog-delete-title = 删除 '{ $title }'?
+workspace-dialog-delete-generic = 删除对话?
+
+# 对话框正文
+workspace-dialog-delete-body = 此对话将被永久删除。此操作无法撤销。
+
+# Toast 提示
+workspace-toast-forked-conversation = 已 fork "{ $title }"
+workspace-toast-mouse-reporting = 你已{ $verb }鼠标报告
+workspace-toast-mouse-reporting-with-undo = 你已{ $verb }鼠标报告。按 { $keystroke } 撤销。
+workspace-toast-synchronized-inputs-all-tabs = 你已{ $verb }所有标签页的同步输入
+workspace-toast-synchronized-inputs-all-tabs-with-undo = 你已{ $verb }所有标签页的同步输入。按 { $keystroke } 撤销。
+workspace-toast-synchronized-inputs-current-tab = 你已{ $verb }当前标签页的同步输入
+workspace-toast-synchronized-inputs-current-tab-with-undo = 你已{ $verb }当前标签页的同步输入。按 { $keystroke } 撤销。
+workspace-toast-install-cli-success = 成功安装 Oz CLI！现在可以在命令行运行 '{ $command }'。
+workspace-toast-install-cli-failed = 安装 Oz 命令失败: { $error }
+workspace-toast-uninstall-cli-failed = 卸载 Oz 命令失败: { $error }
+workspace-toast-remove-config-failed = 删除标签页配置失败: { $error }
+workspace-toast-create-log-bundle-failed = 创建日志包失败: { $error }
+workspace-toast-process-sample-saved = 进程样本已保存到 { $path }
+
+# 溢出计数
+workspace-overflow-more-items = + 还有 { $count } 个
+workspace-overflow-and-more-items = 还有 { $count } 个
+
 # =============================================================================
 # SECTION: terminal-runtime (Owner: agent-i18n-remaining)
 # =============================================================================

--- a/app/src/workspace/delete_conversation_confirmation_dialog.rs
+++ b/app/src/workspace/delete_conversation_confirmation_dialog.rs
@@ -103,15 +103,12 @@ impl View for DeleteConversationConfirmationDialog {
         let title = self
             .source
             .as_ref()
-            .map(|s| format!("Delete '{}'?", s.conversation_title))
-            .unwrap_or_else(|| "Delete conversation?".into());
+            .map(|s| crate::t!("workspace-dialog-delete-title", title = s.conversation_title))
+            .unwrap_or_else(|| crate::t!("workspace-dialog-delete-generic"));
 
         let dialog = Dialog::new(
             title,
-            Some(
-                "This conversation will be permanently deleted. This action cannot be undone."
-                    .into(),
-            ),
+            Some(crate::t!("workspace-dialog-delete-body")),
             UiComponentStyles {
                 width: Some(DIALOG_WIDTH),
                 ..dialog_styles(appearance)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -1928,7 +1928,7 @@ impl Workspace {
                     log::warn!("Failed to remove tab config file: {e:?}");
                     self.toast_stack.update(ctx, |toast_stack, ctx| {
                         toast_stack.add_ephemeral_toast(
-                            DismissibleToast::error(format!("Failed to remove tab config: {e}")),
+                            DismissibleToast::error(crate::t!("workspace-toast-remove-config-failed", error = e)),
                             ctx,
                         );
                     });
@@ -6022,7 +6022,7 @@ impl Workspace {
                     ctx.open_file_path_in_explorer(&path);
                 }
                 Ok(Err(err)) => {
-                    let error_message = format!("Failed to create log bundle: {err}");
+                    let error_message = crate::t!("workspace-toast-create-log-bundle-failed", error = err);
                     log::error!("{error_message}");
                     me.toast_stack.update(ctx, |toast_stack, ctx| {
                         let toast = DismissibleToast::error(error_message);
@@ -6030,7 +6030,7 @@ impl Workspace {
                     });
                 }
                 Err(err) => {
-                    let error_message = format!("Failed to create log bundle: {err}");
+                    let error_message = crate::t!("workspace-toast-create-log-bundle-failed", error = err);
                     log::error!("{error_message}");
                     me.toast_stack.update(ctx, |toast_stack, ctx| {
                         let toast = DismissibleToast::error(error_message);
@@ -6420,7 +6420,7 @@ impl Workspace {
                 .and_then(|view| view.as_ref(ctx).pwd())
                 .map(PathBuf::from);
 
-            let modal_title = format!("Open: {}", tab_config.name);
+            let modal_title = crate::t!("workspace-dialog-open-title", name = tab_config.name);
             self.tab_config_params_modal.view.update(ctx, |modal, ctx| {
                 modal.body().update(ctx, |body, ctx| {
                     body.set_title(modal_title);
@@ -6597,19 +6597,19 @@ impl Workspace {
         if FeatureFlag::Autoupdate.is_enabled() && ChannelState::show_autoupdate_menu_items() {
             if let Some(version) = ChannelState::app_version() {
                 menu_items.push(
-                    MenuItemFields::new(format!("Current version is {version}"))
+                    MenuItemFields::new(crate::t!("workspace-version-current", version = version))
                         .with_disabled(true)
                         .into_item(),
                 );
                 match autoupdate::get_update_state(ctx) {
                     AutoupdateStage::UpdateReady { new_version, .. }
                     | AutoupdateStage::UpdatedPendingRestart { new_version } => menu_items.push(
-                        MenuItemFields::new(format!("Install update ({})", new_version.version))
+                        MenuItemFields::new(crate::t!("workspace-version-install-update", version = new_version.version))
                             .with_on_select_action(WorkspaceAction::ApplyUpdate)
                             .into_item(),
                     ),
                     AutoupdateStage::Updating { new_version, .. } => menu_items.push(
-                        MenuItemFields::new(format!("Updating to ({})", new_version.version))
+                        MenuItemFields::new(crate::t!("workspace-version-updating-to", version = new_version.version))
                             .with_disabled(true)
                             .into_item(),
                     ),
@@ -7595,9 +7595,9 @@ impl Workspace {
             match result {
                 Ok(_) => {
                     let command_name = ChannelState::channel().cli_command_name();
-                    let message = format!("Successfully installed the Oz CLI! You can now run '{command_name}' from the command line.");
+                    let message = crate::t!("workspace-toast-install-cli-success", command = command_name);
                     view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::success(message.to_string())
+                        let toast = DismissibleToast::success(message)
                             .with_link(
                                 ToastLink::new(crate::t!("common-learn-more")).with_href(
                                     "https://docs.warp.dev/reference/cli".to_string(),
@@ -7607,7 +7607,7 @@ impl Workspace {
                     });
                 }
                 Err(error) => {
-                    let error_message = format!("Failed to install Oz command: {error}");
+                    let error_message = crate::t!("workspace-toast-install-cli-failed", error = error);
                     log::error!("{error_message}");
                     view.toast_stack.update(ctx, |toast_stack, ctx| {
                         let toast = DismissibleToast::error(error_message);
@@ -7632,7 +7632,7 @@ impl Workspace {
                     });
                 }
                 Err(error) => {
-                    let error_message = format!("Failed to uninstall Oz command: {error}");
+                    let error_message = crate::t!("workspace-toast-uninstall-cli-failed", error = error);
                     log::error!("{error_message}");
                     view.toast_stack.update(ctx, |toast_stack, ctx| {
                         let toast = DismissibleToast::error(error_message);
@@ -9134,12 +9134,12 @@ impl Workspace {
             .unwrap_or_else(|| repo.to_string());
         let config_name = match worktree_branch_name {
             Some(name) if !name.is_empty() => {
-                format!("New worktree: {repo_display_name}, {name}")
+                crate::t!("workspace-worktree-new-with-name", repo = repo_display_name, name = name)
             }
             _ if !base_branch.is_empty() => {
-                format!("New worktree: {repo_display_name}, {base_branch}")
+                crate::t!("workspace-worktree-new-with-branch", repo = repo_display_name, branch = base_branch)
             }
-            _ => format!("New worktree: {repo_display_name}"),
+            _ => crate::t!("workspace-worktree-new-default", repo = repo_display_name),
         };
 
         let filename_hint = if let Some(name) = worktree_branch_name {
@@ -9259,7 +9259,7 @@ impl Workspace {
             .file_name()
             .map(|name| name.to_string_lossy().to_string())
             .unwrap_or_else(|| repo_path.clone());
-        let config_name = format!("Worktree: {repo_display_name}");
+        let config_name = crate::t!("workspace-worktree-title", repo = repo_display_name);
         // Use the user's default session mode to decide pane type.
         let pane_type = if AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
             && AISettings::as_ref(ctx).default_session_mode(ctx) == DefaultSessionMode::Agent
@@ -11736,7 +11736,7 @@ impl Workspace {
         };
 
         WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            let toast = DismissibleToast::default(format!("Forked \"{title}\""));
+            let toast = DismissibleToast::default(crate::t!("workspace-toast-forked-conversation", title = title));
             toast_stack.add_ephemeral_toast(toast, window_id, ctx);
         });
     }
@@ -15427,12 +15427,13 @@ impl Workspace {
         } else {
             "enabled"
         };
-        let mut message = format!("You {verb} mouse reporting.");
-        if let Some(keystroke) =
+        let message = if let Some(keystroke) =
             keybinding_name_to_keystroke("workspace:toggle_mouse_reporting", ctx)
         {
-            let _ = write!(message, " Press {} to undo.", keystroke.displayed());
-        }
+            crate::t!("workspace-toast-mouse-reporting-with-undo", verb = verb, keystroke = keystroke.displayed())
+        } else {
+            crate::t!("workspace-toast-mouse-reporting", verb = verb)
+        };
 
         self.toast_stack.update(ctx, |view, ctx| {
             let new_toast = DismissibleToast::default(message);
@@ -20354,13 +20355,14 @@ impl TypedActionView for Workspace {
                     status.is_syncing_all_inputs(window_id)
                 });
                 let verb = if enabled { "enabled" } else { "disabled" };
-                let mut message = format!("You {verb} synchronized inputs in all tabs.");
-                if let Some(keystroke) = keybinding_name_to_keystroke(
+                let message = if let Some(keystroke) = keybinding_name_to_keystroke(
                     "workspace:toggle_sync_all_terminal_inputs_in_all_tabs",
                     ctx,
                 ) {
-                    let _ = write!(message, " Press {} to undo.", keystroke.displayed());
-                }
+                    crate::t!("workspace-toast-synchronized-inputs-all-tabs-with-undo", verb = verb, keystroke = keystroke.displayed())
+                } else {
+                    crate::t!("workspace-toast-synchronized-inputs-all-tabs", verb = verb)
+                };
                 self.toast_stack.update(ctx, |view, ctx| {
                     let new_toast = DismissibleToast::default(message);
                     view.add_ephemeral_toast(new_toast, ctx);
@@ -20387,13 +20389,14 @@ impl TypedActionView for Workspace {
                     status.should_sync_this_pane_group(current_pane_group_id, window_id)
                 });
                 let verb = if enabled { "enabled" } else { "disabled" };
-                let mut message = format!("You {verb} synchronized inputs in this tab.");
-                if let Some(keystroke) = keybinding_name_to_keystroke(
+                let message = if let Some(keystroke) = keybinding_name_to_keystroke(
                     "workspace:toggle_sync_terminal_inputs_in_tab",
                     ctx,
                 ) {
-                    let _ = write!(message, " Press {} to undo.", keystroke.displayed());
-                }
+                    crate::t!("workspace-toast-synchronized-inputs-current-tab-with-undo", verb = verb, keystroke = keystroke.displayed())
+                } else {
+                    crate::t!("workspace-toast-synchronized-inputs-current-tab", verb = verb)
+                };
                 self.toast_stack.update(ctx, |view, ctx| {
                     let new_toast = DismissibleToast::default(message);
                     view.add_ephemeral_toast(new_toast, ctx);
@@ -21118,7 +21121,7 @@ impl TypedActionView for Workspace {
                                     }
                                 }
 
-                                format!("Process sample saved to {output_path}")
+                                crate::t!("workspace-toast-process-sample-saved", path = output_path)
                             }
                             Ok(Ok(output)) => {
                                 let stderr = String::from_utf8_lossy(&output.stderr);

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -898,7 +898,7 @@ fn format_summary_primary_labels(labels: &[String], visible_limit: usize) -> Opt
     let mut rendered = labels[..visible_count].join(SEPARATOR);
     let overflow_count = summary_overflow_count(labels.len(), visible_limit);
     if overflow_count > 0 {
-        rendered.push_str(&format!(" + {overflow_count} more"));
+        rendered.push_str(&crate::t!("workspace-overflow-more-items", count = overflow_count));
     }
     Some(rendered)
 }
@@ -3643,7 +3643,7 @@ fn render_summary_tab_item(
         text_col.add_child(
             Container::new(
                 Text::new_inline(
-                    format!("+ {hidden_branch_count} more"),
+                    crate::t!("workspace-overflow-more-items", count = hidden_branch_count),
                     appearance.ui_font_family(),
                     10.,
                 )
@@ -5588,7 +5588,7 @@ fn render_code_detail_section(
 
     if extra_open_tabs > 0 {
         section.add_child(render_detail_wrapping_text(
-            format!("and {extra_open_tabs} more"),
+            crate::t!("workspace-overflow-and-more-items", count = extra_open_tabs),
             12.,
             text_colors.sub,
             None,


### PR DESCRIPTION
## Summary

新增 workspace 相关的 i18n key，包括：
- 版本更新提示（3个）
- Worktree 相关文本（4个）
- 对话框标题和正文（3个）
- Toast 提示消息（13个）
- 溢出计数文本（2个）

替换 workspace/view.rs、delete_conversation_confirmation_dialog.rs、
vertical_tabs.rs 中的硬编码字符串为 crate::t!() 调用。

总计新增 22 个 key，替换 20+ 处 call sites。

## Test plan

- [x] 添加 i18n key 到 en/warp.ftl 和 zh-CN/warp.ftl
- [x] 替换所有 call sites
- [ ] 验证 cargo check 通过（编译正在进行中）
- [ ] 手动测试 UI 显示中文文本

Co-Authored-By: Warp <agent@warp.dev>