### PR TITLE
fix(ai): 修复 Agent 选中复制不生效

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -94,7 +94,7 @@ use crate::cloud_object::model::persistence::ObjectStoreModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
 use crate::server::ids::SyncId;
 use crate::server::telemetry::AgentModeRewindEntrypoint;
-use crate::settings::InputSettings;
+use crate::settings::{InputSettings, SelectionSettings};
 use crate::terminal::view::{CodeDiffAction, TerminalAction};
 use crate::ui_components::icons::Icon;
 #[cfg(feature = "local_fs")]
@@ -1191,11 +1191,12 @@ impl AIBlock {
         for (id, content) in comment_data {
             let state = CommentElementState::new(id, &content, ctx);
             ctx.subscribe_to_view(&state.rich_text_editor, |me, view, event, ctx| {
-                if matches!(event, EditorViewEvent::TextSelectionChanged)
-                    && view.as_ref(ctx).selected_text(ctx).is_some()
-                {
-                    me.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
-                    ctx.emit(AIBlockEvent::ChildViewTextSelected);
+                if matches!(event, EditorViewEvent::TextSelectionChanged) {
+                    if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                        me.maybe_copy_on_select(selected_text, ctx);
+                        me.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
+                        ctx.emit(AIBlockEvent::ChildViewTextSelected);
+                    }
                 }
             });
             comment_states.insert(id, state);
@@ -2534,7 +2535,8 @@ impl AIBlock {
                         // The `is_some` check is necessary because `CodeEditorEvent::SelectionChanged` is
                         // also emitted when the editor's selection is cleared via external means
                         // (i.e. when a text selection is made outside the `CodeEditorView`).
-                        if view.as_ref(ctx).selected_text(ctx).is_some() {
+                        if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                            me.maybe_copy_on_select(selected_text, ctx);
                             me.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
                             ctx.emit(AIBlockEvent::ChildViewTextSelected);
                         }
@@ -2701,6 +2703,9 @@ impl AIBlock {
                 CodeDiffViewEvent::TextSelected => {
                     // If there's an ongoing text selection, clear all other selections within the
                     // `AIBlock`'s view sub-hierarchy to ensure only one component has a selection at a time.
+                    if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                        me.maybe_copy_on_select(selected_text, ctx);
+                    }
                     me.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
                     ctx.emit(AIBlockEvent::ChildViewTextSelected);
                 }
@@ -2993,6 +2998,9 @@ impl AIBlock {
             RequestedCommandViewEvent::TextSelected => {
                 // If there's an ongoing text selection, clear all other selections within the
                 // `AIBlock`'s view sub-hierarchy to ensure only one component has a selection at a time.
+                if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                    self.maybe_copy_on_select(selected_text, ctx);
+                }
                 self.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
                 ctx.emit(AIBlockEvent::ChildViewTextSelected);
             }
@@ -3096,6 +3104,9 @@ impl AIBlock {
             RequestedCommandViewEvent::TextSelected => {
                 // If there's an ongoing text selection, clear all other selections within the
                 // `AIBlock`'s view sub-hierarchy to ensure only one component has a selection at a time.
+                if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                    self.maybe_copy_on_select(selected_text, ctx);
+                }
                 self.clear_other_selections(Some(view.id()), ctx.window_id(), ctx);
                 ctx.emit(AIBlockEvent::ChildViewTextSelected);
             }
@@ -4117,6 +4128,12 @@ impl AIBlock {
                     .find_map(|comment| comment.rich_text_editor.as_ref(ctx).selected_text(ctx))
             })
             .or_else(|| self.selected_text.read().clone())
+    }
+
+    fn maybe_copy_on_select(&self, selection: String, ctx: &mut ViewContext<Self>) {
+        SelectionSettings::handle(ctx).update(ctx, |selection_settings, ctx| {
+            selection_settings.maybe_copy_on_select(ClipboardContent::plain_text(selection), ctx);
+        });
     }
 
     /// Start a selection at the top left corner of the block's SelectableArea.
@@ -5212,6 +5229,8 @@ pub enum AIBlockAction {
     /// are responsible for managing their own text selection states.
     SelectText,
 
+    CopyOnSelect(String),
+
     CopyAIBlockCodeSnippet(String),
 
     /// Continue the conversation using this response
@@ -5413,6 +5432,9 @@ impl TypedActionView for AIBlock {
                 // If we have a selection, we should use the default cursor, even if it's over a link.
                 ctx.reset_cursor();
                 self.dismiss_ai_tooltips(ctx);
+            }
+            AIBlockAction::CopyOnSelect(selection) => {
+                self.maybe_copy_on_select(selection.clone(), ctx);
             }
             AIBlockAction::CopyAIBlockCodeSnippet(text) => {
                 ctx.clipboard()

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -56,7 +56,7 @@ use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions};
 use crate::menu::MenuItemFields;
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::TelemetryEvent;
-use crate::settings::AISettings;
+use crate::settings::{AISettings, SelectionSettings};
 use crate::terminal::input::SET_INPUT_MODE_TERMINAL_ACTION_NAME;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::{ShellLaunchData, TerminalModel};
@@ -815,7 +815,8 @@ impl CLISubagentView {
                 });
                 ctx.subscribe_to_view(&view, |me, view, event, ctx| match event {
                     CodeEditorEvent::SelectionChanged => {
-                        if view.as_ref(ctx).selected_text(ctx).is_some() {
+                        if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                            me.maybe_copy_on_select(selected_text, ctx);
                             me.clear_other_selections(Some(view.id()), ctx);
                             ctx.emit(CLISubagentViewEvent::TextSelected);
                         }
@@ -963,6 +964,12 @@ impl CLISubagentView {
             .or_else(|| self.selected_text.read().clone())
             .filter(|selection| !selection.is_empty())
     }
+
+    fn maybe_copy_on_select(&self, selection: String, ctx: &mut ViewContext<Self>) {
+        SelectionSettings::handle(ctx).update(ctx, |selection_settings, ctx| {
+            selection_settings.maybe_copy_on_select(ClipboardContent::plain_text(selection), ctx);
+        });
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1034,6 +1041,9 @@ impl View for CLISubagentView {
                         {
                             output_selection_handle.clear();
                             action_selection_handle.clear();
+                            ctx.dispatch_typed_action(CLISubagentAction::CopyOnSelect(
+                                selection.clone(),
+                            ));
                             *selected_text.write() = Some(selection);
                             ctx.dispatch_typed_action(CLISubagentAction::SelectText);
                         }
@@ -1275,6 +1285,9 @@ impl View for CLISubagentView {
                     {
                         query_selection_handle.clear();
                         action_selection_handle.clear();
+                        ctx.dispatch_typed_action(CLISubagentAction::CopyOnSelect(
+                            selection.clone(),
+                        ));
                         *selected_text.write() = Some(selection);
                         ctx.dispatch_typed_action(CLISubagentAction::SelectText);
                     }
@@ -1393,6 +1406,9 @@ impl View for CLISubagentView {
                     {
                         query_selection_handle.clear();
                         output_selection_handle.clear();
+                        ctx.dispatch_typed_action(CLISubagentAction::CopyOnSelect(
+                            selection.clone(),
+                        ));
                         *selected_text.write() = Some(selection);
                         ctx.dispatch_typed_action(CLISubagentAction::SelectText);
                     }
@@ -1446,6 +1462,7 @@ pub enum CLISubagentAction {
     ToggleAlwaysAllowReadFiles,
     DismissInput,
     SelectText,
+    CopyOnSelect(String),
     CopyDebugId(String),
     OpenFeedbackDocs,
 }
@@ -1533,6 +1550,9 @@ impl TypedActionView for CLISubagentView {
                 ctx.reset_cursor();
                 ctx.focus_self();
                 ctx.emit(CLISubagentViewEvent::TextSelected);
+            }
+            CLISubagentAction::CopyOnSelect(selection) => {
+                self.maybe_copy_on_select(selection.clone(), ctx);
             }
             CLISubagentAction::CopyDebugId(debug_id) => {
                 ctx.clipboard()

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1192,8 +1192,14 @@ impl View for AIBlock {
 
         let mut selectable = SelectableArea::new(
             self.state_handles.selection_handle.clone(),
-            move |selection_args, _, _| {
-                *selected_text.write() = selection_args.selection;
+            move |selection_args, ctx, _| {
+                let selection = selection_args.selection;
+                if let Some(selection) =
+                    selection.as_ref().filter(|selection| !selection.is_empty())
+                {
+                    ctx.dispatch_typed_action(AIBlockAction::CopyOnSelect(selection.clone()));
+                }
+                *selected_text.write() = selection;
             },
             SavePosition::new(content.finish(), self.saved_position_id().as_str()).finish(),
         )

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::Icon;
 use warp_editor::render::element::VerticalExpansionBehavior;
+use warpui::clipboard::ClipboardContent;
 use warpui::elements::{ConstrainedBox, ScrollbarWidth};
 use warpui::ui_components::components::UiComponent as _;
 use warpui::{
@@ -68,7 +69,11 @@ use crate::view_components::compactible_action_button::{
     MEDIUM_SIZE_SWITCH_THRESHOLD, SMALL_SIZE_SWITCH_THRESHOLD,
 };
 use crate::view_components::compactible_split_action_button::CompactibleSplitActionButton;
-use crate::{cmd_or_ctrl_shift, settings::InputModeSettings, ui_components::blended_colors};
+use crate::{
+    cmd_or_ctrl_shift,
+    settings::{InputModeSettings, SelectionSettings},
+    ui_components::blended_colors,
+};
 
 use super::inline_action_icons::{self, icon_size};
 
@@ -204,6 +209,7 @@ pub enum RequestedCommandViewAction {
     ToggleExpanded,
     OpenActiveAgentProfileEditor,
     SelectText,
+    CopyOnSelect(String),
 }
 
 pub struct RequestedCommandView {
@@ -556,7 +562,12 @@ impl RequestedCommandView {
                 // The `is_some` check is necessary because `CodeEditorEvent::SelectionChanged` is
                 // also emitted when the editor's selection is cleared via external means
                 // (i.e. when a text selection is made outside the `CodeEditorView`).
-                if view.as_ref(ctx).selected_text(ctx).is_some() {
+                if let Some(selected_text) = view.as_ref(ctx).selected_text(ctx) {
+                    self.mcp_content_selection_handle.clear();
+                    if let Ok(mut mcp_selection) = self.mcp_content_selected_text.write() {
+                        *mcp_selection = None;
+                    }
+                    self.maybe_copy_on_select(selected_text, ctx);
                     ctx.emit(RequestedCommandViewEvent::TextSelected);
                 }
             }
@@ -966,15 +977,22 @@ impl RequestedCommandView {
     }
 
     pub fn clear_selection(&mut self, ctx: &mut ViewContext<Self>) {
-        // Clear MCP content selection if it exists, else fall back to editor selection.
+        // Clear both local selection states; either one can be stale after switching selection targets.
         self.mcp_content_selection_handle.clear();
         if let Ok(mut mcp_selection) = self.mcp_content_selected_text.write() {
             *mcp_selection = None;
-        } else if let Some(editor) = &self.editor {
+        }
+        if let Some(editor) = &self.editor {
             editor.update(ctx, |editor, ctx| {
                 editor.clear_selection(ctx);
             });
         }
+    }
+
+    fn maybe_copy_on_select(&self, selection: String, ctx: &mut ViewContext<Self>) {
+        SelectionSettings::handle(ctx).update(ctx, |selection_settings, ctx| {
+            selection_settings.maybe_copy_on_select(ClipboardContent::plain_text(selection), ctx);
+        });
     }
 
     /// Extracts the tool name from MCP tool command text, removing parameters.
@@ -1447,8 +1465,16 @@ impl View for RequestedCommandView {
             let selectable_text = SelectableArea::new(
                 self.mcp_content_selection_handle.clone(),
                 #[allow(clippy::unwrap_used)]
-                move |selection_args, _, _| {
-                    *mcp_selected_text.write().unwrap() = selection_args.selection;
+                move |selection_args, ctx, _| {
+                    let selection = selection_args.selection;
+                    if let Some(selection) =
+                        selection.as_ref().filter(|selection| !selection.is_empty())
+                    {
+                        ctx.dispatch_typed_action(RequestedCommandViewAction::CopyOnSelect(
+                            selection.clone(),
+                        ));
+                    }
+                    *mcp_selected_text.write().unwrap() = selection;
                 },
                 text_element,
             )
@@ -1596,6 +1622,9 @@ impl TypedActionView for RequestedCommandView {
             }
             RequestedCommandViewAction::SelectText => {
                 ctx.emit(RequestedCommandViewEvent::TextSelected);
+            }
+            RequestedCommandViewAction::CopyOnSelect(selection) => {
+                self.maybe_copy_on_select(selection.clone(), ctx);
             }
         }
     }

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -385,6 +385,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_selection_ai_to_last_semantic);
     register_test!(test_selection_ai_to_last_lines);
     register_test!(test_selection_last_to_ai_simple);
+    register_test!(test_copy_on_select_within_ai_simple);
     register_test!(test_selection_last_to_ai_semantic);
     register_test!(test_selection_last_to_ai_lines);
     register_test!(test_restored_ai_block_renders_mermaid_and_local_images);

--- a/crates/integration/src/test/agent_mode.rs
+++ b/crates/integration/src/test/agent_mode.rs
@@ -34,6 +34,8 @@ cfg_if::cfg_if! {
             static ref END_OF_LAST_BLOCK_POSITION: Vector2F = vec2f(209.0, 668.0);
             /// Position in the middle of the word "mo|de" of the AI block output.
             static ref MIDDLE_OF_MODE_POSITION: Vector2F = vec2f(224.0, 557.0);
+            /// Position to the right of "dummy output" on the same AI block output line.
+            static ref END_OF_AI_OUTPUT_LINE_POSITION: Vector2F = vec2f(565.0, 557.0);
         }
     } else {
         lazy_static! {
@@ -43,6 +45,8 @@ cfg_if::cfg_if! {
             static ref END_OF_LAST_BLOCK_POSITION: Vector2F = vec2f(214.0, 645.0);
             /// Position in the middle of the word "mo|de" of the AI block output.
             static ref MIDDLE_OF_MODE_POSITION: Vector2F = vec2f(222.0, 530.0);
+            /// Position to the right of "dummy output" on the same AI block output line.
+            static ref END_OF_AI_OUTPUT_LINE_POSITION: Vector2F = vec2f(560.0, 530.0);
         }
     }
 }
@@ -744,6 +748,65 @@ echo \"hello Im the third block\"
 hello Im the third block".into()
                 )
             ),
+        )
+}
+
+pub fn test_copy_on_select_within_ai_simple() -> Builder {
+    builder_with_setup()
+        .with_step(
+            new_step_with_default_assertions("Enable copy on select").add_assertion(|app, _| {
+                SelectionSettings::handle(app).update(app, |settings, ctx| {
+                    settings
+                        .copy_on_select
+                        .set_value(true, ctx)
+                        .expect("can enable copy_on_select");
+                    async_assert!(settings.copy_on_select_enabled())
+                })
+            }),
+        )
+        .with_step(
+            // Drag within the AI block output, from "mo|de" to the right on the same line.
+            new_step_with_default_assertions("start selecting")
+                .with_event(Event::LeftMouseDown {
+                    position: *MIDDLE_OF_MODE_POSITION,
+                    modifiers: Default::default(),
+                    click_count: 1,
+                    is_first_mouse: false,
+                })
+                .with_event(Event::LeftMouseDragged {
+                    position: *END_OF_AI_OUTPUT_LINE_POSITION,
+                    modifiers: Default::default(),
+                })
+                .add_assertion(assert_view_has_text_selection(true)),
+        )
+        .with_step(
+            new_step_with_default_assertions("end selecting")
+                .with_event(Event::LeftMouseUp {
+                    position: *END_OF_AI_OUTPUT_LINE_POSITION,
+                    modifiers: Default::default(),
+                })
+                .add_assertion(assert_view_has_text_selection(false))
+                .add_assertion(|app, window_id| {
+                    let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                    terminal_view.read(app, |terminal_view, ctx| {
+                        let ai_block = terminal_view.last_ai_block().expect("AI block exists");
+                        ai_block.read(ctx, |ai_block, _| {
+                            let is_simple_selection =
+                                matches!(ai_block.selection_type(), SelectionType::Simple);
+                            let is_selected_text_correct =
+                                ai_block.selected_text(ctx).is_some_and(|selected_text| {
+                                    selected_text == "de and this is my dummy output"
+                                });
+                            async_assert!(
+                                is_simple_selection && is_selected_text_correct,
+                                "AI block has expected selection"
+                            )
+                        })
+                    })
+                })
+                .add_assertion(assert_clipboard_contains_string(
+                    "de and this is my dummy output".into(),
+                )),
         )
 }
 

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -294,6 +294,8 @@ integration_tests! {
     #[ignore = "Affected by agent_view feature flag UI changes"]
     test_selection_last_to_ai_simple,
     #[ignore = "Affected by agent_view feature flag UI changes"]
+    test_copy_on_select_within_ai_simple,
+    #[ignore = "Affected by agent_view feature flag UI changes"]
     test_selection_last_to_ai_semantic,
     #[ignore = "Affected by agent_view feature flag UI changes"]
     test_selection_last_to_ai_lines,


### PR DESCRIPTION
## Description
Fixes copy-on-select inside Agent conversations when the copy-on-select setting is enabled.

Root cause: terminal grid selections call `SelectionSettings::maybe_copy_on_select`, but Agent rich content and nested selectable views keep their own `selected_text` state and did not route finalized selections through that setting.

This change:
- wires Agent block rich content selections to copy-on-select
- covers nested Agent selection sources, including code editors, code diffs, requested command views, MCP content, comments, and CLI subagent sections
- clears stale requested-command MCP selection state when switching back to editor selection
- adds an integration regression test for selecting within AI output and asserting clipboard contents

## Testing
- `git diff --check`
- `rustfmt --check app/src/ai/blocklist/block.rs app/src/ai/blocklist/block/view_impl.rs app/src/ai/blocklist/block/cli.rs app/src/ai/blocklist/inline_action/requested_command.rs crates/integration/src/bin/integration.rs crates/integration/src/test/agent_mode.rs crates/integration/tests/integration/ui_tests.rs`
- `cargo check -p warp`
- `cargo check -p integration` fails on existing unrelated integration-testing compile errors: `server::cloud_object::update_manager::UpdateManager` cannot be resolved in notebook/rules/workflow step helpers, followed by type inference errors in those same helpers.
- Built and opened local `openwarp-dev.app` from the current branch; verified process path under `/Users/staff/project/AI/warp/target/debug/openwarp-dev.app/Contents/MacOS/warp-oss`.

## Server API dependencies
No server API dependencies.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed copy-on-select not copying selected text inside Agent conversations.

Co-Authored-By: Warp <agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic clipboard copying when selecting text in AI block contexts (editors, diffs, commands, tools).

* **Tests**
  * Added integration tests validating copy-on-select functionality across AI blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->