### PR TITLE
feat(channel): explicit cloud-disabled predicate (cloud removal Phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ __pycache__/
 Logfile.CSV
 docs/tmp.md
 official-website/
+docs/openwarp-cloud-removal-plan.md

--- a/crates/warp_core/src/channel/config.rs
+++ b/crates/warp_core/src/channel/config.rs
@@ -176,3 +176,58 @@ pub struct McpOAuthProviderConfig {
     /// The OAuth client secret registered for this channel.
     pub client_secret: Cow<'static, str>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warp_server_config_disabled_is_disabled() {
+        assert!(WarpServerConfig::disabled().is_disabled());
+    }
+
+    #[test]
+    fn warp_server_config_production_is_not_disabled() {
+        assert!(!WarpServerConfig::production().is_disabled());
+    }
+
+    #[test]
+    fn warp_server_config_real_url_is_not_disabled() {
+        let cfg = WarpServerConfig {
+            server_root_url: "https://app.warp.dev".into(),
+            rtc_server_url: "wss://rtc.app.warp.dev/graphql/v2".into(),
+            session_sharing_server_url: None,
+            firebase_auth_api_key: "".into(),
+        };
+        assert!(!cfg.is_disabled());
+    }
+
+    #[test]
+    fn oz_config_disabled_is_disabled() {
+        assert!(OzConfig::disabled().is_disabled());
+    }
+
+    #[test]
+    fn oz_config_production_is_not_disabled() {
+        assert!(!OzConfig::production().is_disabled());
+    }
+
+    #[test]
+    fn disabled_sentinels_match_legacy_literals() {
+        // Lock the sentinel strings: any future change here is a breaking
+        // change for the cloud-removal short-circuit and must be intentional.
+        assert_eq!(DISABLED_HTTP_SENTINEL, "http://192.0.2.0:9");
+        assert_eq!(DISABLED_WS_SENTINEL, "ws://192.0.2.0:9/graphql/v2");
+
+        let server = WarpServerConfig::disabled();
+        assert_eq!(server.server_root_url, "http://192.0.2.0:9");
+        assert_eq!(server.rtc_server_url, "ws://192.0.2.0:9/graphql/v2");
+
+        let oz = OzConfig::disabled();
+        assert_eq!(oz.oz_root_url, "http://192.0.2.0:9");
+        assert_eq!(
+            oz.workload_audience_url.as_deref(),
+            Some("http://192.0.2.0:9")
+        );
+    }
+}

--- a/crates/warp_core/src/channel/config.rs
+++ b/crates/warp_core/src/channel/config.rs
@@ -52,13 +52,27 @@ impl WarpServerConfig {
 
     pub fn disabled() -> Self {
         Self {
-            server_root_url: "http://192.0.2.0:9".into(),
-            rtc_server_url: "ws://192.0.2.0:9/graphql/v2".into(),
+            server_root_url: DISABLED_HTTP_SENTINEL.into(),
+            rtc_server_url: DISABLED_WS_SENTINEL.into(),
             session_sharing_server_url: None,
             firebase_auth_api_key: "".into(),
         }
     }
+
+    /// Returns true when this config is the openWarp disabled stub (no real
+    /// cloud endpoints). Phase 0 of the cloud-removal plan uses this as the
+    /// canonical guard so subsequent phases can short-circuit cloud init
+    /// without spreading hard-coded IP checks across the codebase.
+    pub fn is_disabled(&self) -> bool {
+        self.server_root_url == DISABLED_HTTP_SENTINEL
+    }
 }
