### PR TITLE
fix: preserve newlines in sanitize, sort skills, move env block to end

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -960,7 +960,8 @@ fn sanitize_text_for_json(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {
-            c if (c as u32) < 0x20 => out.push(' '),
+            // 移除控制字符但保留 \n (0x0A), \r (0x0D), \t (0x09)
+            c if (c as u32) < 0x20 && !matches!(c, '\n' | '\r' | '\t') => out.push(' '),
             '\u{7f}' => out.push(' '),
             '\\' => out.push('/'),
             '"' => out.push('\''),

--- a/app/src/ai/agent_providers/prompts/partials/footer.j2
+++ b/app/src/ai/agent_providers/prompts/partials/footer.j2
@@ -1,9 +1,9 @@
 
 {% include "partials/tool_aliases.j2" %}
 
-{% include "partials/env.j2" %}
 {% if skills %}
 {% include "partials/skills.j2" %}
 {% endif %}
 {% include "partials/project_rules.j2" %}
 {% include "partials/plan_mode.j2" %}
+{% include "partials/env.j2" %}

--- a/app/src/ai/skills/skill_utils.rs
+++ b/app/src/ai/skills/skill_utils.rs
@@ -81,7 +81,9 @@ pub(crate) fn unique_skills(
         }
     }
 
-    dedup_map.into_values().collect()
+    let mut skills: Vec<SkillDescriptor> = dedup_map.into_values().collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
 }
 
 /// 列出当前 working directory 适用的全部 skills。


### PR DESCRIPTION
## 问题描述

### 1. sanitize_text_for_json 去掉了所有消息中的换行符
`sanitize_text_for_json` 的注释说"移除控制字符(除 \\n \\r \\t)"，但实际代码用 `c if (c as u32) < 0x20` 匹配，\\n (0x0A)、\\r (0x0D)、\\t (0x09) 全部被替换成了空格。导致 system prompt、user messages、tool results 里的换行全部丢失，整个请求体变成连续的一行文本。

### 2. skills 顺序不确定，降低 prompt cache 命中率
`unique_skills` 使用 `HashMap::into_values().collect()` 返回无序 Vec，同一组 skills 每次调用顺序不同。system prompt 内容的微小变化会导致 LLM 服务端的 prompt cache 失效，每次请求都需要重新计算，大幅增加响应延迟。

### 3. `<env>` 块位置不当，降低 prompt cache 命中率
`<env>` 块包含 Working directory、Shell、Git branch、Today's date 等每轮都可能变化的环境信息，却放在 system prompt 的**前部**。当 env 块内容变化时（比如用户换了目录），会连带使它后面的 skills、project_rules 等**稳定内容**的 cache 一起失效。把 `<env>` 移到最后，可以让前面的稳定内容（skills、project_rules）尽可能命中 cache。

## 修改内容

- **`app/src/ai/agent_providers/chat_stream.rs`**: `sanitize_text_for_json` 排除 \\n \\r \\t，保留换行符
- **`app/src/ai/skills/skill_utils.rs`**: `unique_skills` 结果按 skill 名称字母序排序，保证顺序稳定
- **`app/src/ai/agent_providers/prompts/partials/footer.j2`**: `<env>` 块移到 system prompt 末尾

## 验证

- `cargo check -p warp` — 编译通过
- `prompt_renderer` 12 tests — all passed
- `skill_utils` 7 tests — all passed
- `cargo bundle --bin warp-oss --features gui` — OpenWarp.app bundle 构建成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of text formatting (newlines, tabs, carriage returns) in messages and system prompts
  * Fixed skill listing to display in consistent, sorted order for predictable results

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/59)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->