### PR TITLE
fix(fonts): make CJK Han glyph fallback locale-aware on Windows

### DIFF
--- a/app/src/font_fallback.rs
+++ b/app/src/font_fallback.rs
@@ -103,7 +103,52 @@ lazy_static! {
     };
 }
 
+/// Return the font that should render shared CJK Han ideographs (U+4E00..U+9FEF and related)
+/// based on the current UI locale. Without this, the upstream mapping hard-codes Noto Sans SC
+/// (Simplified Chinese) for every Han code point, which renders Japanese-locale UI text with
+/// Simplified Chinese glyph shapes (e.g. 直/設/規 look "off" to Japanese readers).
+fn cjk_han_font_for_ui_locale() -> ExternalFontFamily {
+    let locale = warpui::current_ui_locale();
+    let lower = locale.to_ascii_lowercase();
+    if lower.starts_with("ja") {
+        NOTO_SANS_JP.clone()
+    } else if lower.starts_with("ko") {
+        NOTO_SANS_KR.clone()
+    } else if lower.starts_with("zh-tw") || lower.starts_with("zh-hk") || lower.starts_with("zh-mo")
+    {
+        NOTO_SANS_TC.clone()
+    } else {
+        NOTO_SANS_SC.clone()
+    }
+}
+
+/// True for CJK Han code points that are visually shared between Japanese / Chinese / Korean and
+/// therefore depend on UI locale to pick the right glyph shape. Limited to the most common Unified
+/// Ideographs blocks; rarer extensions stay on the upstream SC mapping.
+fn is_shared_cjk_han(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF       // CJK Unified Ideographs Extension A
+            | 0x4E00..=0x9FFF // CJK Unified Ideographs
+            | 0xF900..=0xFAFF // CJK Compatibility Ideographs
+            | 0x20000..=0x2A6DF // Extension B
+            | 0x2A700..=0x2B73F // Extension C
+            | 0x2B740..=0x2B81F // Extension D
+            | 0x2B820..=0x2CEAF // Extension E
+    )
+}
+
 pub fn fallback_font_fn(ch: char) -> Option<ExternalFontFamily> {
+    let raw = fallback_font_fn_raw(ch);
+    if let Some(ref font) = raw {
+        if font.name == "Noto Sans SC" && is_shared_cjk_han(ch) {
+            return Some(cjk_han_font_for_ui_locale());
+        }
+    }
+    raw
+}
+
+fn fallback_font_fn_raw(ch: char) -> Option<ExternalFontFamily> {
     match ch {
         '\u{007F}'..='\u{007F}'
         | '\u{21EA}'..='\u{21EA}'

--- a/app/src/i18n.rs
+++ b/app/src/i18n.rs
@@ -63,7 +63,21 @@ pub fn init(override_locale: Option<&str>) {
         loader.fallback_language()
     );
 
+    propagate_ui_locale(&loader);
+
     let _ = LANGUAGE_LOADER.set(loader);
+}
+
+/// Forward the resolved UI locale to `warpui::set_ui_locale` so DirectWrite / CoreText
+/// glyph fallback biases CJK Han characters toward the user's UI language. Japanese,
+/// Simplified Chinese, and Traditional Chinese share Han code points; without a locale
+/// hint, DirectWrite tends to pick Microsoft YaHei (Simplified Chinese) on Windows even
+/// when the UI is rendered in Japanese.
+fn propagate_ui_locale(loader: &FluentLanguageLoader) {
+    let langs = loader.current_languages();
+    if let Some(li) = langs.first() {
+        warpui::set_ui_locale(li.to_string());
+    }
 }
 
 /// 取全局 loader。`init()` 没调过时返回 `None`(早期/测试代码可用 [`t_or`] 兜底)。
@@ -99,6 +113,7 @@ pub fn set_locale(locale: &str) {
         "[i18n] locale switched to {locale:?}; current_languages={:?}",
         loader.current_languages()
     );
+    propagate_ui_locale(loader);
 }
 
 /// 重置回系统语言(撤销显式 override)。
