### PR TITLE
Fix panic on macOS launch from Spotlight/Finder/Launchpad

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -569,6 +569,13 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
 pub fn run() -> Result<()> {
+    if std::env::var_os("LANG").is_none()
+        && std::env::var_os("LC_ALL").is_none()
+        && std::env::var_os("LC_CTYPE").is_none()
+    {
+        std::env::set_var("LANG", "en_US.UTF-8");
+    }
+
     // Perform any necessary platform-specific initialization.
     platform::init();
 


### PR DESCRIPTION
## Summary

Fix a hard panic that prevents the app from launching on macOS via Spotlight, Finder, or Launchpad. The transitive dep `locale_config 0.3.0` (via `i18n-embed`) calls `LanguageRange::from_unix(NSLocale.currentLocale.localeIdentifier).unwrap()` at [`macos.rs:16`](https://docs.rs/locale_config/0.3.0/src/locale_config/macos.rs.html#16), and the parser rejects identifiers macOS returns when no locale env is set (e.g. `en_AR@calendar=gregorian`), failing with `NotWellFormed`.

## Symptoms

- Terminal launches via `open` work — the user's shell propagates `LANG`.
- GUI launches via LaunchServices (Spotlight, Finder, Launchpad) hand the process a minimal env (`PATH=/usr/bin:/bin:/usr/sbin:/sbin`), so the crate panics during early init **before the file logger initializes**, so:
  - icon bounces in the dock then disappears
  - nothing in `~/Library/Logs/openwarp.log` (the file is created later)
  - exit code `101` (Rust panic) in the unified system log

## Reproduction

```sh
# panics with the bug, prints the locale_config NotWellFormed panic
env -i PATH=/usr/bin:/bin HOME="$HOME" \
  /Applications/OpenWarp.app/Contents/MacOS/warp-oss

# survives with the fix
```

## Fix

Set `LANG=en_US.UTF-8` as a fallback at the top of `warp::run()` if no locale is present in env, before `i18n::init()` runs. Touches user-set locale only when nothing is set, so terminal users keep their configured locale.

```rust
pub fn run() -> Result<()> {
    if std::env::var_os("LANG").is_none()
        && std::env::var_os("LC_ALL").is_none()
        && std::env::var_os("LC_CTYPE").is_none()
    {
        std::env::set_var("LANG", "en_US.UTF-8");
    }
    // ...
}
```

## Alternatives considered

- **Bump `locale_config`**: unmaintained since 2018; no fix upstream.
- **Replace with `sys-locale`**: bigger refactor, downstream of `i18n-embed`'s dep tree.
- **`LSEnvironment` in `Info.plist`**: only affects bundled launches, misses unbundled `cargo run`.

The env-fallback approach is one-liner, addresses every launch path (bundled GUI, unbundled, CI), and doesn't change behavior when the user's locale is set.

## Test plan

- [x] `env -i ... warp-oss` panics on `main` and runs on this branch
- [x] `open /Applications/OpenWarp.app` opens a window from a terminal launch
- [x] Spotlight launch (⌘Space → OpenWarp → Enter) opens a window — confirmed end-to-end on a clean checkout
- [x] Close the last window with `quit_on_last_window_closed = true`, then relaunch from Spotlight — works