### PR TITLE
fix(ime): enable IME marked text rendering on Windows

### DIFF
--- a/app/src/bin/oss.rs
+++ b/app/src/bin/oss.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use warp_core::{
     channel::{Channel, ChannelConfig, ChannelState, OzConfig, WarpServerConfig},
+    features::{FeatureFlag, DEBUG_FLAGS},
     AppId,
 };
 
@@ -24,15 +25,14 @@ fn main() -> Result<()> {
         },
     );
     if cfg!(debug_assertions) {
-        state = state.with_additional_features(warp_core::features::DEBUG_FLAGS);
+        state = state.with_additional_features(DEBUG_FLAGS);
     }
-    // Always enable IME marked-text rendering on platforms where the winit IME path supports it.
-    // Without this, Warp drops the preedit/composition update and only the OS candidate window is
-    // visible while the user is typing — broken for Japanese/Chinese/Korean input on Windows.
-    #[cfg(any(target_os = "macos", windows))]
+    // 始终启用 IME marked-text 渲染:winit 的 IME 路径在 macOS / Windows 都支持,
+    // 但若不在此处显式开启,Warp 会把 preedit / 输入合成更新整体丢弃,只剩 OS 的候选窗
+    // 可见 —— 在 Windows 上对日文 / 中文 / 韩文输入都属于实质性损坏。
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
-        state = state
-            .with_additional_features(&[warp_core::features::FeatureFlag::ImeMarkedText]);
+        state = state.with_additional_features(&[FeatureFlag::ImeMarkedText]);
     }
     ChannelState::set(state);
 

--- a/app/src/bin/oss.rs
+++ b/app/src/bin/oss.rs
@@ -26,6 +26,14 @@ fn main() -> Result<()> {
     if cfg!(debug_assertions) {
         state = state.with_additional_features(warp_core::features::DEBUG_FLAGS);
     }
+    // Always enable IME marked-text rendering on platforms where the winit IME path supports it.
+    // Without this, Warp drops the preedit/composition update and only the OS candidate window is
+    // visible while the user is typing — broken for Japanese/Chinese/Korean input on Windows.
+    #[cfg(any(target_os = "macos", windows))]
+    {
+        state = state
+            .with_additional_features(&[warp_core::features::FeatureFlag::ImeMarkedText]);
+    }
     ChannelState::set(state);
 
     warp::run()

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -930,8 +930,10 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::Autoupdate,
     FeatureFlag::Changelog,
     FeatureFlag::CrashReporting,
-    // Marked text is currently only supported on MacOS.
-    #[cfg(target_os = "macos")]
+    // Marked text is supported by the winit IME path on macOS and Windows.
+    // Windows needs this to render IME preedit/composition text; otherwise only
+    // the OS candidate window is visible while Warp drops the marked text update.
+    #[cfg(any(target_os = "macos", windows))]
     FeatureFlag::ImeMarkedText,
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -930,10 +930,10 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::Autoupdate,
     FeatureFlag::Changelog,
     FeatureFlag::CrashReporting,
-    // Marked text is supported by the winit IME path on macOS and Windows.
-    // Windows needs this to render IME preedit/composition text; otherwise only
-    // the OS candidate window is visible while Warp drops the marked text update.
-    #[cfg(any(target_os = "macos", windows))]
+    // winit 的 IME 路径在 macOS 和 Windows 都已支持 marked text。
+    // Windows 必须开启该 flag 才能渲染 IME preedit / 输入合成文本,
+    // 否则只能看到 OS 的候选窗,Warp 会把 marked text 更新整体丢弃。
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     FeatureFlag::ImeMarkedText,
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]


### PR DESCRIPTION
## Summary

Enables inline IME composition (preedit / marked text) rendering on Windows in the terminal, search bar, and AI prompt. Without this, Japanese / Chinese / Korean IME users see the candidate window but the variable-length composition string before commit is completely invisible while typing.

## Note about upstream

This mirrors **warpdotdev/warp#10122** (\"Enable IME marked text on Windows and Linux\"), which has been open and unreviewed since 2026-05-05. Filing here so OpenWarp users get the fix without waiting for upstream merge. When the next upstream sync absorbs #10122 this will be a no-op delta — the change is the same shape (extend the \`#[cfg]\` on \`FeatureFlag::ImeMarkedText\` to include Windows).

## Changes

### 1. \`crates/warp_features/src/lib.rs\`

Extend \`RELEASE_FLAGS\`' \`FeatureFlag::ImeMarkedText\` cfg from \`target_os = \"macos\"\` to \`any(target_os = \"macos\", windows)\`. The winit IME path on Windows already supports the \`Ime::Preedit\` event and dispatches \`SetMarkedText\`, but \`set_marked_text_on_terminal\` (and similar render paths) early-return when this feature flag is off.

### 2. \`app/src/bin/oss.rs\`

Add \`FeatureFlag::ImeMarkedText\` to \`additional_features\` for \`Channel::Oss\` on macOS / Windows. Without this, dev/debug builds of \`warp-oss\` (which don't trip the \`release_bundle\` cfg gate that activates \`RELEASE_FLAGS\`) don't pick up the flag — useful for contributors who run \`cargo build --bin warp-oss\` without the bundle pipeline.

## Test plan

- [x] \`cargo check --bin warp-oss\` passes
- [x] \`cargo build --bin warp-oss\` succeeds
- [x] On Windows 11 with **Microsoft IME**: composition string appears inline in terminal / search / AI prompt while typing 日本語
- [x] On Windows 11 with **Google Japanese Input**: same as above
- [x] Candidate window position remains usable (no regression in caret-area positioning)
- [x] Existing macOS behavior unchanged

## Out of scope

CodeEditorView (\`app/src/code/editor/\`) preedit is a separate issue — that view doesn't have a \`SetMarkedText\` matcher yet (\`MarkedTextState\` not implemented). Tracked separately, not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled IME marked text support on Windows, improving input method editing: smoother text composition, more accurate caret placement and selection handling, and overall parity with macOS for users typing with complex input methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/63)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->