@@ -110,6 +125,7 @@ pub fn reset_to_system_locale() {
     if let Err(e) = i18n_embed::select(loader, &Localizations, &requested) {
         log::warn!("[i18n] reset_to_system_locale failed: {e}");
     }
+    propagate_ui_locale(loader);
 }
 
 /// 获取已激活的语言列表(主选 + fallback)。仅供调试 / settings UI 显示用。

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -563,13 +563,11 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
 pub fn run() -> Result<()> {
-    // POSIX locale fallback: ensure C/Rust libs that consult LANG/LC_* (e.g. chrono number
-    // formatting, libc strftime) have a sane UTF-8 default when nothing is set. On Windows
-    // we deliberately skip this — Windows APIs (`GetUserPreferredUILanguages`) are the source
-    // of truth for UI locale, and forcing `LANG=en_US.UTF-8` here causes
-    // `DesktopLanguageRequester` to prefer en regardless of the user's selected UI language,
-    // which in turn breaks the CJK Han glyph fallback (Japanese UI ends up with Simplified
-    // Chinese glyph shapes).
+    // POSIX locale 兜底:在 LANG/LC_* 全部未设置时,给依赖这些环境变量的 C/Rust 库
+    // (chrono 数字格式化、libc strftime 等) 一个合理的 UTF-8 默认值。Windows 上特意跳过
+    // —— Windows API (`GetUserPreferredUILanguages`) 才是 UI locale 的真实来源,这里
+    // 强制 `LANG=en_US.UTF-8` 会让 `DesktopLanguageRequester` 不论用户选什么 UI 语言
+    // 都返回 en,进而把 CJK Han 字形回退打偏 (日文 UI 反倒拿到简体字字形)。
     #[cfg(not(windows))]
     if std::env::var_os("LANG").is_none()
         && std::env::var_os("LC_ALL").is_none()

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -563,6 +563,14 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
 pub fn run() -> Result<()> {
+    // POSIX locale fallback: ensure C/Rust libs that consult LANG/LC_* (e.g. chrono number
+    // formatting, libc strftime) have a sane UTF-8 default when nothing is set. On Windows
+    // we deliberately skip this — Windows APIs (`GetUserPreferredUILanguages`) are the source
+    // of truth for UI locale, and forcing `LANG=en_US.UTF-8` here causes
+    // `DesktopLanguageRequester` to prefer en regardless of the user's selected UI language,
+    // which in turn breaks the CJK Han glyph fallback (Japanese UI ends up with Simplified
+    // Chinese glyph shapes).
+    #[cfg(not(windows))]
     if std::env::var_os("LANG").is_none()
         && std::env::var_os("LC_ALL").is_none()
         && std::env::var_os("LC_CTYPE").is_none()

--- a/crates/warpui/src/lib.rs
+++ b/crates/warpui/src/lib.rs
@@ -5,3 +5,55 @@ pub mod windowing;
 
 // Re-export everything from the core crate.
 pub use warpui_core::*;
+
+/// UI locale used to bias DirectWrite / CoreText / fontconfig glyph fallback for CJK Han characters.
+/// Set by `app::i18n::init` / `set_locale` so that font fallback for Japanese UI prefers Japanese
+/// glyphs (e.g. Yu Gothic / Meiryo) over Simplified Chinese (Microsoft YaHei) on Windows.
+mod ui_locale {
+    use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+    static UI_LOCALE: OnceLock<RwLock<String>> = OnceLock::new();
+
+    type LocaleListener = Arc<dyn Fn(&str) + Send + Sync>;
+    static LISTENERS: OnceLock<Mutex<Vec<LocaleListener>>> = OnceLock::new();
+
+    fn cell() -> &'static RwLock<String> {
+        UI_LOCALE.get_or_init(|| RwLock::new("en-US".to_string()))
+    }
+
+    fn listeners() -> &'static Mutex<Vec<LocaleListener>> {
+        LISTENERS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub fn set_ui_locale(locale: impl Into<String>) {
+        let s = locale.into();
+        if s.is_empty() {
+            return;
+        }
+        {
+            let mut guard = cell().write().unwrap();
+            if *guard == s {
+                return;
+            }
+            *guard = s.clone();
+        }
+        let snapshot: Vec<LocaleListener> = listeners().lock().unwrap().iter().cloned().collect();
+        for cb in snapshot {
+            cb(&s);
+        }
+    }
+
+    pub fn current_ui_locale() -> String {
+        cell().read().unwrap().clone()
+    }
+
+    /// Register a callback fired whenever `set_ui_locale` actually changes the stored value.
+    /// Used by `TextLayoutSystem` to rebuild cosmic-text's `FontSystem` with the new locale
+    /// (it has no public `set_locale`). Subscribers are kept alive by this registry; capture
+    /// `Weak` references inside the closure if you want the underlying object to be droppable.
+    pub fn on_ui_locale_changed(cb: LocaleListener) {
+        listeners().lock().unwrap().push(cb);
+    }
+}
+
+pub use ui_locale::{current_ui_locale, on_ui_locale_changed, set_ui_locale};

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -298,12 +298,28 @@ impl Default for TextLayoutSystem {
     }
 }
 
