### PR TITLE
fix: 修复 macOS i18n 自动识别语言的问题

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
       "request": "launch",
       "name": "Debug MacOS executable",
       "preLaunchTask": "build_warplocal",
-      "program": "${workspaceFolder}/target/debug/bundle/osx/WarpLocal.app/Contents/MacOS/warp",
+      "program": "${workspaceFolder}/target/debug/bundle/osx/OpenWarp.app/Contents/MacOS/warp-oss",
       "args": [],
       "cwd": "${workspaceFolder}",
       "sourceLanguages": ["rust"]
@@ -71,7 +71,7 @@
       "request": "launch",
       "name": "Debug MacOS executable local session sharing server",
       "preLaunchTask": "build_warplocal_localsessionsharing",
-      "program": "${workspaceFolder}/target/debug/bundle/osx/WarpLocal.app/Contents/MacOS/warp",
+      "program": "${workspaceFolder}/target/debug/bundle/osx/OpenWarp.app/Contents/MacOS/warp-oss",
       "args": [],
       "cwd": "${workspaceFolder}",
       "sourceLanguages": ["rust"]
@@ -84,7 +84,7 @@
         "RUST_BACKTRACE": "1"
       },
       "preLaunchTask": "build_warplocal_fastdev",
-      "program": "${workspaceFolder}/target/debug/bundle/osx/WarpLocal.app/Contents/MacOS/warp",
+      "program": "${workspaceFolder}/target/debug/bundle/osx/OpenWarp.app/Contents/MacOS/warp-oss",
       "args": [],
       "cwd": "${workspaceFolder}",
       "sourceLanguages": ["rust"]
@@ -94,7 +94,7 @@
       "request": "launch",
       "name": "Debug MacOS executable with fast_dev + local session sharing server",
       "preLaunchTask": "build_warplocal_fastdev_localsessionsharing",
-      "program": "${workspaceFolder}/target/debug/bundle/osx/WarpLocal.app/Contents/MacOS/warp",
+      "program": "${workspaceFolder}/target/debug/bundle/osx/OpenWarp.app/Contents/MacOS/warp-oss",
       "args": [],
       "cwd": "${workspaceFolder}",
       "sourceLanguages": ["rust"]

--- a/app/assets/resources/mac/CLI-Info.plist
+++ b/app/assets/resources/mac/CLI-Info.plist
@@ -8,6 +8,11 @@
   <string>Warp CLI</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
+  <key>CFBundleLocalizations</key>
+  <array>
+    <string>en</string>
+    <string>zh-CN</string>
+  </array>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>

--- a/app/assets/resources/mac/CLI-Info.plist
+++ b/app/assets/resources/mac/CLI-Info.plist
@@ -11,6 +11,7 @@
   <key>CFBundleLocalizations</key>
   <array>
     <string>en</string>
+    <string>ja</string>
     <string>zh-CN</string>
   </array>
   <key>CFBundlePackageType</key>

--- a/app/i18n/MACOS.md
+++ b/app/i18n/MACOS.md
@@ -1,0 +1,10 @@
+# macOS 加新语种的需要做的事
+
+为了让 macOS 能正常翻译，当新增语种(如 `zh-TW`、`ja` 等)时，还需要:
+
+1. **更新 macOS plist 配置**: 在所有需要声明本地化的 plist 中添加新语种代码到 `CFBundleLocalizations` 数组:
+   - `app/assets/resources/mac/CLI-Info.plist` —— 修改 `<key>CFBundleLocalizations</key>` 下的 `<array>`
+   - `app/src/bin/local.rs` —— 修改 `embed_plist::embed_info_plist_bytes!` 宏内的 plist XML
+   - `app/src/bin/oss.rs` —— 修改 `embed_plist::embed_info_plist_bytes!` 宏内的 plist XML
+   - 例:添加 `<string>zh-TW</string>` 到 `<array>` 中
+2. **更新构建脚本**: 在 `script/update_plist` 脚本的 `plutil -insert/replace CFBundleLocalizations` 命令中添加新语种代码

