### PR TITLE
chore(billing,pricing): leaf cleanup (cloud removal Phase 1a)

### DIFF
--- a/app/src/billing/mod.rs
+++ b/app/src/billing/mod.rs
@@ -1,1 +1,0 @@
-// OpenWarp:删除 shared_objects_creation_denied_{body,modal}(云端 Drive 配额拒绝弹窗)

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -13,7 +13,6 @@ mod app_state;
 mod auth;
 mod autoupdate;
 mod banner;
-mod billing;
 mod changelog_model;
 mod chip_configurator;
 mod cloud_object;
@@ -1555,7 +1554,6 @@ fn initialize_app(
     prompt::editor_modal::init(ctx);
     ai::blocklist::agent_view::editor::init(ctx);
     undo_close::init(ctx);
-    // OpenWarp:删除 billing::shared_objects_creation_denied_modal::init
     tab_configs::new_worktree_modal::init(ctx);
     tab_configs::params_modal::init(ctx);
     ai::blocklist::init(ctx);

--- a/app/src/pricing/mod.rs
+++ b/app/src/pricing/mod.rs
@@ -4,11 +4,12 @@ use warpui::{Entity, ModelContext, SingletonEntity};
 /// A global model for pricing information from the server.
 ///
 /// In OpenWarp this is effectively a no-op stub: the OSS channel has no
-/// cloud server feeding it, so `pricing_info` stays `None` for the lifetime
-/// of the process and every getter returns `None`. The model is preserved
-/// only because consumer call sites (request_usage, billing-aware modals,
-/// teams settings page) still reference it; downstream cloud-removal phases
-/// will eventually retire those call sites and let us delete this entirely.
+/// cloud server pushing pricing data, so `pricing_info` is normally `None`
+/// for the lifetime of the process and every getter returns `None`. The
+/// model is preserved only because consumer call sites (request_usage,
+/// billing-aware modals, teams settings page) still reference it;
+/// downstream cloud-removal phases will eventually retire those call sites
+/// and let us delete this entirely.
 #[derive(Debug)]
 pub struct PricingInfoModel {
     pricing_info: Option<PricingInfo>,

--- a/app/src/pricing/mod.rs
+++ b/app/src/pricing/mod.rs
@@ -1,12 +1,16 @@
-use warp_graphql::billing::{
-    AddonCreditsOption, OveragesPricing, PlanPricing, PricingInfo, StripeSubscriptionPlan,
-};
+use warp_graphql::billing::{AddonCreditsOption, PlanPricing, PricingInfo, StripeSubscriptionPlan};
 use warpui::{Entity, ModelContext, SingletonEntity};
 
-/// A global model for maintaining pricing information from the server.
+/// A global model for pricing information from the server.
+///
+/// In OpenWarp this is effectively a no-op stub: the OSS channel has no
+/// cloud server feeding it, so `pricing_info` stays `None` for the lifetime
+/// of the process and every getter returns `None`. The model is preserved
+/// only because consumer call sites (request_usage, billing-aware modals,
+/// teams settings page) still reference it; downstream cloud-removal phases
+/// will eventually retire those call sites and let us delete this entirely.
 #[derive(Debug)]
 pub struct PricingInfoModel {
-    /// The latest-known pricing information from the server.
     pricing_info: Option<PricingInfo>,
 }
 
@@ -21,34 +25,13 @@ impl PricingInfoModel {
         ctx.emit(PricingInfoModelEvent::PricingInfoUpdated);
     }
 
-    /// Returns the current overage pricing information.
-    #[allow(dead_code)]
-    fn overage_pricing(&self) -> Option<&OveragesPricing> {
-        self.pricing_info.as_ref().map(|info| &info.overages)
-    }
-
     /// Returns the pricing for a specific plan.
-    #[allow(dead_code)]
     pub fn plan_pricing(&self, plan: &StripeSubscriptionPlan) -> Option<&PlanPricing> {
         self.pricing_info
             .as_ref()?
             .plans
             .iter()
             .find(|p| &p.plan == plan)
-    }
-
-    /// Returns the overage cost in dollars (converted from cents).
-    #[allow(dead_code)]
-    pub fn overage_cost_dollars(&self) -> Option<f64> {
-        self.overage_pricing()
-            .map(|overages| overages.price_per_request_usd_cents as f64 / 100.0)
-    }
-
-    /// Returns the monthly cost for a plan in dollars (converted from cents).
-    #[allow(dead_code)]
-    pub fn monthly_plan_cost_dollars(&self, plan: &StripeSubscriptionPlan) -> Option<f64> {
-        self.plan_pricing(plan)
-            .map(|pricing| pricing.monthly_plan_price_per_month_usd_cents as f64 / 100.0)
     }
 
     pub fn addon_credits_options(&self) -> Option<&[AddonCreditsOption]> {


### PR DESCRIPTION
## Summary
First half of Phase 1 from `docs/openwarp-cloud-removal-plan.md`. Pure leaf cleanup, no behaviour change in OSS builds.

- Delete `app/src/billing/mod.rs` (was a 2-line comment shell after a prior pass removed `shared_objects_creation_denied_modal`) and the matching `mod billing;` line in `lib.rs`, plus a dangling marker comment.
- Trim `PricingInfoModel` to its actually-used surface: drop the three `#[allow(dead_code)]` getters (`overage_pricing` / `overage_cost_dollars` / `monthly_plan_cost_dollars`) and the now-unused `OveragesPricing` import. The pruned doc comment now states explicitly that the model is a runtime stub in OSS — `pricing_info` stays `None`, every getter returns `None`, and consumers (request_usage_model, free_tier_limit modal, build_plan_migration modal, root_view, teams settings page) already handle that path.

## Why split out of Phase 1
The original Phase 1 also targets `reward_view` and `referral_theme_status`, but those are alive (not just shells) and their `RewardView` modal flow plus `ReferralThemeStatus` subscription touch ~10 sites in `workspace/view.rs` plus `themes/theme_chooser.rs` and `global_resource_handles.rs`. That is medium-risk surgery and deserves its own PR/review (Phase 1b).

## Test plan
- [x] `cargo check -p warp --bin warp-oss` — clean (1m 42s on Windows)
- [ ] Manual smoke: launch OpenWarp, confirm OSS startup unaffected and consumer modals (free-tier limit, build-plan migration, teams page) still render with empty pricing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)