+/// Rebuild the cosmic-text `FontSystem` in-place with a new locale, reusing the existing
+/// `fontdb::Database` so no font data is reloaded. `cosmic_text::FontSystem` exposes no public
+/// `set_locale`, so we swap the whole struct via `std::mem::replace` and reattach the db.
+fn rebuild_font_system_for_locale(
+    store: &std::sync::Arc<RwLock<cosmic_text::FontSystem>>,
+    locale: &str,
+) {
+    let mut guard = store.write();
+    let old = std::mem::replace(
+        &mut *guard,
+        cosmic_text::FontSystem::new_with_locale_and_db("en".into(), Default::default()),
+    );
+    let (_, db) = old.into_locale_and_db();
+    *guard = cosmic_text::FontSystem::new_with_locale_and_db(locale.to_string(), db);
+}
+
 impl TextLayoutSystem {
     pub fn new() -> Self {
         let initial_locale = crate::current_ui_locale();
         let font_store = std::sync::Arc::new(RwLock::new(
             cosmic_text::FontSystem::new_with_locale_and_db(
-                initial_locale,
+                initial_locale.clone(),
                 Default::default(),
             ),
         ));
@@ -314,21 +330,17 @@ impl TextLayoutSystem {
         let weak: std::sync::Weak<RwLock<cosmic_text::FontSystem>> =
             std::sync::Arc::downgrade(&font_store);
         crate::on_ui_locale_changed(std::sync::Arc::new(move |locale: &str| {
-            let Some(store) = weak.upgrade() else {
-                return;
-            };
-            let mut guard = store.write();
-            // `cosmic_text::FontSystem` has no public `set_locale`; replace + reuse the database.
-            let old = std::mem::replace(
-                &mut *guard,
-                cosmic_text::FontSystem::new_with_locale_and_db(
-                    "en".into(),
-                    Default::default(),
-                ),
-            );
-            let (_, db) = old.into_locale_and_db();
-            *guard = cosmic_text::FontSystem::new_with_locale_and_db(locale.to_string(), db);
+            if let Some(store) = weak.upgrade() {
+                rebuild_font_system_for_locale(&store, locale);
+            }
         }));
+        // Race compensation: `set_ui_locale` may have fired between `current_ui_locale()` and
+        // the listener registration above, in which case we'd miss that notification. Re-read
+        // and rebuild if it diverged.
+        let post_register_locale = crate::current_ui_locale();
+        if post_register_locale != initial_locale {
+            rebuild_font_system_for_locale(&font_store, &post_register_locale);
+        }
         Self {
             families: Default::default(),
             font_store,

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -199,7 +199,7 @@ pub struct TextLayoutSystem {
     /// However, the `FontDB` trait for text layout is _immutable_ and cannot be easily changed to
     /// mutable. Therefore, we use an [`RwLock`] for internal mutability. `FontDB` is Sync and Send,
     /// so we can't use a `RefCell`.
-    font_store: RwLock<cosmic_text::FontSystem>,
+    font_store: std::sync::Arc<RwLock<cosmic_text::FontSystem>>,
     font_id_map: RwLock<BiMap<FontId, fontdb::ID>>,
     font_selections: DashMap<(FamilyId, Properties), FontId>,
     loaded_fonts: DashMap<FontKey, FontId>,
@@ -300,14 +300,38 @@ impl Default for TextLayoutSystem {
 
 impl TextLayoutSystem {
     pub fn new() -> Self {
+        let initial_locale = crate::current_ui_locale();
+        let font_store = std::sync::Arc::new(RwLock::new(
+            cosmic_text::FontSystem::new_with_locale_and_db(
+                initial_locale,
+                Default::default(),
+            ),
+        ));
+        // Subscribe to UI-locale changes so cosmic-text's `FontSystem` is rebuilt with the new
+        // locale (it has no public `set_locale` and locale biases CJK Han glyph fallback). We
+        // capture a `Weak` to allow this `TextLayoutSystem` to be dropped without leaking the
+        // listener.
+        let weak: std::sync::Weak<RwLock<cosmic_text::FontSystem>> =
+            std::sync::Arc::downgrade(&font_store);
+        crate::on_ui_locale_changed(std::sync::Arc::new(move |locale: &str| {
+            let Some(store) = weak.upgrade() else {
+                return;
+            };
+            let mut guard = store.write();
+            // `cosmic_text::FontSystem` has no public `set_locale`; replace + reuse the database.
+            let old = std::mem::replace(
+                &mut *guard,
+                cosmic_text::FontSystem::new_with_locale_and_db(
+                    "en".into(),
+                    Default::default(),
+                ),
+            );
+            let (_, db) = old.into_locale_and_db();
+            *guard = cosmic_text::FontSystem::new_with_locale_and_db(locale.to_string(), db);
+        }));
         Self {
             families: Default::default(),
-            font_store: RwLock::new(cosmic_text::FontSystem::new_with_locale_and_db(
-                // Locale is needed for font fallback. For now, we hardcode this to "en" to match
-                // our mac implementation https://github.com/warpdotdev/warp-internal/blob/bf33d651a9fcece70df8eac35f89b0393ca5189a/ui/src/platform/mac/fonts.rs#L383.
-                "en".into(),
-                Default::default(),
-            )),
+            font_store,
             font_id_map: Default::default(),
             font_selections: Default::default(),
             loaded_fonts: Default::default(),

--- a/crates/warpui/src/windowing/winit/fonts/windows.rs
+++ b/crates/warpui/src/windowing/winit/fonts/windows.rs
@@ -16,6 +16,12 @@ use std::sync::Arc;
 
 const EN_US_LOCALE: &str = "en-US";
 
+/// Returns the BCP-47 locale string used to bias DirectWrite Han-glyph fallback.
+/// Mirrors the current UI locale (set via `crate::set_ui_locale` from `app::i18n`).
+fn current_fallback_locale() -> String {
+    crate::current_ui_locale()
+}
+
 /// Windows symbol fonts that are used to render window control icons. We specifically do not do any
 /// validation of these fonts (i.e. to check if the font contains english characters).
 const SYMBOL_ICON_FONTS: &[&str] = &["Segoe Fluent Icons", "Segoe MDL2 Assets"];
@@ -165,8 +171,34 @@ impl TextLayoutSystem {
             anyhow::anyhow!("Unable to load typeface from font_kit Handle: {err:?}")
         })?;
 
+        let locale = current_fallback_locale();
+
+        // Locale-preferred CJK system fonts. DirectWrite's IDWriteFontFallback ignores locale
+        // for Han disambiguation on Windows English/dev environments and returns Microsoft YaHei
+        // first, which renders Japanese UI text with Simplified Chinese glyph shapes. For shared
+        // CJK Han we prepend the locale's native system fonts (e.g. Yu Gothic UI for ja-*).
+        let mut fallback_font_vec: Vec<FontId> = Vec::new();
+        if is_shared_cjk_han(character) {
+            for family in preferred_cjk_families_for_locale(&locale) {
+                if let Ok(fam) = source.select_family_by_name(family) {
+                    for fk_handle in fam.fonts() {
+                        if let Ok(handle) =
+                            load_font_from_handle(fk_handle, ValidateFontSupportsEn::No)
+                        {
+                            if let Ok(id) = self.insert_font(handle) {
+                                fallback_font_vec.push(id);
+                            }
+                        }
+                    }
+                    if !fallback_font_vec.is_empty() {
+                        break;
+                    }
+                }
+            }
+        }
+
         let fallback_result =
-            loaded_font.get_fallbacks(character.to_string().as_str(), EN_US_LOCALE);
+            loaded_font.get_fallbacks(character.to_string().as_str(), &locale);
 
         // Convert each font-kit fallback `Font` into a UI framework `FontHandle` and load it into
         // fontdb. We deliberately avoid `font_kit::Font::handle()` here: its default impl reads
@@ -178,22 +210,17 @@ impl TextLayoutSystem {
         // `DirectWriteSource::create_handle_from_dwrite_font` does for enumerated system fonts.
         // This lets fontdb mmap the file lazily and lets `insert_font` dedup by `(path, index)`,
         // so the same fallback family is loaded at most once per process.
-        let fallback_font_vec = fallback_result
-            .fonts
-            .into_iter()
-            .flat_map(|fallback_font| {
-                let loaded_handle =
-                    fallback_font_path_handle(&fallback_font.font).or_else(|| {
-                        // Last-resort fallback for fonts that aren't backed by a local file (e.g.
-                        // custom collection loaders). These don't appear in practice for DirectWrite
-                        // system fallbacks, but preserve the original byte-copy behavior so we
-                        // degrade gracefully instead of dropping the glyph.
-                        let handle = fallback_font.font.handle()?;
-                        load_font_from_handle(&handle, ValidateFontSupportsEn::No).ok()
-                    })?;
-                self.insert_font(loaded_handle).ok()
-            })
-            .collect_vec();
+        fallback_font_vec.extend(fallback_result.fonts.into_iter().flat_map(|fallback_font| {
+            let loaded_handle = fallback_font_path_handle(&fallback_font.font).or_else(|| {
+                // Last-resort fallback for fonts that aren't backed by a local file (e.g.
+                // custom collection loaders). These don't appear in practice for DirectWrite
+                // system fallbacks, but preserve the original byte-copy behavior so we
+                // degrade gracefully instead of dropping the glyph.
+                let handle = fallback_font.font.handle()?;
+                load_font_from_handle(&handle, ValidateFontSupportsEn::No).ok()
+            })?;
+            self.insert_font(loaded_handle).ok()
+        }));
 
         Ok(fallback_font_vec)
     }
@@ -241,6 +268,40 @@ fn load_font_from_handle(
             let typeface = OwnedFace::from_vec(bytes.to_vec(), *font_index)?;
             Ok(FontHandle::from(typeface))
         }
+    }
+}
+
+/// True for CJK Han code points whose glyph shape varies between ja / zh-Hans / zh-Hant / ko.
+/// Used to bias DirectWrite fallback toward locale-native system fonts (e.g. Yu Gothic UI on ja-*).
+fn is_shared_cjk_han(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF       // CJK Unified Ideographs Extension A
+            | 0x4E00..=0x9FFF // CJK Unified Ideographs
+            | 0xF900..=0xFAFF // CJK Compatibility Ideographs
+            | 0x20000..=0x2A6DF // Extension B
+            | 0x2A700..=0x2B73F // Extension C
+            | 0x2B740..=0x2B81F // Extension D
+            | 0x2B820..=0x2CEAF // Extension E
+    )
+}
+
+/// Locale-preferred Windows system CJK font families, in priority order.
+/// Used to override DirectWrite's locale-insensitive Han fallback (which favors
+/// Microsoft YaHei / Simplified Chinese on Windows English/dev environments).
+fn preferred_cjk_families_for_locale(locale: &str) -> &'static [&'static str] {
+    let lower = locale.to_ascii_lowercase();
+    if lower.starts_with("ja") {
+        &["Yu Gothic UI", "Yu Gothic", "Meiryo UI", "Meiryo", "MS Gothic"]
+    } else if lower.starts_with("ko") {
+        &["Malgun Gothic", "Gulim", "Dotum"]
+    } else if lower.starts_with("zh-tw") || lower.starts_with("zh-hk") || lower.starts_with("zh-mo")
+    {
+        &["Microsoft JhengHei UI", "Microsoft JhengHei", "PMingLiU", "MingLiU"]
+    } else if lower.starts_with("zh") {
+        &["Microsoft YaHei UI", "Microsoft YaHei", "SimSun"]
+    } else {
+        &[]
     }
 }
 

--- a/crates/warpui/src/windowing/winit/fonts/windows.rs
+++ b/crates/warpui/src/windowing/winit/fonts/windows.rs
@@ -14,8 +14,6 @@ use owned_ttf_parser::OwnedFace;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const EN_US_LOCALE: &str = "en-US";
-
 /// Returns the BCP-47 locale string used to bias DirectWrite Han-glyph fallback.
 /// Mirrors the current UI locale (set via `crate::set_ui_locale` from `app::i18n`).
 fn current_fallback_locale() -> String {
@@ -289,20 +287,38 @@ fn is_shared_cjk_han(ch: char) -> bool {
 /// Locale-preferred Windows system CJK font families, in priority order.
 /// Used to override DirectWrite's locale-insensitive Han fallback (which favors
 /// Microsoft YaHei / Simplified Chinese on Windows English/dev environments).
+///
+/// Routing handles BCP-47 region subtags (zh-TW / zh-HK / zh-MO) and script
+/// subtags (zh-Hant / zh-Hans, optionally with region: zh-Hant-TW etc.) so
+/// callers don't need to normalize their locale tag first.
 fn preferred_cjk_families_for_locale(locale: &str) -> &'static [&'static str] {
     let lower = locale.to_ascii_lowercase();
     if lower.starts_with("ja") {
         &["Yu Gothic UI", "Yu Gothic", "Meiryo UI", "Meiryo", "MS Gothic"]
     } else if lower.starts_with("ko") {
         &["Malgun Gothic", "Gulim", "Dotum"]
-    } else if lower.starts_with("zh-tw") || lower.starts_with("zh-hk") || lower.starts_with("zh-mo")
-    {
+    } else if is_zh_traditional(&lower) {
         &["Microsoft JhengHei UI", "Microsoft JhengHei", "PMingLiU", "MingLiU"]
     } else if lower.starts_with("zh") {
         &["Microsoft YaHei UI", "Microsoft YaHei", "SimSun"]
     } else {
         &[]
     }
+}
+
+/// True if `lower` (already ASCII-lowercased BCP-47 tag) refers to Traditional Chinese.
+/// Matches both region forms (zh-tw / zh-hk / zh-mo) and script-subtag forms
+/// (zh-hant, zh-hant-tw, zh-foo-hant, etc.). Hyphenated boundaries are required so
+/// `zh-hansolo` style accidents don't match.
+fn is_zh_traditional(lower: &str) -> bool {
+    if !lower.starts_with("zh") {
+        return false;
+    }
+    if lower.starts_with("zh-tw") || lower.starts_with("zh-hk") || lower.starts_with("zh-mo") {
+        return true;
+    }
+    // Walk the hyphen-separated subtags after the primary "zh".
+    lower.split('-').skip(1).any(|sub| sub == "hant")
 }
 
 /// Builds a path-backed [`FontHandle`] for a font-kit DirectWrite `Font` by reaching through

--- a/crates/warpui/src/windowing/winit/fonts/windows.rs
+++ b/crates/warpui/src/windowing/winit/fonts/windows.rs
@@ -14,8 +14,8 @@ use owned_ttf_parser::OwnedFace;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Returns the BCP-47 locale string used to bias DirectWrite Han-glyph fallback.
-/// Mirrors the current UI locale (set via `crate::set_ui_locale` from `app::i18n`).
+/// 返回用于偏置 DirectWrite Han 字形回退的 BCP-47 locale 字符串。
+/// 与当前 UI locale 同步(由 `app::i18n` 通过 `crate::set_ui_locale` 设置)。
 fn current_fallback_locale() -> String {
     crate::current_ui_locale()
 }
@@ -171,10 +171,10 @@ impl TextLayoutSystem {
 
         let locale = current_fallback_locale();
 
-        // Locale-preferred CJK system fonts. DirectWrite's IDWriteFontFallback ignores locale
-        // for Han disambiguation on Windows English/dev environments and returns Microsoft YaHei
-        // first, which renders Japanese UI text with Simplified Chinese glyph shapes. For shared
-        // CJK Han we prepend the locale's native system fonts (e.g. Yu Gothic UI for ja-*).
+        // 按 locale 优先的 CJK 系统字体:DirectWrite 的 IDWriteFontFallback 在 Windows 英文 / 开发环境
+        // 下不参考 locale 解决 Han 字形歧义,默认返回 Microsoft YaHei,导致日文 UI 反倒拿到简体字字形。
+        // 因此对共享 CJK Han 字符,我们在 DirectWrite 回退之前先 prepend 当前 locale 对应的系统字体
+        // (例如 ja-* → Yu Gothic UI)。
         let mut fallback_font_vec: Vec<FontId> = Vec::new();
         if is_shared_cjk_han(character) {
             for family in preferred_cjk_families_for_locale(&locale) {
@@ -269,8 +269,9 @@ fn load_font_from_handle(
     }
 }
 
-/// True for CJK Han code points whose glyph shape varies between ja / zh-Hans / zh-Hant / ko.
-/// Used to bias DirectWrite fallback toward locale-native system fonts (e.g. Yu Gothic UI on ja-*).
+/// 共享 CJK Han 码点判定:这些字符在 ja / zh-Hans / zh-Hant / ko 之间字形不同,
+/// 用于把 DirectWrite 回退偏向当前 locale 的本地字体(例如 ja-* → Yu Gothic UI)。
+/// 覆盖到 Extension G(0x3134F),后续若 Unicode 再扩展可在此追加。
 fn is_shared_cjk_han(ch: char) -> bool {
     matches!(
         ch as u32,
@@ -281,43 +282,53 @@ fn is_shared_cjk_han(ch: char) -> bool {
             | 0x2A700..=0x2B73F // Extension C
             | 0x2B740..=0x2B81F // Extension D
             | 0x2B820..=0x2CEAF // Extension E
+            | 0x2CEB0..=0x2EBEF // Extension F
+            | 0x30000..=0x3134F // Extension G
     )
 }
 
-/// Locale-preferred Windows system CJK font families, in priority order.
-/// Used to override DirectWrite's locale-insensitive Han fallback (which favors
-/// Microsoft YaHei / Simplified Chinese on Windows English/dev environments).
+/// 提取 BCP-47 标签的主语言子标签(primary subtag),已统一 ASCII 小写。
+/// 例如 `ja-jp` → `ja`、`zh-hant-tw` → `zh`、`kok-in` → `kok`。
+/// 用于精确判断主语言,避免 `starts_with("ko")` 这类前缀匹配把
+/// `kok-IN`(孔卡尼语)误判为韩文,或 `zha-CN`(壮语)误判为中文。
+fn primary_subtag(lower: &str) -> &str {
+    lower
+        .split(|c: char| c == '-' || c == '_')
+        .next()
+        .unwrap_or("")
+}
+
+/// 按 locale 优先返回 Windows 系统 CJK 字体族(按优先级)。
+/// 用于覆盖 DirectWrite 不参考 locale 的 Han 回退(默认偏向 Microsoft YaHei /
+/// 简体中文,这在 Windows 英文 / 开发环境下尤其明显)。
 ///
-/// Routing handles BCP-47 region subtags (zh-TW / zh-HK / zh-MO) and script
-/// subtags (zh-Hant / zh-Hans, optionally with region: zh-Hant-TW etc.) so
-/// callers don't need to normalize their locale tag first.
+/// 路由同时识别 BCP-47 region 子标签(zh-TW / zh-HK / zh-MO)和 script 子标签
+/// (zh-Hant / zh-Hans,可带 region:zh-Hant-TW 等),调用方无需事先规范化 tag。
 fn preferred_cjk_families_for_locale(locale: &str) -> &'static [&'static str] {
     let lower = locale.to_ascii_lowercase();
-    if lower.starts_with("ja") {
-        &["Yu Gothic UI", "Yu Gothic", "Meiryo UI", "Meiryo", "MS Gothic"]
-    } else if lower.starts_with("ko") {
-        &["Malgun Gothic", "Gulim", "Dotum"]
-    } else if is_zh_traditional(&lower) {
-        &["Microsoft JhengHei UI", "Microsoft JhengHei", "PMingLiU", "MingLiU"]
-    } else if lower.starts_with("zh") {
-        &["Microsoft YaHei UI", "Microsoft YaHei", "SimSun"]
-    } else {
-        &[]
+    match primary_subtag(&lower) {
+        "ja" => &["Yu Gothic UI", "Yu Gothic", "Meiryo UI", "Meiryo", "MS Gothic"],
+        "ko" => &["Malgun Gothic", "Gulim", "Dotum"],
+        "zh" if is_zh_traditional(&lower) => {
+            &["Microsoft JhengHei UI", "Microsoft JhengHei", "PMingLiU", "MingLiU"]
+        }
+        "zh" => &["Microsoft YaHei UI", "Microsoft YaHei", "SimSun"],
+        _ => &[],
     }
 }
 
-/// True if `lower` (already ASCII-lowercased BCP-47 tag) refers to Traditional Chinese.
-/// Matches both region forms (zh-tw / zh-hk / zh-mo) and script-subtag forms
-/// (zh-hant, zh-hant-tw, zh-foo-hant, etc.). Hyphenated boundaries are required so
-/// `zh-hansolo` style accidents don't match.
+/// `lower`(已 ASCII 小写化的 BCP-47 标签)是否指向繁体中文。
+/// 同时匹配 region 形式(zh-tw / zh-hk / zh-mo)和 script 子标签形式
+/// (zh-hant、zh-hant-tw、zh-foo-hant 等)。要求连字符边界,
+/// 避免 `zh-hansolo` 之类意外匹配。
 fn is_zh_traditional(lower: &str) -> bool {
-    if !lower.starts_with("zh") {
+    if primary_subtag(lower) != "zh" {
         return false;
     }
     if lower.starts_with("zh-tw") || lower.starts_with("zh-hk") || lower.starts_with("zh-mo") {
         return true;
     }
-    // Walk the hyphen-separated subtags after the primary "zh".
+    // 遍历主标签后的连字符子标签。
     lower.split('-').skip(1).any(|sub| sub == "hant")
 }
 


### PR DESCRIPTION
## Summary

UI rendered with the Japanese locale on OpenWarp Windows currently displays shared CJK Han ideographs (e.g. 設, 規, 直, 反) using **Simplified Chinese glyph shapes** instead of Japanese ones. Same problem will hit Traditional Chinese / Korean if those locales are added.

This PR fixes the root causes end-to-end so a Japanese-locale UI gets Japanese-shaped glyphs and a Chinese-locale UI gets Chinese-shaped glyphs, on Windows English / Japanese / Chinese OSes.

## Root causes (all fixed)

### 1. cosmic-text \`FontSystem\` locale was hardcoded \`\"en\"\`

\`crates/warpui/src/windowing/winit/fonts.rs:308\` constructed \`cosmic_text::FontSystem\` with \`\"en\"\`. cosmic-text uses that string to disambiguate Han glyph fallback for shared code points; locked to \"en\" it picks zh-Hans-leaning glyphs.

cosmic-text has no public \`set_locale\`, so we rebuild the \`FontSystem\` when the UI locale changes, reusing the existing \`fontdb::Database\` (cheap — no font data is reloaded). \`font_store\` is wrapped in \`Arc<RwLock<>>\` so the listener can hold a \`Weak\` reference.

### 2. \`LANG=en_US.UTF-8\` unconditionally exported on every platform

\`app/src/lib.rs:566\` unconditionally pinned LANG when POSIX locale env vars were unset. On Windows that overrides \`i18n_embed::DesktopLanguageRequester\`, forcing the i18n layer to \`en\` regardless of the user's UI language preference. Restricted to non-Windows (Windows uses \`GetUserPreferredUILanguages\` as the source of truth).

### 3. DirectWrite fallback called with hardcoded \`\"en-US\"\`

\`crates/warpui/src/windowing/winit/fonts/windows.rs::get_fallback_fonts_for_character\` hardcoded \`\"en-US\"\` when calling DirectWrite's \`IDWriteFontFallback\`. \`MapCharacters\` is locale-sensitive for CJK Han, so we thread the current UI locale through.

As a belt-and-braces measure (DirectWrite's system fallback chain still leans on OS UI language on English-Windows), we explicitly prepend locale-native system CJK families:

- ja-*: Yu Gothic UI / Yu Gothic / Meiryo UI / Meiryo / MS Gothic
- zh-TW / zh-HK / zh-MO: Microsoft JhengHei UI / Microsoft JhengHei / PMingLiU / MingLiU
- zh-*: Microsoft YaHei UI / Microsoft YaHei / SimSun
- ko-*: Malgun Gothic / Gulim / Dotum

This only applies to characters in the shared CJK Han ranges (\`U+3400-4DBF\`, \`U+4E00-9FFF\`, \`U+F900-FAFF\`, plus Extensions A-E); kana, hangul, and non-Han text are unaffected.

## API additions

\`warpui\` now exposes:

\`\`\`rust
pub fn current_ui_locale() -> String;
pub fn set_ui_locale(locale: impl Into<String>);
pub fn on_ui_locale_changed(cb: Arc<dyn Fn(&str) + Send + Sync>);
\`\`\`

\`app::i18n\` forwards the resolved locale into it from \`init\` / \`set_locale\` / \`reset_to_system_locale\`.

## Other touched files

- \`app/src/font_fallback.rs\`: shared CJK Han codepoints in the per-codepoint \`ExternalFontFamily\` table now remap to Noto Sans JP / KR / TC by UI locale. This path is \`#[cfg(target_family = \"wasm\")]\` only today, so it's effectively a no-op on desktop, but keeps the table consistent for the day desktop hooks into the same registry.

## No-op for existing users

For System / English / SimplifiedChinese, cosmic-text's locale ends up matching whatever \`DesktopLanguageRequester\` returned — same as today's behavior. The DirectWrite prepend only fires for ja / zh / ko locales on shared Han characters, never for English UI.

## Test plan

- [x] \`cargo check --bin warp-oss\` passes
- [x] \`cargo build --bin warp-oss\` succeeds
- [x] On Windows English with Settings → Language = 日本語: 設, 規, 直, 反 render with Japanese glyph shapes (Yu Gothic UI), confirmed visually
- [x] On Windows English with Settings → Language = 简体中文: existing zh-CN UI unchanged
- [x] cosmic-text \`FontSystem\` rebuilt on locale switch (verified via debug logs during development; logs were removed before this commit)
- [x] No regressions on English UI

## Companion PR

#61 surfaces the \`Japanese\` Language variant so users can pick it in Settings → Appearance. Without that PR, this glyph fix is exercised only on machines whose OS UI language is already ja-JP. Order doesn't matter — the two PRs are independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale-aware CJK font fallback: CJK characters use fonts matching the UI language and update immediately when you change locales.
  * Runtime font system refresh so text rendering adapts to UI locale changes without restarting.

* **Bug Fixes**
  * Windows behavior refined: POSIX locale defaulting is skipped on Windows to avoid incorrect locale assumptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/62)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->