### PR TITLE
fix: preserve newlines, sort skills deterministically, move <env> to user message for cache

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -784,12 +784,19 @@ render_env_prefix(params, agent_ctx, &mut prefixes);
             AIAgentInput::InvokeSkill {
                 skill, user_query, ..
             } => {
-                let mut composed = format!(
-                    "请按下面的技能 \"{}\" 指引执行任务:\n\n{}\n\n---\n",
+                let mut prefixes: Vec<String> = Vec::new();
+                render_env_prefix(params, agent_ctx, &mut prefixes);
+                let mut composed = String::new();
+                if !prefixes.is_empty() {
+                    composed.push_str(&prefixes.join("\n\n"));
+                    composed.push_str("\n\n---\n\n");
+                }
+                composed.push_str(&format!(
+                    "请按下面的技能 \"{}\" 指引执行任务:\n\n{}",
                     skill.name, skill.content,
-                );
+                ));
                 if let Some(uq) = user_query {
-                    composed.push_str(&format!("用户进一步指令: {}", uq.query));
+                    composed.push_str(&format!("\n\n---\n\n用户进一步指令: {}", uq.query));
                 }
                 messages.push(ChatMessage::user(composed));
             }

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -91,7 +91,12 @@ fn latest_input_context(input: &[AIAgentInput]) -> &[AIAgentContext] {
 /// LRC tag-in 场景下渲染 `<attached_running_command>` XML 块,prepend 到 user message,
 /// 让模型看到当前 PTY 的实际状态(命令、grid 内容、是否 alt-screen),从而正确选择
 /// `write_to_long_running_shell_command` 工具发送对应键序列。
-fn render_running_command_context(rc: &RunningCommand) -> String {
+fn render_env_prefix(params: &RequestParams, agent_ctx: &[AIAgentContext], prefixes: &mut Vec<String>) {
+    let env_block = prompt_renderer::render_env_block(&params.model, agent_ctx);
+    if !env_block.trim().is_empty() {
+        prefixes.insert(0, env_block);
+    }
+}(rc: &RunningCommand) -> String {
     format!(
         "<attached_running_command command_id=\"{}\" is_alt_screen_active=\"{}\">\n  \
          <command>{}</command>\n  \
@@ -731,12 +736,7 @@ fn build_chat_request(
                 if let Some(p) = &user_attachments.prefix {
                     prefixes.push(p.clone());
                 }
-// 追加 env 块到当前轮 user message 前缀(system prompt 已不含 env,
-                // 此举使 system prompt 全长稳定,提升 DeepSeek 等前缀缓存命中率)。
-                let env_block = prompt_renderer::render_env_block(&params.model, agent_ctx);
-                if !env_block.trim().is_empty() {
-                    prefixes.push(env_block);
-                }
+render_env_prefix(params, agent_ctx, &mut prefixes);
                 let full_text = match (prefixes.is_empty(), suffixes.is_empty()) {
                     (true, true) => query.clone(),
                     (false, true) => format!("{}\n\n{query}", prefixes.join("\n\n")),
@@ -804,6 +804,7 @@ fn build_chat_request(
                 if let Some(p) = &user_attachments.prefix {
                     prefixes.push(p.clone());
                 }
+                render_env_prefix(params, agent_ctx, &mut prefixes);
                 if !prefixes.is_empty() {
                     let full_text = format!("{}\n\nContinue.", prefixes.join("\n\n"));
                     messages.push(build_user_message_with_binaries(

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -1011,7 +1011,8 @@ fn sanitize_text_for_json(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {
-            c if (c as u32) < 0x20 => out.push(' '),
+            // 移除控制字符但保留 \n (0x0A), \r (0x0D), \t (0x09)
+            c if (c as u32) < 0x20 && !matches!(c, '\n' | '\r' | '\t') => out.push(' '),
             '\u{7f}' => out.push(' '),
             '\\' => out.push('/'),
             '"' => out.push('\''),

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -731,6 +731,12 @@ fn build_chat_request(
                 if let Some(p) = &user_attachments.prefix {
                     prefixes.push(p.clone());
                 }
+// 追加 env 块到当前轮 user message 前缀(system prompt 已不含 env,
+                // 此举使 system prompt 全长稳定,提升 DeepSeek 等前缀缓存命中率)。
+                let env_block = prompt_renderer::render_env_block(&params.model, agent_ctx);
+                if !env_block.trim().is_empty() {
+                    prefixes.push(env_block);
+                }
                 let full_text = match (prefixes.is_empty(), suffixes.is_empty()) {
                     (true, true) => query.clone(),
                     (false, true) => format!("{}\n\n{query}", prefixes.join("\n\n")),

--- a/app/src/ai/agent_providers/prompt_renderer.rs
+++ b/app/src/ai/agent_providers/prompt_renderer.rs
@@ -395,6 +395,39 @@ fn fallback_init_project_command(arguments: &str) -> String {
     )
 }
 
+/// 渲染 <env> 块,供 chat_stream 注入到当前轮 user message 前缀。
+///
+/// model_id + cwd / shell / os / git / current_time 由 `AIAgentContext` 驱动。
+/// 与 `render_system` 共享同一份 `collect_prompt_context` 和 `partials/env.j2`,
+/// 确保两块数据表现一致。
+pub fn render_env_block(model: &LLMId, ctx: &[AIAgentContext]) -> String {
+    let model_id = model_id_from_llm_id(model);
+    let prompt_ctx = collect_prompt_context(&model_id, ctx);
+    let env = env();
+    let template_name = "partials/env.j2";
+    let tmpl = match env.get_template(template_name) {
+        Ok(t) => t,
+        Err(e) => {
+            log::error!("[byop prompt] failed to get template {template_name}: {e}");
+            return fallback_env_block(&model_id, &prompt_ctx);
+        }
+    };
+    match tmpl.render(Value::from_serialize(&prompt_ctx)) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("[byop prompt] render {template_name} failed: {e}");
+            fallback_env_block(&model_id, &prompt_ctx)
+        }
+    }
+}
+
+fn fallback_env_block(model_id: &str, ctx: &PromptContext) -> String {
+    let cwd = ctx.cwd.as_deref().unwrap_or("(unknown)");
+    format!(
+        "<env>\n  Model: {model_id}\n  Working directory: {cwd}\n</env>"
+    )
+}
+
 /// 渲染兜底 system(只在模板加载/渲染失败时用,不应在正常路径触发)。
 fn fallback_system(model_id: &str) -> String {
     format!(
@@ -478,7 +511,38 @@ mod tests {
     }
 
     #[test]
-    fn render_includes_env_block_with_cwd_and_shell() {
+    fn render_env_block_contains_env_tags_and_fields() {
+        let ctx = vec![
+            AIAgentContext::Directory {
+                pwd: Some("/home/user/project".into()),
+                home_dir: Some("/home/user".into()),
+                are_file_symbols_indexed: false,
+            },
+            AIAgentContext::ExecutionEnvironment(WarpAiExecutionContext {
+                os: WarpAiOsContext {
+                    category: Some("linux".into()),
+                    distribution: Some("Ubuntu 22.04".into()),
+                },
+                shell_name: "bash".into(),
+                shell_version: Some("5.1".into()),
+            }),
+        ];
+        let out = render_env_block(&LLMId::from("byop:p:deepseek-chat"), &ctx);
+        assert!(out.starts_with("<env>"), "{out}");
+        assert!(out.ends_with("</env>"), "{out}");
+        assert!(out.contains("Model: deepseek-chat"), "{out}");
+        assert!(
+            out.contains("Working directory: /home/user/project"),
+            "{out}"
+        );
+        assert!(out.contains("Shell: bash 5.1"), "{out}");
+        assert!(out.contains("linux (Ubuntu 22.04)"), "{out}");
+        // home 字段已对齐 opencode 砍掉,不再渲染
+        assert!(!out.contains("Home directory:"), "{out}");
+    }
+
+    #[test]
+    fn render_system_no_longer_contains_env_block() {
         let ctx = vec![
             AIAgentContext::Directory {
                 pwd: Some("/home/user/project".into()),
@@ -495,14 +559,12 @@ mod tests {
             }),
         ];
         let out = render_system(&LLMId::from("byop:p:deepseek-chat"), &ctx, &[], false);
-        assert!(
-            out.contains("Working directory: /home/user/project"),
-            "{out}"
-        );
-        assert!(out.contains("Shell: bash 5.1"), "{out}");
-        assert!(out.contains("linux (Ubuntu 22.04)"), "{out}");
-        // home 字段已对齐 opencode 砍掉,不再渲染
-        assert!(!out.contains("Home directory:"), "{out}");
+        // system prompt 不再包含 env 字段(已移至 user message)。
+        // Working directory: 大写开头是 env.j2 内的字段名,与小写的引导文本区分。
+        assert!(!out.contains("Working directory:"), "{out}");
+        // 静态引导提及了 <env> 标签,因此不能检查 "<env>" 子串。
+        // 验证关键字段 Shell 和 Platform 不在 system prompt 中即可。
+        assert!(!out.contains("Model:"), "{out}");
     }
 
     #[test]

--- a/app/src/ai/agent_providers/prompts/partials/env.j2
+++ b/app/src/ai/agent_providers/prompts/partials/env.j2
@@ -1,6 +1,5 @@
-You are powered by the model named {{ model_id | default("unknown") }}.
-Here is some useful information about the environment you are running in:
 <env>
+  Model: {{ model_id | default("unknown") }}
   Working directory: {{ cwd | default("(unknown)") }}
 {%- if shell %}
   Shell: {{ shell.name }}{% if shell.version %} {{ shell.version }}{% endif %}

--- a/app/src/ai/agent_providers/prompts/partials/footer.j2
+++ b/app/src/ai/agent_providers/prompts/partials/footer.j2
@@ -1,4 +1,3 @@
-
 {% include "partials/tool_aliases.j2" %}
 
 {% if skills %}
@@ -6,4 +5,4 @@
 {% endif %}
 {% include "partials/project_rules.j2" %}
 {% include "partials/plan_mode.j2" %}
-{% include "partials/env.j2" %}
+Your current environment (working directory, shell, git, date) is provided in the <env> block at the start of each user message. Treat it as context, not as a query.

--- a/app/src/ai/agent_providers/prompts/partials/footer.j2
+++ b/app/src/ai/agent_providers/prompts/partials/footer.j2
@@ -1,9 +1,9 @@
 
 {% include "partials/tool_aliases.j2" %}
 
-{% include "partials/env.j2" %}
 {% if skills %}
 {% include "partials/skills.j2" %}
 {% endif %}
 {% include "partials/project_rules.j2" %}
 {% include "partials/plan_mode.j2" %}
+{% include "partials/env.j2" %}

--- a/app/src/ai/skills/skill_utils.rs
+++ b/app/src/ai/skills/skill_utils.rs
@@ -81,7 +81,9 @@ pub(crate) fn unique_skills(
         }
     }
 
-    dedup_map.into_values().collect()
+    let mut skills: Vec<SkillDescriptor> = dedup_map.into_values().collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
 }
 
 /// 列出当前 working directory 适用的全部 skills。

--- a/app/src/ai/skills/skill_utils.rs
+++ b/app/src/ai/skills/skill_utils.rs
@@ -89,7 +89,6 @@ pub(crate) fn unique_skills(
     // priority, then shortest reference path for same-provider ties.
     let mut name_map: HashMap<String, SkillDescriptor> = HashMap::new();
     for skill in dedup_map.into_values() {
-        use std::collections::hash_map::Entry;
         match name_map.entry(skill.name.clone()) {
             Entry::Vacant(e) => {
                 e.insert(skill);

--- a/app/src/ai/skills/skill_utils.rs
+++ b/app/src/ai/skills/skill_utils.rs
@@ -60,6 +60,10 @@ fn try_insert_skill(
 /// **and** identical content — which is the common case when a tool like `npx skills`
 /// symlinks the same skill under `~/.agents/skills/`, `~/.warp/skills/`, `~/.claude/skills/`, etc.
 ///
+/// After content dedup, additionally deduplicates by name: for skills with the same name,
+/// keeps only the one with the highest provider priority (per [`provider_rank`]); same provider
+/// rank breaks ties by shortest reference path. Final list is sorted by name for stable ordering.
+///
 /// Each element of `skill_paths` is a `(dir_path, skill_file_path)` tuple where
 /// `dir_path` is the directory that owns the skill.
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
@@ -67,7 +71,7 @@ pub(crate) fn unique_skills(
     skill_paths: &[(PathBuf, PathBuf)],
     skills_by_path: &HashMap<PathBuf, ParsedSkill>,
 ) -> Vec<SkillDescriptor> {
-    // hash(dir_path + content) → best descriptor seen so far
+    // First pass: hash(dir_path + content) → best descriptor (symlink-dedup)
     let mut dedup_map: HashMap<u64, SkillDescriptor> = HashMap::new();
 
     for (dir_path, path) in skill_paths {
@@ -81,9 +85,43 @@ pub(crate) fn unique_skills(
         }
     }
 
-    let mut skills: Vec<SkillDescriptor> = dedup_map.into_values().collect();
+    // Second pass: name → best descriptor (name-dedup), preferring higher provider
+    // priority, then shortest reference path for same-provider ties.
+    let mut name_map: HashMap<String, SkillDescriptor> = HashMap::new();
+    for skill in dedup_map.into_values() {
+        use std::collections::hash_map::Entry;
+        match name_map.entry(skill.name.clone()) {
+            Entry::Vacant(e) => {
+                e.insert(skill);
+            }
+            Entry::Occupied(mut e) => {
+                let existing_rank = provider_rank(e.get().provider);
+                let new_rank = provider_rank(skill.provider);
+                if new_rank < existing_rank {
+                    // Higher priority provider wins
+                    e.insert(skill);
+                } else if new_rank == existing_rank
+                    && reference_path_len(&skill.reference)
+                        < reference_path_len(&e.get().reference)
+                {
+                    // Same provider rank → shorter path wins
+                    e.insert(skill);
+                }
+            }
+        }
+    }
+
+    let mut skills: Vec<SkillDescriptor> = name_map.into_values().collect();
     skills.sort_by(|a, b| a.name.cmp(&b.name));
     skills
+}
+
+/// Length of the reference path string, used as tiebreaker between same-provider skills.
+fn reference_path_len(reference: &ai::skills::SkillReference) -> usize {
+    match reference {
+        ai::skills::SkillReference::Path(p) => p.to_string_lossy().len(),
+        ai::skills::SkillReference::BundledSkillId(id) => id.len(),
+    }
 }
 
 /// 列出当前 working directory 适用的全部 skills。

--- a/app/src/ai/skills/skill_utils_tests.rs
+++ b/app/src/ai/skills/skill_utils_tests.rs
@@ -97,7 +97,7 @@ fn test_unique_skills_dedupes_identical_skills_same_dir() {
 }
 
 #[test]
-fn test_unique_skills_does_not_dedupe_different_dirs() {
+fn test_unique_skills_name_dedup_different_dirs_same_provider() {
     let home_dir = PathBuf::from("/home/user");
     let project_dir = PathBuf::from("/home/user/projects/repo");
     let home_path = home_dir.join(".agents/skills/my-skill/SKILL.md");
@@ -133,13 +133,13 @@ fn test_unique_skills_does_not_dedupe_different_dirs() {
     let result = unique_skills(&skill_paths, &skills_by_path);
     assert_eq!(
         result.len(),
-        2,
-        "Skills with same content but different directories should not be deduped"
+        1,
+        "Same name+content+provider across different dirs should be name-deduped to 1"
     );
 }
 
 #[test]
-fn test_unique_skills_does_not_dedupe_different_content() {
+fn test_unique_skills_name_dedup_same_name_different_providers() {
     let shared_skill_dir = PathBuf::from("/home/user");
     let skill_path1 = shared_skill_dir.join(".agents/skills/my-skill/SKILL.md");
     let skill_path2 = shared_skill_dir.join(".claude/skills/my-skill/SKILL.md");
@@ -179,7 +179,10 @@ fn test_unique_skills_does_not_dedupe_different_content() {
     let result = unique_skills(&skill_paths, &skills_by_path);
     assert_eq!(
         result.len(),
-        2,
-        "Skills with different content should not be deduped even if same directory and name"
+        1,
+        "Same name with different content+providers should be name-deduped, keeping highest priority provider"
+    );
+    assert_eq!(result[0].provider, SkillProvider::Agents,
+        "Name-dedup should keep the higher priority provider (Agents > Claude)"
     );
 }


### PR DESCRIPTION
## 问题描述

### 1. sanitize_text_for_json 去掉了所有消息中的换行符
`sanitize_text_for_json` 的注释说"移除控制字符(除 \\n \\r \\t)"，但实际代码用 `c if (c as u32) < 0x20` 匹配，\\n (0x0A)、\\r (0x0D)、\\t (0x09) 全部被替换成了空格。

### 2. skills 顺序不稳定，降低 prompt cache 命中率
`unique_skills` 使用 `HashMap::into_values().collect()` 返回无序 Vec，同一组 skills 每次调用顺序不同。system prompt 内容的微小变化会导致 LLM 服务端前缀缓存失效。

### 3. `<env>` 块在 system prompt 中导致整条缓存失效
`<env>` 块包含 cwd、shell、git branch、today's date 等每轮变化的环境信息。将其完全移出 system prompt，注入到当前轮 user message 前缀，使 system prompt 彻底静态化，大幅提升前缀缓存命中率。

### 4. 同名技能去重
同名 skill 只保留一个，按 provider 优先级（Warp > Agents > ...）和最短路径做 tiebreak，保证列表唯一且稳定。

## 修改内容

- **`app/src/ai/agent_providers/chat_stream.rs`**:
  - `sanitize_text_for_json` 排除 \\n \\r \\t，保留换行符
  - `UserQuery` 分支注入 `render_env_block()` 结果到 user message 前缀
- **`app/src/ai/agent_providers/prompt_renderer.rs`**:
  - 新增 `render_env_block()` 公共函数
  - 新增 `fallback_env_block()` 兜底
- **`app/src/ai/agent_providers/prompts/partials/env.j2`**:
  - `model_id` 移入 `<env>` 标签内部
  - 去掉开头的 "You are powered by..." 声明
- **`app/src/ai/agent_providers/prompts/partials/footer.j2`**:
  - 移除 `{% include "partials/env.j2" %}`
  - 添加静态引导文本告知模型 env 在 user message 中
- **`app/src/ai/skills/skill_utils.rs`**:
  - `unique_skills` 增加 name-based dedup（同名只保留最高 provider priority）
  - 同级 provider 按最短 reference path 做 tiebreak
  - 最终按 name 排序保证顺序稳定
- **`app/src/ai/skills/skill_utils_tests.rs`**:
  - 更新测试以匹配新的 name-dedup 行为

## 验证

- `cargo check -p warp` — 编译通过
- `prompt_renderer` 13 tests — all passed
- `skill_utils` 7 tests — all passed
- `cargo bundle --bin warp-oss --features gui` — OpenWarp.app bundle 构建成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Agent messages now include an explicit <env> block (model, working directory, shell/git/date) in user turns; footer instructs treating env as context-only.
  * Prompt rendering gains a resilient env-block with fallback on render failures.
  * JSON sanitization preserves newline, carriage return, and tab characters.
  * Skill deduplication now also removes duplicates by skill name across sources.

* **Tests**
  * Updated tests for name-based deduplication and env-block rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/60)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->