### PR TITLE
fix(linux/oss): 让 OSS desktop file ID 与运行时 app id 对齐到 dev.openwarp.OpenWarp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,7 @@ input_classifier/models/**/*tokenizer.json linguist-generated=true
 # 用法:本地需先注册驱动 `git config merge.openwarp-ours.driver true`
 # CI / 新克隆者执行 `script/setup-merge-drivers.sh` 自动配置
 .github/workflows/openwarp_release.yml merge=openwarp-ours
-app/channels/oss/dev.warp.OpenWarp.desktop merge=openwarp-ours
+app/channels/oss/dev.openwarp.OpenWarp.desktop merge=openwarp-ours
 lib/rust-genai/** merge=openwarp-ours
 
 # openWarp 自治区(BYOP / cloud 清理 / i18n / footer 删改 等已永久分叉)

--- a/app/channels/oss/dev.openwarp.OpenWarp.desktop
+++ b/app/channels/oss/dev.openwarp.OpenWarp.desktop
@@ -12,7 +12,7 @@ StartupWMClass=dev.openwarp.OpenWarp
 
 Keywords=shell;prompt;command;commandline;cmd;
 
-Icon=dev.warp.OpenWarp
+Icon=dev.openwarp.OpenWarp
 
 Categories=System;TerminalEmulator;
 

--- a/app/channels/oss/dev.warp.OpenWarp.desktop
+++ b/app/channels/oss/dev.warp.OpenWarp.desktop
@@ -8,7 +8,7 @@ Name=OpenWarp
 GenericName=TerminalEmulator
 
 Exec=warp-terminal-oss %U
-StartupWMClass=dev.warp.OpenWarp
+StartupWMClass=dev.openwarp.OpenWarp
 
 Keywords=shell;prompt;command;commandline;cmd;
 

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -197,7 +197,15 @@ elif [[ "$ARTIFACT" == "app" ]]; then
   FEATURES="$FEATURES,gui,nld_improvements"
 fi
 
-BUNDLE_ID="dev.warp.$APP_NAME"
+if [[ $RELEASE_CHANNEL = "oss" ]]; then
+  # OSS(OpenWarp) bundle id 与运行时 app id (`dev.openwarp.OpenWarp`, 见
+  # `app/src/bin/oss.rs` / Cargo bundle metadata) 对齐, 否则 Linux 桌面
+  # (尤其是 Wayland) 会按 desktop-file ID 而非 StartupWMClass 关联窗口,
+  # 导致 icon 找不到.
+  BUNDLE_ID="dev.openwarp.OpenWarp"
+else
+  BUNDLE_ID="dev.warp.$APP_NAME"
+fi
 EXECUTABLE_PATH="$CARGO_TARGET_OUTPUT_DIR/$WARP_BIN"
 DEBUG_EXECUTABLE_PATH="$EXECUTABLE_PATH.debug"
 


### PR DESCRIPTION
## 背景

承接 #90 (@web1n)。原 PR 仅把 OSS desktop entry 内 `StartupWMClass` 从 `dev.warp.OpenWarp` 改为 `dev.openwarp.OpenWarp`,但 Copilot review 已经指出:Wayland 桌面是通过 **desktop-file ID(即 `.desktop` 文件名)** 而非 `StartupWMClass` 把窗口与图标关联起来,所以只改一个键解决不了 Wayland 上图标缺失的根因。

实际上 OSS channel 的运行时 app id 在 `app/src/bin/oss.rs`、`app/Cargo.toml` bundle metadata、`script/macos/bundle`、`script/windows/bundle.ps1` 处都已统一为 `dev.openwarp.OpenWarp`,只有 Linux 这条链路名字还是历史遗留的 `dev.warp.OpenWarp`,导致名字四处不一致。

## 本 PR 改动(在 #90 基础上)

- cherry-pick #90 的 `StartupWMClass` 改动(保留原作者署名)
- 重命名 `app/channels/oss/dev.warp.OpenWarp.desktop` → `dev.openwarp.OpenWarp.desktop`,确保 `bundle_install` 安装出来的 desktop 文件 ID 等于运行时 app id
- desktop entry 内 `Icon=dev.warp.OpenWarp` → `Icon=dev.openwarp.OpenWarp`,与 hicolor 主题里 icon 文件名(以 `BUNDLE_ID.png` 命名)对齐
- `script/linux/bundle` 对 `oss` channel 单独设 `BUNDLE_ID=dev.openwarp.OpenWarp`,其余 channel 保持 `dev.warp.$APP_NAME` 不变
- `.gitattributes` 中 `openwarp-ours` 合并驱动的路径同步更名

## 影响范围

- 只动 Linux 桌面打包链路 + .gitattributes,**未触碰 Rust 代码**,无需 `cargo check`(无 Rust 改动)
- macOS / Windows / WASM / 其他 channel(dev/preview/stable/local)完全不受影响

Closes #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application identifiers and release channel configuration to align branding across build systems and desktop environments. Configuration changes ensure proper identification for the OSS release channel while maintaining compatibility with other release channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/92)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->