### PR TITLE
fix(mac): 修复 OpenWarp 启动反复请求 App 数据权限

### DIFF
--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -477,8 +477,12 @@ pub(super) fn init_db() -> Result<SqliteConnection> {
     #[cfg(target_os = "macos")]
     if warp_core::channel::ChannelState::channel() == warp_core::channel::Channel::Oss {
         if let Some(legacy_dir) = openwarp_legacy_app_group_sqlite_dir() {
-            migrate_openwarp_app_group_sqlite_if_needed(&db_path, &legacy_dir)
-                .context("Failed to migrate OpenWarp SQLite database out of legacy App Group")?;
+            if let Err(err) = migrate_openwarp_app_group_sqlite_if_needed(&db_path, &legacy_dir)
+                .context("Failed to migrate OpenWarp SQLite database out of legacy App Group")
+            {
+                report_error!(err);
+                log::warn!("Skipping legacy App Group SQLite migration and continuing startup");
+            }
         }
     }
 
@@ -584,24 +588,36 @@ fn should_copy_legacy_openwarp_sqlite(legacy_db: &Path, target_db: &Path) -> Res
         return Ok(true);
     }
 
-    let legacy_modified = std::fs::metadata(legacy_db)
-        .and_then(|metadata| metadata.modified())
-        .with_context(|| {
-            format!(
-                "Failed to read modified time for legacy SQLite database `{}`",
-                legacy_db.display()
-            )
-        })?;
-    let target_modified = std::fs::metadata(target_db)
-        .and_then(|metadata| metadata.modified())
-        .with_context(|| {
-            format!(
-                "Failed to read modified time for target SQLite database `{}`",
-                target_db.display()
-            )
-        })?;
+    let legacy_modified = latest_sqlite_modified_time(legacy_db)?;
+    let target_modified = latest_sqlite_modified_time(target_db)?;
 
     Ok(legacy_modified > target_modified)
+}
+
+#[cfg(target_os = "macos")]
+fn latest_sqlite_modified_time(db: &Path) -> Result<std::time::SystemTime> {
+    let mut latest = std::fs::metadata(db)
+        .and_then(|metadata| metadata.modified())
+        .with_context(|| format!("Failed to read modified time for `{}`", db.display()))?;
+
+    for extension in ["sqlite-wal", "sqlite-shm"] {
+        let sidecar = db.with_extension(extension);
+        if !sidecar.exists() {
+            continue;
+        }
+
+        let modified = std::fs::metadata(&sidecar)
+            .and_then(|metadata| metadata.modified())
+            .with_context(|| {
+                format!(
+                    "Failed to read modified time for SQLite sidecar `{}`",
+                    sidecar.display()
+                )
+            })?;
+        latest = latest.max(modified);
+    }
+
+    Ok(latest)
 }
 
 #[cfg(target_os = "macos")]

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -139,6 +139,9 @@ const COMMANDS_COUNT_LIMIT: i64 = 10000;
 use warp_server_client::persistence::{upsert_cloud_object, CloudObjectId};
 
 const WARP_SQLITE_FILE_NAME: &str = "warp.sqlite";
+const OPENWARP_APP_GROUP_SQLITE_MIGRATION_MARKER: &str = ".openwarp-app-group-sqlite-migrated";
+#[cfg(target_os = "macos")]
+const WARP_APP_GROUP_ID: &str = "2BBY89MBSN.dev.warp";
 
 /// When delete a cloud object, this callback is used to delete the cloud
 /// object. It takes the id of the cloud object to delete as a parameter.
@@ -471,6 +474,14 @@ pub(super) fn init_db() -> Result<SqliteConnection> {
         );
     }
 