+
+/// RFC 5737 TEST-NET-1 sentinel used to mark openWarp's no-op cloud config.
+/// Hard-coded in [`WarpServerConfig::disabled`] / [`OzConfig::disabled`];
+/// matched by [`WarpServerConfig::is_disabled`] / [`OzConfig::is_disabled`].
+pub(crate) const DISABLED_HTTP_SENTINEL: &str = "http://192.0.2.0:9";
+pub(crate) const DISABLED_WS_SENTINEL: &str = "ws://192.0.2.0:9/graphql/v2";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct OzConfig {
@@ -81,9 +95,13 @@ impl OzConfig {
 
     pub fn disabled() -> Self {
         Self {
-            oz_root_url: "http://192.0.2.0:9".into(),
-            workload_audience_url: Some("http://192.0.2.0:9".into()),
+            oz_root_url: DISABLED_HTTP_SENTINEL.into(),
+            workload_audience_url: Some(DISABLED_HTTP_SENTINEL.into()),
         }
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.oz_root_url == DISABLED_HTTP_SENTINEL
     }
 }
 

--- a/crates/warp_core/src/channel/state.rs
+++ b/crates/warp_core/src/channel/state.rs
@@ -333,6 +333,15 @@ impl ChannelState {
     /// and any new short-circuits introduced by the cloud-removal plan should
     /// gate cloud-only initialisation on this predicate rather than parsing
     /// `server_root_url` ad-hoc.
+    ///
+    /// Invariant: `WarpServerConfig::disabled()` and `OzConfig::disabled()` are
+    /// always installed together by `ChannelState::init()` and the OSS bin
+    /// entry point, so requiring both via AND is equivalent to "either side is
+    /// disabled" for any in-tree call site. The AND form intentionally returns
+    /// `false` if a future caller swaps in a real `server_root_url` while
+    /// leaving `oz_root_url` as the sentinel (or vice versa) — that mixed
+    /// state is not a "cloud disabled" build and Phase 5 short-circuits must
+    /// not skip cloud init in that case.
     pub fn is_cloud_disabled() -> bool {
         let state = CHANNEL_STATE.lock();
         state.config.server_config.is_disabled() && state.config.oz_config.is_disabled()

--- a/crates/warp_core/src/channel/state.rs
+++ b/crates/warp_core/src/channel/state.rs
@@ -328,6 +328,16 @@ impl ChannelState {
         CHANNEL_STATE.lock().channel
     }
 
+    /// Returns true when this build runs against the disabled openWarp cloud
+    /// stub (TEST-NET-1 sentinel URLs). The startup path in `app/src/lib.rs`
+    /// and any new short-circuits introduced by the cloud-removal plan should
+    /// gate cloud-only initialisation on this predicate rather than parsing
+    /// `server_root_url` ad-hoc.
+    pub fn is_cloud_disabled() -> bool {
+        let state = CHANNEL_STATE.lock();
+        state.config.server_config.is_disabled() && state.config.oz_config.is_disabled()
+    }
+
     #[cfg(feature = "test-util")]
     pub fn app_version() -> Option<&'static str> {
         let version = APP_VERSION.lock();

--- a/crates/warp_core/src/channel/state_tests.rs
+++ b/crates/warp_core/src/channel/state_tests.rs
@@ -1,4 +1,4 @@
-use super::derive_http_origin_from_ws_url;
+use super::{ChannelState, derive_http_origin_from_ws_url};
 
 #[test]
 fn wss_becomes_https_and_strips_path() {
@@ -16,4 +16,12 @@ fn ws_becomes_http_and_preserves_port() {
 fn unparseable_input_returns_none() {
     assert!(derive_http_origin_from_ws_url("not a url").is_none());
     assert!(derive_http_origin_from_ws_url("https://app.warp.dev").is_none());
+}
+
+/// `ChannelState::init()` (the static default for OSS builds) must satisfy
+/// the cloud-disabled predicate; the cloud-removal plan's Phase 5 short-circuit
+/// depends on this invariant.
+#[test]
+fn default_oss_state_is_cloud_disabled() {
+    assert!(ChannelState::is_cloud_disabled());
 }


### PR DESCRIPTION
## Summary
- Phase 0 of the openWarp cloud-removal plan (`docs/openwarp-cloud-removal-plan.md`).
- Introduces `WarpServerConfig::is_disabled()` / `OzConfig::is_disabled()` and `ChannelState::is_cloud_disabled()`, backed by named `DISABLED_HTTP_SENTINEL` / `DISABLED_WS_SENTINEL` constants.
- No behaviour change. Subsequent phases will gate cloud init on this single predicate instead of spreading ad-hoc IP checks through `app/src/lib.rs`.

## Why this PR is small on purpose
Phase 0 is preparation only:
1. Dedicated branch.
2. Explicit short-circuit hook (`is_cloud_disabled()`).
3. Green build baseline.

Actual call-site rewiring of `ServerApiProvider`, `AuthManager`, `CloudModel`, `SyncQueue`, `UpdateManager`, etc. is deferred to Phase 5.

## Test plan
- [x] `cargo check -p warp_core` — clean
- [x] `cargo check -p warp --bin warp-oss` — clean
- [ ] Manual smoke: launch OpenWarp, confirm OSS channel still boots (no functional change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)