### PR TITLE
fix(ai): DeepSeek thinking 模型经 OpenAI 兼容端点也需回传 reasoning_content

### DIFF
--- a/app/src/ai/agent_providers/reasoning.rs
+++ b/app/src/ai/agent_providers/reasoning.rs
@@ -72,11 +72,7 @@ pub fn model_reasoning_variants(
         //
         // Ollama 后端模型 id 任意,保守留空。
         AgentProviderApiType::DeepSeek => {
-            if id.contains("deepseek-reasoner")
-                || id.contains("deepseek-v4")
-                || id.contains("deepseek-thinking")
-                || id.contains("deepseek-r1")
-            {
+            if is_deepseek_thinking_model(&id) {
                 // DeepSeek 官方思考深度只有 high / max 两档(low/medium/xhigh
                 // 即便服务端 deserializer 接受也只是同档别名,picker 不暴露冗余项)。
                 // Off 档走"关闭思考":本地 fork genai 已支持 ChatOptions::extra_body,
@@ -183,6 +179,15 @@ fn is_openai_reasoning_model(id: &str) -> bool {
     false
 }
 
+fn is_deepseek_thinking_model(id: &str) -> bool {
+    // DeepSeek thinking-mode 模型名约定:reasoner / r1 / v4* / *-thinking。
+    // `deepseek-v4` 子串覆盖 `deepseek-v4-flash` 等后续变体。
+    id.contains("deepseek-reasoner")
+        || id.contains("deepseek-v4")
+        || id.contains("deepseek-thinking")
+        || id.contains("deepseek-r1")
+}
+
 fn is_gemini_reasoning_model(id: &str) -> bool {
     // gemini-2.5-* 起 thinking 模式(flash-thinking-exp / pro / pro-thinking)。
     // gemini-3.* 全系(opencode 在 levels 上区分 3 / 3.1)。
@@ -211,6 +216,10 @@ fn is_gemini_reasoning_model(id: &str) -> bool {
 /// - **DeepSeek api_type**:全 echo(adapter 即 DeepSeek 专属)
 /// - **OpenAI / OpenAiResp + model_id 含 `kimi` / `moonshot`**:Kimi 走 OpenAI
 ///   兼容路径,thinking-mode 校验同源
+/// - **OpenAI / OpenAiResp + DeepSeek thinking 模型**(`deepseek-reasoner` /
+///   `deepseek-r1` / `deepseek-v4*` / `deepseek-thinking`):DeepSeek 官方端点是
+///   OpenAI-compatible 的,用户常把它配成 OpenAI api_type 的 BYOP provider,
+///   thinking-mode 服务端校验完全相同
 /// - 其他:false(Anthropic 走 thinking blocks,Gemini 走 thought signatures,
 ///   都不需要这个 echo)
 pub fn model_requires_reasoning_echo(api_type: AgentProviderApiType, model_id: &str) -> bool {
@@ -218,7 +227,7 @@ pub fn model_requires_reasoning_echo(api_type: AgentProviderApiType, model_id: &
         AgentProviderApiType::DeepSeek => true,
         AgentProviderApiType::OpenAi | AgentProviderApiType::OpenAiResp => {
             let id = model_id.to_ascii_lowercase();
-            id.contains("kimi") || id.contains("moonshot")
+            id.contains("kimi") || id.contains("moonshot") || is_deepseek_thinking_model(&id)
         }
         AgentProviderApiType::Anthropic
         | AgentProviderApiType::Gemini
@@ -338,6 +347,29 @@ mod tests {
         // 普通 OpenAI 模型不 echo
         assert!(!model_requires_reasoning_echo(t, "gpt-5"));
         assert!(!model_requires_reasoning_echo(t, "o3-mini"));
+    }
+
+    #[test]
+    fn requires_reasoning_echo_deepseek_via_openai() {
+        // DeepSeek 官方端点是 OpenAI-compatible 的,用户常把它配成 OpenAI api_type 的
+        // BYOP provider。thinking 模型必须回 echo `reasoning_content`,否则 400。
+        let t = AgentProviderApiType::OpenAi;
+        assert!(model_requires_reasoning_echo(t, "deepseek-v4-flash"));
+        assert!(model_requires_reasoning_echo(t, "deepseek-v4"));
+        assert!(model_requires_reasoning_echo(t, "deepseek-reasoner"));
+        assert!(model_requires_reasoning_echo(t, "deepseek-r1"));
+        assert!(model_requires_reasoning_echo(t, "deepseek-thinking"));
+        // 大小写不敏感
+        assert!(model_requires_reasoning_echo(t, "DeepSeek-V4-Flash"));
+        // OpenAiResp 同源
+        assert!(model_requires_reasoning_echo(
+            AgentProviderApiType::OpenAiResp,
+            "deepseek-r1"
+        ));
+        // 非 thinking 的 DeepSeek 模型(deepseek-chat / deepseek-coder)走 OpenAI
+        // 兼容路径时不进 thinking-mode 校验,无需 echo
+        assert!(!model_requires_reasoning_echo(t, "deepseek-chat"));
+        assert!(!model_requires_reasoning_echo(t, "deepseek-coder"));
     }
 
     #[test]


### PR DESCRIPTION
## 现象

  将 DeepSeek 官方端点配置为 BYOP provider(OpenAI api_type)使用 `deepseek-v4-flash` 等 thinking-mode 模型时,多轮对话第二轮起报 400:

  Request failed with error: Other(BYOP stream error: Web stream error for model 'deepseek-v4-flash (adapter: OpenAI)').
  Status: 400 Bad Request
  Body: {"error":{"message":"The reasoning_content in the thinking mode must be passed back to the API.","type":"invalid_request_error"}}

  ## 根因

  `reasoning::model_requires_reasoning_echo` 在 `OpenAi` / `OpenAiResp` 分支只识别 `kimi` / `moonshot`,没有覆盖 DeepSeek thinking 模型。

  DeepSeek 官方端点本身是 OpenAI-compatible 的,用户把它配成 OpenAI api_type 的 BYOP provider 是常规做法 —— 这条路径下 `force_echo_reasoning =
  false`,序列化层(`adapter_shared.rs`)不会自动补 `reasoning_content` 占位,而 DeepSeek 服务端 thinking-mode 校验要求**每条 assistant 消息都必须带
  `reasoning_content` 字段**(空串也接受,只校验存在性),于是第二轮请求直接被拒。

  `DeepSeek` api_type 分支(全 echo)和 Kimi(OpenAI 兼容路径下 echo)早已正确处理,这次只是把 DeepSeek 经 OpenAI 兼容路径的场景补齐。

  ## 改动

  `app/src/ai/agent_providers/reasoning.rs`:

  - 抽 `is_deepseek_thinking_model(id)` helper(`deepseek-reasoner` / `deepseek-r1` / `deepseek-v4*` / `deepseek-thinking`),与 `model_reasoning_variants` 的
  DeepSeek 分支共用同一份模式,避免后续漂移。
  - `model_requires_reasoning_echo` 的 `OpenAi` / `OpenAiResp` 分支在 kimi/moonshot 之外追加 `is_deepseek_thinking_model(&id)` 判定。
  - 同步更新该函数的命中规则文档注释。
  - 新增测试 `requires_reasoning_echo_deepseek_via_openai`,覆盖 `deepseek-v4-flash` / `deepseek-v4` / `deepseek-reasoner` / `deepseek-r1` /
  `deepseek-thinking`、大小写不敏感、`OpenAiResp` 同路径,以及 `deepseek-chat` / `deepseek-coder` 这类非 thinking 模型不应 echo 的负样本。

  非 thinking 的 `deepseek-chat` / `deepseek-coder` 走 OpenAI 兼容路径时不进 thinking-mode 校验,因此**不**强制挂占位 —— 行为最小化,只修触发 400 的那批模型。

  ## 测试

  cargo test -p warp --lib ai::agent_providers::reasoning::

  27 passed,新测试 `requires_reasoning_echo_deepseek_via_openai` 通过。

  ## 影响范围

  - 仅影响 `model_requires_reasoning_echo` 在 `OpenAi` / `OpenAiResp` + DeepSeek thinking 模型组合下的返回值(false → true)。
  - 既有 `DeepSeek` api_type 用户、Kimi/Moonshot 用户、其他 OpenAI 模型用户行为不变。
  - 占位 `reasoning_content` 由 client 层挂在历史 assistant 消息上,首轮请求不受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reasoning support for DeepSeek thinking-mode models with improved detection across multiple model variants
  * Better reasoning content handling for DeepSeek models using OpenAI-compatible API endpoints

* **Tests**
  * Extended test coverage for DeepSeek thinking-model reasoning requirements including case-insensitive model matching

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->