+    #[cfg(target_os = "macos")]
+    if warp_core::channel::ChannelState::channel() == warp_core::channel::Channel::Oss {
+        if let Some(legacy_dir) = openwarp_legacy_app_group_sqlite_dir() {
+            migrate_openwarp_app_group_sqlite_if_needed(&db_path, &legacy_dir)
+                .context("Failed to migrate OpenWarp SQLite database out of legacy App Group")?;
+        }
+    }
+
     // Migrate old SQLite files into the secure application container.
     let old_db_path = warp_core::paths::state_dir().join(WARP_SQLITE_FILE_NAME);
     if old_db_path != db_path && old_db_path.exists() && !db_path.exists() {
@@ -513,6 +524,111 @@ pub(super) fn init_db() -> Result<SqliteConnection> {
     }
 
     setup_database(&database_file_path())
+}
+
+#[cfg(target_os = "macos")]
+fn openwarp_legacy_app_group_sqlite_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home_dir| {
+        home_dir
+            .join("Library/Group Containers")
+            .join(WARP_APP_GROUP_ID)
+            .join("Library/Application Support")
+            .join(warp_core::channel::ChannelState::app_id().to_string())
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn migrate_openwarp_app_group_sqlite_if_needed(target_db: &Path, legacy_dir: &Path) -> Result<()> {
+    let Some(target_dir) = target_db.parent() else {
+        return Ok(());
+    };
+
+    let marker = target_dir.join(OPENWARP_APP_GROUP_SQLITE_MIGRATION_MARKER);
+    if marker.exists() {
+        return Ok(());
+    }
+
+    let legacy_db = legacy_dir.join(WARP_SQLITE_FILE_NAME);
+    if !legacy_db.exists() {
+        write_openwarp_app_group_sqlite_migration_marker(&marker)?;
+        return Ok(());
+    }
+
+    if !should_copy_legacy_openwarp_sqlite(&legacy_db, target_db)? {
+        write_openwarp_app_group_sqlite_migration_marker(&marker)?;
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(target_dir).with_context(|| {
+        format!(
+            "Failed to create SQLite state directory `{}`",
+            target_dir.display()
+        )
+    })?;
+    copy_sqlite_file(&legacy_db, target_db)?;
+    copy_sqlite_sidecar(&legacy_db, target_db, "sqlite-wal")?;
+    copy_sqlite_sidecar(&legacy_db, target_db, "sqlite-shm")?;
+    write_openwarp_app_group_sqlite_migration_marker(&marker)?;
+
+    safe_info!(
+        safe: ("Migrated OpenWarp SQLite database out of legacy App Group"),
+        full: ("Migrated OpenWarp SQLite database from `{}` to `{}`", legacy_db.display(), target_db.display())
+    );
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn should_copy_legacy_openwarp_sqlite(legacy_db: &Path, target_db: &Path) -> Result<bool> {
+    if !target_db.exists() {
+        return Ok(true);
+    }
+
+    let legacy_modified = std::fs::metadata(legacy_db)
+        .and_then(|metadata| metadata.modified())
+        .with_context(|| {
+            format!(
+                "Failed to read modified time for legacy SQLite database `{}`",
+                legacy_db.display()
+            )
+        })?;
+    let target_modified = std::fs::metadata(target_db)
+        .and_then(|metadata| metadata.modified())
+        .with_context(|| {
+            format!(
+                "Failed to read modified time for target SQLite database `{}`",
+                target_db.display()
+            )
+        })?;
+
+    Ok(legacy_modified > target_modified)
+}
+
+#[cfg(target_os = "macos")]
+fn copy_sqlite_sidecar(legacy_db: &Path, target_db: &Path, extension: &str) -> Result<()> {
+    let legacy_path = legacy_db.with_extension(extension);
+    if !legacy_path.exists() {
+        return Ok(());
+    }
+
+    copy_sqlite_file(&legacy_path, &target_db.with_extension(extension))
+}
+
+#[cfg(target_os = "macos")]
+fn copy_sqlite_file(source: &Path, target: &Path) -> Result<()> {
+    std::fs::copy(source, target).map(|_| ()).with_context(|| {
+        format!(
+            "Failed to copy `{}` to `{}`",
+            source.display(),
+            target.display()
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn write_openwarp_app_group_sqlite_migration_marker(marker: &Path) -> Result<()> {
+    std::fs::write(marker, b"migrated\n")
+        .with_context(|| format!("Failed to write migration marker `{}`", marker.display()))
 }
 
 /// Creates or connects to the database at `database_path` and runs any migrations.

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -392,7 +392,7 @@ fn test_migrate_openwarp_app_group_sqlite_copies_newer_legacy_files() {
     fs::create_dir_all(&state_dir).expect("state dir should be created");
 
     fs::write(&target_db, "old-target").expect("target db should be written");
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::thread::sleep(std::time::Duration::from_secs(1));
 
     let legacy_db = legacy_dir.join("warp.sqlite");
     fs::write(&legacy_db, "legacy-db").expect("legacy db should be written");
@@ -416,6 +416,36 @@ fn test_migrate_openwarp_app_group_sqlite_copies_newer_legacy_files() {
     assert!(state_dir
         .join(".openwarp-app-group-sqlite-migrated")
         .exists());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_migrate_openwarp_app_group_sqlite_copies_when_legacy_wal_is_newer() {
+    use super::migrate_openwarp_app_group_sqlite_if_needed;
+
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let legacy_dir = tempdir.path().join("legacy");
+    let state_dir = tempdir.path().join("state");
+    let legacy_db = legacy_dir.join("warp.sqlite");
+    let target_db = state_dir.join("warp.sqlite");
+    fs::create_dir_all(&legacy_dir).expect("legacy dir should be created");
+    fs::create_dir_all(&state_dir).expect("state dir should be created");
+
+    fs::write(&legacy_db, "legacy-db").expect("legacy db should be written");
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    fs::write(&target_db, "target-db").expect("target db should be written");
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    fs::write(legacy_db.with_extension("sqlite-wal"), "legacy-wal")
+        .expect("legacy wal should be written");
+
+    migrate_openwarp_app_group_sqlite_if_needed(&target_db, &legacy_dir)
+        .expect("migration should succeed");
+
+    assert_eq!(fs::read_to_string(&target_db).unwrap(), "legacy-db");
+    assert_eq!(
+        fs::read_to_string(target_db.with_extension("sqlite-wal")).unwrap(),
+        "legacy-wal"
+    );
 }
 
 #[cfg(target_os = "macos")]

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc};
 
 use warp_core::features::FeatureFlag;
 use warp_graphql::scalars::time::ServerTimestamp;
@@ -377,6 +377,71 @@ fn test_path_encode_decode() {
     assert_encode_then_decode_preserves_original_path(PathBuf::from("/temp/ñoñàscii/temp.txt"));
     assert_encode_then_decode_preserves_original_path(PathBuf::from("/temp/hindi/हिन्दी"));
     assert_encode_then_decode_preserves_original_path(PathBuf::from("/temp/cjk/狗没有耐心"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_migrate_openwarp_app_group_sqlite_copies_newer_legacy_files() {
+    use super::migrate_openwarp_app_group_sqlite_if_needed;
+
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let legacy_dir = tempdir.path().join("legacy");
+    let state_dir = tempdir.path().join("state");
+    let target_db = state_dir.join("warp.sqlite");
+    fs::create_dir_all(&legacy_dir).expect("legacy dir should be created");
+    fs::create_dir_all(&state_dir).expect("state dir should be created");
+
+    fs::write(&target_db, "old-target").expect("target db should be written");
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    let legacy_db = legacy_dir.join("warp.sqlite");
+    fs::write(&legacy_db, "legacy-db").expect("legacy db should be written");
+    fs::write(legacy_db.with_extension("sqlite-wal"), "legacy-wal")
+        .expect("legacy wal should be written");
+    fs::write(legacy_db.with_extension("sqlite-shm"), "legacy-shm")
+        .expect("legacy shm should be written");
+
+    migrate_openwarp_app_group_sqlite_if_needed(&target_db, &legacy_dir)
+        .expect("migration should succeed");
+
+    assert_eq!(fs::read_to_string(&target_db).unwrap(), "legacy-db");
+    assert_eq!(
+        fs::read_to_string(target_db.with_extension("sqlite-wal")).unwrap(),
+        "legacy-wal"
+    );
+    assert_eq!(
+        fs::read_to_string(target_db.with_extension("sqlite-shm")).unwrap(),
+        "legacy-shm"
+    );
+    assert!(state_dir
+        .join(".openwarp-app-group-sqlite-migrated")
+        .exists());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_migrate_openwarp_app_group_sqlite_marker_skips_copy() {
+    use super::migrate_openwarp_app_group_sqlite_if_needed;
+
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let legacy_dir = tempdir.path().join("legacy");
+    let state_dir = tempdir.path().join("state");
+    let target_db = state_dir.join("warp.sqlite");
+    fs::create_dir_all(&legacy_dir).expect("legacy dir should be created");
+    fs::create_dir_all(&state_dir).expect("state dir should be created");
+
+    fs::write(legacy_dir.join("warp.sqlite"), "legacy-db").expect("legacy db should be written");
+    fs::write(&target_db, "target-db").expect("target db should be written");
+    fs::write(
+        state_dir.join(".openwarp-app-group-sqlite-migrated"),
+        "migrated\n",
+    )
+    .expect("marker should be written");
+
+    migrate_openwarp_app_group_sqlite_if_needed(&target_db, &legacy_dir)
+        .expect("migration should succeed");
+
+    assert_eq!(fs::read_to_string(&target_db).unwrap(), "target-db");
 }
 
 #[test]

--- a/crates/warp_core/src/paths.rs
+++ b/crates/warp_core/src/paths.rs
@@ -160,7 +160,7 @@ pub fn state_dir() -> PathBuf {
 /// On macOS, this will use the App Group container directory if available.
 pub fn secure_state_dir() -> Option<PathBuf> {
     // Do not use the secure state directory in integration tests, which have a temporary home directory instead.
-    if ChannelState::channel() == Channel::Integration {
+    if matches!(ChannelState::channel(), Channel::Integration | Channel::Oss) {
         return None;
     }
 

--- a/crates/warp_core/src/paths_tests.rs
+++ b/crates/warp_core/src/paths_tests.rs
@@ -97,6 +97,13 @@ fn test_state_dir_path() {
 }
 
 #[test]
+fn test_oss_secure_state_dir_is_disabled() {
+    // ChannelState 默认是 Channel::Oss。OpenWarp 不应该探测 Warp 官方 App Group,
+    // 否则 macOS 会把它识别成访问其他 App 数据并在每次启动时弹权限窗。
+    assert_eq!(secure_state_dir(), None);
+}
+
+#[test]
 fn test_project_path_for_warp_app_id() {
     let project_dirs = project_dirs_for_app_id(AppId::new("dev", "warp", "Warp"), None)
         .expect("should be able to compute project dirs");


### PR DESCRIPTION
## Description

### What
- Disable `secure_state_dir()` for the OSS/OpenWarp channel so startup no longer probes the official Warp App Group container.
- Add a macOS-only one-time SQLite migration from the legacy `2BBY89MBSN.dev.warp` App Group path into OpenWarp's own state directory.
- Copy `warp.sqlite`, `warp.sqlite-wal`, and `warp.sqlite-shm` only when the legacy DB is newer, and write a marker to avoid repeated probes.

### Why
OpenWarp currently resolves `secure_state_dir()` through the official Warp App Group. macOS treats that as OpenWarp accessing another app's data and shows the privacy prompt on every launch. Simply disabling the App Group would make existing users fall back to a different SQLite database path, so the fix also preserves newer local state from the old location.

### How
OSS builds now fall back to `state_dir()` for secure state. During SQLite initialization, OpenWarp checks the legacy App Group DB path once, migrates newer SQLite files when present, and then records `.openwarp-app-group-sqlite-migrated` in the target state directory.

## Testing
- `cargo fmt --check`
- `cargo test -p warp_core --features local_fs test_oss_secure_state_dir_is_disabled`
- `cargo test -p warp --features local_fs openwarp_app_group_sqlite`
- `cargo check -p warp --lib`

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-time migration of legacy macOS App Group SQLite data into the current secure storage (including sidecar files) for the OSS channel.
  * Disabled secure state directory handling for Integration and OSS channels to match platform expectations.

* **Tests**
  * Added macOS tests verifying legacy migration behavior, sidecar preservation, and the migration marker.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->