--- a/app/src/bin/local.rs
+++ b/app/src/bin/local.rs
@@ -42,6 +42,11 @@ embed_plist::embed_info_plist_bytes!(r#"
     <string>dev.warp.Warp-Local</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+    <string>en</string>
+    <string>zh-CN</string>
+    </array>
     <key>CFBundleName</key>
     <string>WarpLocal</string>
     <key>CFBundlePackageType</key>

--- a/app/src/bin/local.rs
+++ b/app/src/bin/local.rs
@@ -45,6 +45,7 @@ embed_plist::embed_info_plist_bytes!(r#"
     <key>CFBundleLocalizations</key>
     <array>
     <string>en</string>
+    <string>ja</string>
     <string>zh-CN</string>
     </array>
     <key>CFBundleName</key>

--- a/app/src/bin/oss.rs
+++ b/app/src/bin/oss.rs
@@ -56,6 +56,11 @@ embed_plist::embed_info_plist_bytes!(r#"
     <string>dev.openwarp.OpenWarp</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+    <string>en</string>
+    <string>zh-CN</string>
+    </array>
     <key>CFBundleName</key>
     <string>OpenWarp</string>
     <key>CFBundlePackageType</key>

--- a/app/src/bin/oss.rs
+++ b/app/src/bin/oss.rs
@@ -59,6 +59,7 @@ embed_plist::embed_info_plist_bytes!(r#"
     <key>CFBundleLocalizations</key>
     <array>
     <string>en</string>
+    <string>ja</string>
     <string>zh-CN</string>
     </array>
     <key>CFBundleName</key>

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -568,7 +568,9 @@ pub fn run() -> Result<()> {
     // —— Windows API (`GetUserPreferredUILanguages`) 才是 UI locale 的真实来源,这里
     // 强制 `LANG=en_US.UTF-8` 会让 `DesktopLanguageRequester` 不论用户选什么 UI 语言
     // 都返回 en,进而把 CJK Han 字形回退打偏 (日文 UI 反倒拿到简体字字形)。
-    #[cfg(not(windows))]
+    // macOS 如果桌面打开 Bundle 也是没有环境变量的, 但它的 `DesktopLanguageRequester`
+    // 如果设置了 `LANG` 环境变量会直接返回该值而不询问系统, 因此同样需要跳过。
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     if std::env::var_os("LANG").is_none()
         && std::env::var_os("LC_ALL").is_none()
         && std::env::var_os("LC_CTYPE").is_none()

--- a/script/update_plist
+++ b/script/update_plist
@@ -51,6 +51,10 @@ if [[ -n "$WARP_SCHEME_NAME" ]]; then
   plutil -insert CFBundleURLTypes -xml "<array><dict><key>CFBundleURLName</key><string>Custom App</string><key>CFBundleURLSchemes</key><array><string>$WARP_SCHEME_NAME</string></array></dict></array>" "$WARP_PLIST_PATH"
 fi
 
+echo "Updating plist with supported localizations"
+plutil -insert CFBundleLocalizations -xml "<array><string>en</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH" 2>/dev/null || \
+  plutil -replace CFBundleLocalizations -xml "<array><string>en</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH"
+
 if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
   echo "Updating plist with supported file types"
   plutil -insert CFBundleDocumentTypes -xml "

--- a/script/update_plist
+++ b/script/update_plist
@@ -52,8 +52,8 @@ if [[ -n "$WARP_SCHEME_NAME" ]]; then
 fi
 
 echo "Updating plist with supported localizations"
-plutil -insert CFBundleLocalizations -xml "<array><string>en</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH" 2>/dev/null || \
-  plutil -replace CFBundleLocalizations -xml "<array><string>en</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH"
+plutil -insert CFBundleLocalizations -xml "<array><string>en</string><string>ja</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH" 2>/dev/null || \
+  plutil -replace CFBundleLocalizations -xml "<array><string>en</string><string>ja</string><string>zh-CN</string></array>" "$WARP_PLIST_PATH"
 
 if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
   echo "Updating plist with supported file types"


### PR DESCRIPTION
顺便修改了 macOS 下 VSCode 调试的二进制路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS application now supports Japanese and Simplified Chinese localizations in addition to English, providing native language interfaces

* **Bug Fixes**
  * Fixed macOS locale handling to properly respect system language preferences instead of defaulting to English when locale is unconfigured

* **Documentation**
  * Added guide for managing and extending macOS application localizations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->