### PR TITLE
Fix macOS Finder launch panic during i18n initialization

### DIFF
--- a/app/src/i18n.rs
+++ b/app/src/i18n.rs
@@ -10,9 +10,11 @@
 //!   - 当前 locale 没有 → fluent 内部 fallback 到 fallback_language (en)
 //!   - 连英文都没有 → 返回 key 本身字符串(并 log::warn,便于 CI 抓未翻译条目)
 
+#[cfg(not(target_os = "macos"))]
+use i18n_embed::DesktopLanguageRequester;
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
-    DesktopLanguageRequester, LanguageLoader,
+    LanguageLoader,
 };
 use rust_embed::RustEmbed;
 use std::sync::OnceLock;
@@ -47,10 +49,10 @@ pub fn init(override_locale: Option<&str>) {
             Ok(li) => vec![li],
             Err(e) => {
                 log::warn!("[i18n] invalid override_locale {s:?}: {e} — falling back to system");
-                DesktopLanguageRequester::requested_languages()
+                system_requested_languages()
             }
         },
-        None => DesktopLanguageRequester::requested_languages(),
+        None => system_requested_languages(),
     };
 
     if let Err(e) = i18n_embed::select(&loader, &Localizations, &requested) {
@@ -77,6 +79,67 @@ fn propagate_ui_locale(loader: &FluentLanguageLoader) {
     let langs = loader.current_languages();
     if let Some(li) = langs.first() {
         warpui::set_ui_locale(li.to_string());
+    }
+}
+
+fn system_requested_languages() -> Vec<LanguageIdentifier> {
+    #[cfg(target_os = "macos")]
+    {
+        macos_requested_languages()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        DesktopLanguageRequester::requested_languages()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_requested_languages() -> Vec<LanguageIdentifier> {
+    use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+    use warpui::platform::mac::utils::nsstring_as_str;
+
+    unsafe {
+        let locale_class = class!(NSLocale);
+        let locale: *const Object = msg_send![locale_class, currentLocale];
+
+        let is_language_code_supported: bool =
+            msg_send![locale, respondsToSelector: sel!(languageCode)];
+        if !is_language_code_supported {
+            return vec!["en".parse().expect("en is a valid language identifier")];
+        }
+
+        let language_code: *const Object = msg_send![locale, languageCode];
+        let language_code_str = nsstring_as_str(language_code)
+            .map(str::to_owned)
+            .unwrap_or_else(|_| "en".to_string());
+        let _: () = msg_send![language_code, release];
+
+        let is_country_code_supported: bool =
+            msg_send![locale, respondsToSelector: sel!(countryCode)];
+        let locale = if is_country_code_supported {
+            let country_code: *const Object = msg_send![locale, countryCode];
+            let country_code_str = nsstring_as_str(country_code)
+                .map(str::to_owned)
+                .unwrap_or_default();
+            let _: () = msg_send![country_code, release];
+
+            if country_code_str.is_empty() {
+                language_code_str
+            } else {
+                format!("{language_code_str}-{country_code_str}")
+            }
+        } else {
+            language_code_str
+        };
+
+        match locale.parse() {
+            Ok(locale) => vec![locale],
+            Err(err) => {
+                log::warn!("[i18n] invalid macOS locale {locale:?}: {err}; falling back to en");
+                vec!["en".parse().expect("en is a valid language identifier")]
+            }
+        }
     }
 }
 
@@ -121,7 +184,7 @@ pub fn reset_to_system_locale() {
     let Some(loader) = LANGUAGE_LOADER.get() else {
         return;
     };
-    let requested = DesktopLanguageRequester::requested_languages();
+    let requested = system_requested_languages();
     if let Err(e) = i18n_embed::select(loader, &Localizations, &requested) {
         log::warn!("[i18n] reset_to_system_locale failed: {e}");
     }


### PR DESCRIPTION
## Problem Description

Opening the bundled macOS app from Finder could cause the app to bounce briefly in the Dock and then exit immediately, while `cargo run` worked normally.

The crash happened during early i18n initialization. On macOS, `DesktopLanguageRequester::requested_languages()` calls into `locale_config::Locale::current()`, which can panic when the system locale identifier is not accepted by `locale_config`.

## Changes

- Added a macOS-specific system language requester for i18n.
- On macOS, read `NSLocale.currentLocale` using `languageCode` and `countryCode`.
- Continue passing the resolved language identifier into the existing `i18n_embed::select` fallback chain.
- Keep non-macOS behavior unchanged by continuing to use `DesktopLanguageRequester::requested_languages()`.

## Tests

- Built release.
- Tested no more panic issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved system language detection on macOS for better internationalization support and more reliable locale handling across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->