### PR TITLE
fix(ai): 阻止 BYOP 普通流程发送占位 tool result

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -96,6 +96,10 @@ pub struct RequestParams {
     pub ask_user_question_enabled: bool,
     pub research_agent_enabled: bool,
     pub supported_tools_override: Option<Vec<warp_multi_agent_api::ToolType>>,
+    /// OpenWarp BYOP 专用:本地会话 id,只用于 request-readiness 诊断日志。
+    pub byop_conversation_id: Option<AIConversationId>,
+    /// OpenWarp BYOP 专用:单次请求内的非持久诊断关联 id。
+    pub byop_readiness_attempt_id: Option<String>,
     /// The conversation ID of the parent agent that spawned this child agent, if any.
     pub parent_agent_id: Option<String>,
     /// The display name for this agent (e.g. "Agent 1"), assigned by the orchestrator.
@@ -116,6 +120,8 @@ pub struct RequestParams {
     ///
     /// 默认 `None` = 兼容路径(无压缩)。
     pub compaction_state: Option<crate::ai::byop_compaction::state::CompactionState>,
+    /// OpenWarp BYOP repair sidecar 快照。serializer 只读使用,不在请求构造中反序列化持久化 JSON。
+    pub byop_repair_state: crate::ai::byop_readiness::RepairStateStatus,
     /// OpenWarp BYOP 专用:本轮是否需要模拟上游 CreateTask 流程来升级 optimistic CLI subtask。
     /// 只有用户刚 tag-in 的首轮需要;已存在 CLI subagent 的后续轮只复用 task,不能重复 spawn。
     pub lrc_should_spawn_subagent: bool,
@@ -146,6 +152,52 @@ pub struct ConversationData {
 }
 
 impl RequestParams {
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        input: Vec<AIAgentInput>,
+        tasks: Vec<warp_multi_agent_api::Task>,
+    ) -> Self {
+        Self {
+            input,
+            conversation_token: None,
+            forked_from_conversation_token: None,
+            ambient_agent_task_id: None,
+            byop_target_task_id: tasks.first().map(|task| task.id.clone()),
+            tasks,
+            existing_suggestions: None,
+            metadata: None,
+            session_context: SessionContext::new_for_test(),
+            model: LLMId::from("byop:test"),
+            coding_model: LLMId::from("byop:test"),
+            cli_agent_model: LLMId::from("byop:test"),
+            computer_use_model: LLMId::from("byop:test"),
+            is_memory_enabled: false,
+            warp_drive_context_enabled: false,
+            context_window_limit: None,
+            mcp_context: None,
+            planning_enabled: true,
+            should_redact_secrets: false,
+            api_keys: None,
+            allow_use_of_warp_credits_with_byok: false,
+            autonomy_level: warp_multi_agent_api::AutonomyLevel::Supervised,
+            isolation_level: warp_multi_agent_api::IsolationLevel::None,
+            web_search_enabled: false,
+            computer_use_enabled: false,
+            ask_user_question_enabled: false,
+            research_agent_enabled: false,
+            supported_tools_override: None,
+            byop_conversation_id: Some(AIConversationId::new()),
+            byop_readiness_attempt_id: None,
+            parent_agent_id: None,
+            agent_name: None,
+            lrc_command_id: None,
+            lrc_running_command: None,
+            compaction_state: None,
+            byop_repair_state: Default::default(),
+            lrc_should_spawn_subagent: false,
+        }
+    }
+
     pub fn new(
         terminal_view_id: Option<EntityId>,
         session_context: SessionContext,
@@ -324,6 +376,8 @@ impl RequestParams {
             ask_user_question_enabled,
             research_agent_enabled,
             supported_tools_override: request_input.supported_tools_override.clone(),
+            byop_conversation_id: Some(conversation.id),
+            byop_readiness_attempt_id: None,
             parent_agent_id: None,
             agent_name: None,
             lrc_command_id: None,
@@ -333,6 +387,7 @@ impl RequestParams {
             // BYOP-only:由 controller 在 dispatch 到 BYOP exec 前回填(setter 风格,
             // 避免穿过 ConversationRequestData / 非 BYOP 路径)。
             compaction_state: None,
+            byop_repair_state: Default::default(),
         }
     }
 }

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3,6 +3,7 @@ use crate::ai::agent::linearization::compute_task_depths;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::{RequestInput, ResponseStreamId, SerializedBlockListItem};
+use crate::ai::byop_readiness::RepairStateStatus;
 use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
 use crate::persistence::model::{ConversationUsageMetadata, ModelTokenUsage, ToolUsageMetadata};
@@ -223,6 +224,9 @@ pub struct AIConversation {
     /// 默认空表 = 未压缩状态,完全无侵入。
     /// 详见 [`crate::ai::byop_compaction`]。
     pub(crate) compaction_state: crate::ai::byop_compaction::state::CompactionState,
+    /// OpenWarp BYOP repair sidecar。invalid sidecar 必须原样保留,避免保存时
+    /// 静默授权 repair 或抹掉损坏元数据。
+    pub(crate) byop_repair_state: RepairStateStatus,
 }
 
 pub(crate) fn artifact_from_fork_proto(
@@ -273,6 +277,7 @@ impl AIConversation {
             is_remote_child: false,
             last_event_sequence: None,
             compaction_state: Default::default(),
+            byop_repair_state: RepairStateStatus::default(),
         }
     }
 
@@ -354,6 +359,7 @@ impl AIConversation {
             autoexecute_override,
             last_event_sequence,
             compaction_state,
+            byop_repair_state,
         ) = if let Some(data) = conversation_data {
             let server_conversation_token = data
                 .server_conversation_token
@@ -393,6 +399,13 @@ impl AIConversation {
                         .ok()
                 })
                 .unwrap_or_default();
+            let byop_repair_state =
+                RepairStateStatus::from_sidecar_json(data.byop_repair_state_json);
+            if let Some(error_category) = byop_repair_state.error_category() {
+                log::error!(
+                    "[byop-repair] failed to load repair sidecar category={error_category:?}"
+                );
+            }
 
             (
                 server_conversation_token,
@@ -407,6 +420,7 @@ impl AIConversation {
                 autoexecute_override,
                 last_event_sequence,
                 compaction_state,
+                byop_repair_state,
             )
         } else {
             (
@@ -422,6 +436,7 @@ impl AIConversation {
                 AIConversationAutoexecuteMode::default(),
                 None,
                 crate::ai::byop_compaction::state::CompactionState::default(),
+                RepairStateStatus::default(),
             )
         };
 
@@ -465,6 +480,7 @@ impl AIConversation {
             is_remote_child: false,
             last_event_sequence,
             compaction_state,
+            byop_repair_state,
         })
     }
 
@@ -1344,6 +1360,45 @@ impl AIConversation {
         // turn 启动即落盘:user query 提交时先写一次,stream 中途强退也能保留提问记录。
         self.write_updated_conversation_state(ctx);
         Ok(())
+    }
+
+    pub fn append_byop_preflight_messages_to_task(
+        &mut self,
+        task_id: TaskId,
+        messages: Vec<api::Message>,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) -> Result<usize, UpdateConversationError> {
+        let message_count = messages.len();
+        if message_count == 0 {
+            return Ok(0);
+        }
+        self.ensure_can_persist_byop_preflight_state(ctx)?;
+
+        let message_ids = messages
+            .iter()
+            .map(|message| message.id.clone())
+            .collect::<HashSet<_>>();
+        self.task_store
+            .modify_task(&task_id, |task| task.append_source_messages(messages))
+            .ok_or(UpdateConversationError::TaskNotFound)??;
+        if let Err(e) = self.send_updated_conversation_state_for_byop_preflight(ctx) {
+            if let Some(rollback_result) = self.task_store.modify_task(&task_id, |task| {
+                task.remove_source_messages_by_ids(&message_ids)
+            }) {
+                if let Err(rollback_error) = rollback_result {
+                    log::error!(
+                        "[byop-readiness] failed to roll back preflight messages after \
+                         persistence error: {rollback_error:?}"
+                    );
+                }
+            } else {
+                log::error!(
+                    "[byop-readiness] failed to find task while rolling back preflight messages"
+                );
+            }
+            return Err(e);
+        }
+        Ok(message_count)
     }
 
     pub fn append_reassigned_exchange(
@@ -2781,29 +2836,7 @@ impl AIConversation {
         }
     }
 
-    pub(crate) fn write_updated_conversation_state(
-        &mut self,
-        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
-    ) {
-        // We should not persist non-local conversations (e.g. shared sessions).
-        if self.is_viewing_shared_session {
-            return;
-        }
-
-        if !*GeneralSettings::as_ref(ctx).persist_conversations
-            || !AppExecutionMode::as_ref(ctx).can_save_session()
-        {
-            return;
-        }
-
-        let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(ctx)
-            .get()
-            .model_event_sender
-            .clone()
-        else {
-            return;
-        };
-
+    fn updated_conversation_state_event(&self) -> ModelEvent {
         let reverted_action_ids = if self.reverted_action_ids.is_empty() {
             None
         } else {
@@ -2830,7 +2863,7 @@ impl AIConversation {
             }
         };
 
-        let event = ModelEvent::UpdateMultiAgentConversation {
+        ModelEvent::UpdateMultiAgentConversation {
             conversation_id: self.id.to_string(),
             updated_tasks: self
                 .all_tasks()
@@ -2867,8 +2900,93 @@ impl AIConversation {
                         }
                     }
                 },
+                byop_repair_state_json: self.byop_repair_state.to_sidecar_json(),
             },
+        }
+    }
+
+    fn ensure_can_persist_byop_preflight_state(
+        &self,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) -> Result<(), UpdateConversationError> {
+        if self.is_viewing_shared_session {
+            return Err(
+                UpdateConversationError::ByopPreflightPersistenceUnavailable(
+                    "shared session conversations are not persisted".to_owned(),
+                ),
+            );
+        }
+        if !*GeneralSettings::as_ref(ctx).persist_conversations {
+            return Err(
+                UpdateConversationError::ByopPreflightPersistenceUnavailable(
+                    "conversation persistence is disabled".to_owned(),
+                ),
+            );
+        }
+        if !AppExecutionMode::as_ref(ctx).can_save_session() {
+            return Err(
+                UpdateConversationError::ByopPreflightPersistenceUnavailable(
+                    "current execution mode cannot save sessions".to_owned(),
+                ),
+            );
+        }
+        if GlobalResourceHandlesProvider::as_ref(ctx)
+            .get()
+            .model_event_sender
+            .is_none()
+        {
+            return Err(
+                UpdateConversationError::ByopPreflightPersistenceUnavailable(
+                    "sqlite sender is unavailable".to_owned(),
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    fn send_updated_conversation_state_for_byop_preflight(
+        &self,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) -> Result<(), UpdateConversationError> {
+        self.ensure_can_persist_byop_preflight_state(ctx)?;
+        let sqlite_sender = GlobalResourceHandlesProvider::as_ref(ctx)
+            .get()
+            .model_event_sender
+            .clone()
+            .ok_or_else(|| {
+                UpdateConversationError::ByopPreflightPersistenceUnavailable(
+                    "sqlite sender is unavailable".to_owned(),
+                )
+            })?;
+        sqlite_sender
+            .try_send(self.updated_conversation_state_event())
+            .map_err(|e| UpdateConversationError::ByopPreflightPersistenceSend(format!("{e:?}")))
+    }
+
+    pub(crate) fn write_updated_conversation_state(
+        &mut self,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) {
+        // We should not persist non-local conversations (e.g. shared sessions).
+        if self.is_viewing_shared_session {
+            return;
+        }
+
+        if !*GeneralSettings::as_ref(ctx).persist_conversations
+            || !AppExecutionMode::as_ref(ctx).can_save_session()
+        {
+            return;
+        }
+
+        let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(ctx)
+            .get()
+            .model_event_sender
+            .clone()
+        else {
+            return;
         };
+
+        let event = self.updated_conversation_state_event();
         ctx.spawn(
             async move {
                 if let Err(e) = sqlite_sender.send(event) {
@@ -3532,6 +3650,10 @@ pub enum UpdateConversationError {
     NoActiveTask,
     #[error("No pending request.")]
     NoPendingRequest,
+    #[error("BYOP preflight conversation persistence is unavailable: {0}")]
+    ByopPreflightPersistenceUnavailable(String),
+    #[error("Failed to persist BYOP preflight conversation state: {0}")]
+    ByopPreflightPersistenceSend(String),
 }
 
 /// A globally unique ID for a conversation with an AI agent.

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -4,7 +4,12 @@ use super::{
     artifact_from_fork_proto, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::byop_readiness::{
+    InvalidRepairState, RepairRecord, RepairSource, RepairState, RepairStateLoadError,
+    RepairStateStatus, ToolCallKey,
+};
 use crate::persistence::model::AgentConversationData;
+use crate::persistence::ModelEvent;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 
@@ -54,6 +59,21 @@ fn agent_output_message(id: &str, request_id: &str) -> api::Message {
             },
         )),
         request_id: request_id.to_string(),
+        timestamp: None,
+    }
+}
+
+fn tool_call_message(id: &str, call_id: &str) -> api::Message {
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: call_id.to_string(),
+            tool: None,
+        })),
+        request_id: "request-1".to_string(),
         timestamp: None,
     }
 }
@@ -166,6 +186,103 @@ fn restored_conversation_ignores_persisted_autoexecute_override_when_disabled() 
     assert_eq!(
         conversation.autoexecute_override(),
         AIConversationAutoexecuteMode::RespectUserSettings
+    );
+}
+
+#[test]
+fn restored_conversation_loads_valid_byop_repair_sidecar() {
+    let record = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        ToolCallKey::new("root-task", "assistant-1", "call-1"),
+    );
+    let sidecar_json = serde_json::to_string(&RepairState::new(vec![record.clone()])).unwrap();
+    let conversation_data: AgentConversationData = serde_json::from_value(serde_json::json!({
+        "server_conversation_token": null,
+        "byop_repair_state_json": sidecar_json,
+    }))
+    .unwrap();
+
+    let conversation = restored_conversation(Some(conversation_data));
+
+    assert_eq!(
+        conversation.byop_repair_state,
+        RepairStateStatus::Valid(RepairState::new(vec![record]))
+    );
+}
+
+#[test]
+fn restored_conversation_preserves_invalid_byop_repair_sidecar() {
+    let sidecar_json = "{not valid json".to_string();
+    let conversation_data: AgentConversationData = serde_json::from_value(serde_json::json!({
+        "server_conversation_token": null,
+        "byop_repair_state_json": sidecar_json,
+    }))
+    .unwrap();
+
+    let conversation = restored_conversation(Some(conversation_data));
+
+    assert!(matches!(
+        conversation.byop_repair_state,
+        RepairStateStatus::Invalid(InvalidRepairState {
+            error_category: RepairStateLoadError::InvalidJson,
+            ..
+        })
+    ));
+    assert_eq!(
+        conversation.byop_repair_state.to_sidecar_json().as_deref(),
+        Some("{not valid json")
+    );
+}
+
+#[test]
+fn restored_conversation_does_not_infer_legacy_repair_for_unexplained_gap() {
+    let conversation = AIConversation::new_restored(
+        AIConversationId::new(),
+        vec![api::Task {
+            id: "root-task".to_string(),
+            messages: vec![tool_call_message("assistant-1", "call-1")],
+            dependencies: None,
+            description: String::new(),
+            summary: String::new(),
+            server_data: String::new(),
+        }],
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(conversation.byop_repair_state, RepairStateStatus::default());
+}
+
+#[test]
+fn byop_repair_sidecar_survives_serialization_after_fork_token_cleared() {
+    let record = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        ToolCallKey::new("root-task", "assistant-1", "call-1"),
+    );
+    let sidecar_json = serde_json::to_string(&RepairState::new(vec![record.clone()])).unwrap();
+    let conversation_data: AgentConversationData = serde_json::from_value(serde_json::json!({
+        "server_conversation_token": null,
+        "forked_from_server_conversation_token": "source-token",
+        "byop_repair_state_json": sidecar_json,
+    }))
+    .unwrap();
+    let mut conversation = restored_conversation(Some(conversation_data));
+
+    conversation.clear_forked_from_server_conversation_token();
+
+    let ModelEvent::UpdateMultiAgentConversation {
+        conversation_data, ..
+    } = conversation.updated_conversation_state_event()
+    else {
+        panic!("expected conversation update event");
+    };
+    assert_eq!(
+        conversation_data.forked_from_server_conversation_token,
+        None
+    );
+    assert_eq!(
+        RepairStateStatus::from_sidecar_json(conversation_data.byop_repair_state_json),
+        RepairStateStatus::Valid(RepairState::new(vec![record]))
     );
 }
 

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -663,6 +663,11 @@ impl From<&AIApiError> for RenderableAIError {
         match value {
             AIApiError::QuotaLimit => Self::QuotaLimit,
             AIApiError::ServerOverloaded => Self::ServerOverloaded,
+            AIApiError::Other(error) => Self::Other {
+                error_message: error.to_string(),
+                will_attempt_resume: false,
+                waiting_for_network: false,
+            },
             _ => Self::Other {
                 error_message: format!("Request failed with error: {value:?}"),
                 will_attempt_resume: false,

--- a/app/src/ai/agent/task.rs
+++ b/app/src/ai/agent/task.rs
@@ -707,6 +707,24 @@ impl Task {
         Ok(())
     }
 
+    pub(super) fn append_source_messages(
+        &mut self,
+        messages: Vec<api::Message>,
+    ) -> Result<(), UpdateTaskError> {
+        self.try_get_source_mut()?.messages.extend(messages);
+        Ok(())
+    }
+
+    pub(super) fn remove_source_messages_by_ids(
+        &mut self,
+        message_ids: &std::collections::HashSet<String>,
+    ) -> Result<(), UpdateTaskError> {
+        self.try_get_source_mut()?
+            .messages
+            .retain(|message| !message_ids.contains(&message.id));
+        Ok(())
+    }
+
     pub(super) fn upsert_message(
         &mut self,
         message: api::Message,

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -153,6 +153,7 @@ fn test_display_status_uses_matching_conversation_for_in_progress_task() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -205,6 +206,7 @@ fn test_display_status_updates_when_blocked_conversation_resumes() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -281,6 +283,7 @@ fn test_display_status_terminal_task_state_overrides_matching_conversation() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -333,6 +336,7 @@ fn test_status_filter_uses_display_status_for_task_backed_conversations() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -615,6 +619,7 @@ fn test_get_tasks_and_conversations_prefers_task_when_task_id_matches_conversati
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -673,6 +678,7 @@ fn test_get_tasks_and_conversations_prefers_task_when_server_token_matches() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 
@@ -730,6 +736,7 @@ fn test_get_tasks_and_conversations_keeps_unrelated_tasks_and_conversations() {
                 autoexecute_override: None,
                 last_event_sequence: None,
                 compaction_state_json: None,
+                byop_repair_state_json: None,
             },
         );
 

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -39,7 +39,7 @@
 //! 对 ToolCallChunk 累积 buffer(按 call_id),流末统一 emit `Message::ToolCall`,
 //! controller 自动接管。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -57,9 +57,17 @@ use genai::resolver::{AuthData, Endpoint, ServiceTargetResolver};
 use genai::{Client, ModelIden, ServiceTarget, WebConfig};
 
 use crate::ai::agent::api::{RequestParams, ResponseStream};
-use crate::ai::agent::{AIAgentInput, RunningCommand, UserQueryMode};
+use crate::ai::agent::{AIAgentActionResult, AIAgentInput, RunningCommand, UserQueryMode};
 use crate::ai::api_error::AIApiError;
 use crate::ai::byop_compaction;
+use crate::ai::byop_readiness::{
+    classify_projection, AcceptedRepair, BlockedByopReadinessError, LiveToolCall,
+    LiveToolCallState, ProjectedToolCall, ProjectedToolResult, ProjectionItem, ReadinessCategory,
+    ReadinessContext, ReadinessDiagnosticCoalescer, ReadinessDiagnosticContext,
+    ReadinessDiagnosticLevel, ReadinessReport, ReadinessState, ReadinessTriggerLayer,
+    RedactedToolKind, RepairSource, RepairStateStatus, TerminalResultKind, ToolCallKey,
+    ToolCallRef, ToolResultSource,
+};
 use crate::settings::AgentProviderApiType;
 use ai::agent::convert::ConvertToAPITypeError;
 
@@ -256,6 +264,7 @@ const REASONING_ECHO_PLACEHOLDER: &str = " ";
 struct AssistantBuffer {
     text: Option<String>,
     tool_calls: Vec<ToolCall>,
+    tool_call_keys: Vec<ToolCallKey>,
     /// 上一轮 AgentReasoning(thinking 链)。flush 时挂到对应 assistant message
     /// 的 reasoning_content 字段(genai 内部按 adapter 序列化:DeepSeek/Kimi 走 reasoning_content,
     /// Anthropic 走 thinking blocks)。
@@ -273,7 +282,19 @@ impl AssistantBuffer {
         }
     }
 
+    fn push_tool_call(&mut self, tool_call: ToolCall, key: ToolCallKey) {
+        self.tool_calls.push(tool_call);
+        self.tool_call_keys.push(key);
+    }
+
     fn flush_into(&mut self, messages: &mut Vec<ChatMessage>) {
+        let _ = self.flush_into_with_group(messages);
+    }
+
+    fn flush_into_with_group(
+        &mut self,
+        messages: &mut Vec<ChatMessage>,
+    ) -> Option<OutboundAssistantToolGroup> {
         let reasoning = self.reasoning.take();
         let has_tool_calls = !self.tool_calls.is_empty();
         // 决定本次 flush 要挂到 assistant message 上的 reasoning 字符串。
@@ -317,7 +338,33 @@ impl AssistantBuffer {
             if let Some(r) = echo_reasoning {
                 msg = msg.with_reasoning_content(Some(r));
             }
+            let message_index = messages.len();
             messages.push(msg);
+            Some(OutboundAssistantToolGroup {
+                message_index,
+                tool_call_keys: std::mem::take(&mut self.tool_call_keys),
+            })
+        } else {
+            self.tool_call_keys.clear();
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OutboundAssistantToolGroup {
+    message_index: usize,
+    tool_call_keys: Vec<ToolCallKey>,
+}
+
+fn flush_assistant_buffer(
+    buf: &mut AssistantBuffer,
+    messages: &mut Vec<ChatMessage>,
+    outbound_tool_groups: &mut Vec<OutboundAssistantToolGroup>,
+) {
+    if let Some(group) = buf.flush_into_with_group(messages) {
+        if !group.tool_call_keys.is_empty() {
+            outbound_tool_groups.push(group);
         }
     }
 }
@@ -518,6 +565,617 @@ fn collect_linearized_task_messages(tasks: &[api::Task]) -> Vec<&api::Message> {
     out
 }
 
+struct SerializerProjectionBuilder {
+    items: Vec<ProjectionItem>,
+    pending_tool_calls: Vec<ProjectedToolCall>,
+    pending_task_id: Option<String>,
+    pending_assistant_message_id: Option<String>,
+    skipped_tool_results: HashSet<(String, String)>,
+}
+
+impl SerializerProjectionBuilder {
+    fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            pending_task_id: None,
+            pending_assistant_message_id: None,
+            skipped_tool_results: HashSet::new(),
+        }
+    }
+
+    fn push_user_boundary(&mut self, task_id: String, message_id: String) {
+        self.flush_tool_calls();
+        self.items
+            .push(ProjectionItem::user_boundary(task_id, message_id));
+    }
+
+    fn push_assistant_boundary(&mut self, task_id: String, message_id: String) {
+        self.flush_tool_calls();
+        self.items
+            .push(ProjectionItem::assistant_boundary(task_id, message_id));
+    }
+
+    fn push_tool_call(
+        &mut self,
+        task_id: &str,
+        message_id: &str,
+        tool_call: &api::message::ToolCall,
+    ) {
+        use crate::ai::agent::task::helper::ToolCallExt;
+
+        if tool_call.subagent().is_some() {
+            self.skipped_tool_results
+                .insert((task_id.to_owned(), tool_call.tool_call_id.clone()));
+            return;
+        }
+
+        if self
+            .pending_task_id
+            .as_deref()
+            .is_some_and(|pending_task_id| pending_task_id != task_id)
+        {
+            self.flush_tool_calls();
+        }
+
+        if self.pending_tool_calls.is_empty() {
+            self.pending_task_id = Some(task_id.to_owned());
+            self.pending_assistant_message_id = Some(message_id.to_owned());
+        }
+
+        let assistant_message_id = self
+            .pending_assistant_message_id
+            .clone()
+            .unwrap_or_else(|| message_id.to_owned());
+        self.pending_tool_calls.push(ProjectedToolCall::new(
+            task_id,
+            assistant_message_id,
+            tool_call.tool_call_id.clone(),
+            redacted_tool_kind_for_tool_call(tool_call),
+        ));
+    }
+
+    fn push_tool_result(&mut self, result: ProjectedToolResult) {
+        self.flush_tool_calls();
+        self.items.push(ProjectionItem::tool_result(result));
+    }
+
+    fn should_skip_tool_result(&self, task_id: &str, tool_call_id: &str) -> bool {
+        self.skipped_tool_results
+            .contains(&(task_id.to_owned(), tool_call_id.to_owned()))
+    }
+
+    fn finish(mut self) -> Vec<ProjectionItem> {
+        self.flush_tool_calls();
+        self.items
+    }
+
+    fn flush_tool_calls(&mut self) {
+        if self.pending_tool_calls.is_empty() {
+            return;
+        }
+
+        let task_id = self.pending_task_id.take().unwrap_or_default();
+        let assistant_message_id = self.pending_assistant_message_id.take().unwrap_or_default();
+        self.items.push(ProjectionItem::assistant_tool_calls(
+            task_id,
+            assistant_message_id,
+            std::mem::take(&mut self.pending_tool_calls),
+        ));
+    }
+}
+
+fn redacted_tool_kind_for_tool_call(tool_call: &api::message::ToolCall) -> RedactedToolKind {
+    use crate::ai::agent::task::helper::ToolExt;
+
+    tool_call
+        .tool
+        .as_ref()
+        .map(|tool| RedactedToolKind::new(tool.name()))
+        .unwrap_or_default()
+}
+
+fn current_input_result_kind(result: &AIAgentActionResult) -> TerminalResultKind {
+    if result.result.is_cancelled() {
+        TerminalResultKind::Cancellation
+    } else {
+        TerminalResultKind::Real
+    }
+}
+
+fn persisted_tool_result_kind(
+    msg: &api::Message,
+    compacted_tool_msg_ids: Option<&std::collections::HashSet<String>>,
+) -> TerminalResultKind {
+    if compacted_tool_msg_ids.is_some_and(|ids| ids.contains(&msg.id)) {
+        return TerminalResultKind::Compacted;
+    }
+
+    let Some(api::message::Message::ToolCallResult(tool_call_result)) = msg.message.as_ref() else {
+        return TerminalResultKind::Real;
+    };
+    if tool_call_result.result.is_some() {
+        return TerminalResultKind::Real;
+    }
+
+    let content = msg.server_message_data.trim();
+    if content.is_empty() {
+        return TerminalResultKind::Real;
+    }
+
+    match serde_json::from_str::<Value>(content) {
+        Ok(value) => {
+            if value
+                .get("_byop_intercepted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                TerminalResultKind::LocalInterception
+            } else if value.get("error").and_then(Value::as_str) == Some("invalid_arguments") {
+                TerminalResultKind::StructuredError
+            } else {
+                TerminalResultKind::Real
+            }
+        }
+        Err(_)
+            if content.contains("_byop_intercepted") || content.contains("invalid_arguments") =>
+        {
+            TerminalResultKind::UnreadableLocalInterception
+        }
+        Err(_) => TerminalResultKind::Real,
+    }
+}
+
+fn current_input_task_id(params: &RequestParams) -> String {
+    params
+        .byop_target_task_id
+        .clone()
+        .or_else(|| params.tasks.first().map(|task| task.id.clone()))
+        .unwrap_or_else(|| "current_input".to_owned())
+}
+
+fn build_serializer_readiness_projection(
+    params: &RequestParams,
+    all_msgs: &[&api::Message],
+    summarize_head_end: Option<usize>,
+    summary_inserts: &HashMap<String, String>,
+    hidden_msg_ids: &std::collections::HashSet<String>,
+    compacted_tool_msg_ids: &std::collections::HashSet<String>,
+) -> Vec<ProjectionItem> {
+    let mut builder = SerializerProjectionBuilder::new();
+
+    for (idx, msg) in all_msgs.iter().enumerate() {
+        if let Some(head_end) = summarize_head_end {
+            if idx >= head_end {
+                continue;
+            }
+        }
+
+        if hidden_msg_ids.contains(&msg.id) {
+            if summary_inserts.contains_key(&msg.id) {
+                builder.push_user_boundary(msg.task_id.clone(), format!("summary_user:{}", msg.id));
+                builder.push_assistant_boundary(
+                    msg.task_id.clone(),
+                    format!("summary_assistant:{}", msg.id),
+                );
+            }
+            continue;
+        }
+
+        let Some(inner) = &msg.message else {
+            continue;
+        };
+
+        match inner {
+            api::message::Message::UserQuery(_) => {
+                builder.push_user_boundary(msg.task_id.clone(), msg.id.clone());
+            }
+            api::message::Message::AgentOutput(_) => {
+                builder.push_assistant_boundary(msg.task_id.clone(), msg.id.clone());
+            }
+            api::message::Message::AgentReasoning(_) => {}
+            api::message::Message::ToolCall(tool_call) => {
+                builder.push_tool_call(&msg.task_id, &msg.id, tool_call);
+            }
+            api::message::Message::ToolCallResult(tool_call_result) => {
+                if builder.should_skip_tool_result(&msg.task_id, &tool_call_result.tool_call_id) {
+                    continue;
+                }
+                builder.push_tool_result(ProjectedToolResult::new(
+                    msg.task_id.clone(),
+                    msg.id.clone(),
+                    None,
+                    tool_call_result.tool_call_id.clone(),
+                    RedactedToolKind::default(),
+                    ToolResultSource::PersistedHistory,
+                    persisted_tool_result_kind(msg, Some(compacted_tool_msg_ids)),
+                ));
+            }
+            api::message::Message::ServerEvent(_)
+            | api::message::Message::SystemQuery(_)
+            | api::message::Message::UpdateTodos(_)
+            | api::message::Message::Summarization(_)
+            | api::message::Message::CodeReview(_)
+            | api::message::Message::UpdateReviewComments(_)
+            | api::message::Message::WebSearch(_)
+            | api::message::Message::WebFetch(_)
+            | api::message::Message::DebugOutput(_)
+            | api::message::Message::ArtifactEvent(_)
+            | api::message::Message::InvokeSkill(_)
+            | api::message::Message::MessagesReceivedFromAgents(_)
+            | api::message::Message::ModelUsed(_)
+            | api::message::Message::EventsFromAgents(_)
+            | api::message::Message::PassiveSuggestionResult(_) => {}
+        }
+    }
+
+    let current_task_id = current_input_task_id(params);
+    for (idx, input) in params.input.iter().enumerate() {
+        match input {
+            AIAgentInput::UserQuery { .. }
+            | AIAgentInput::InvokeSkill { .. }
+            | AIAgentInput::ResumeConversation { .. }
+            | AIAgentInput::SummarizeConversation { .. } => {
+                builder.push_user_boundary(
+                    current_task_id.clone(),
+                    format!("current_input:{idx}:user"),
+                );
+            }
+            AIAgentInput::ActionResult { result, .. } => {
+                let tool_call_id = result.id.to_string();
+                builder.push_tool_result(ProjectedToolResult::new(
+                    result.task_id.to_string(),
+                    format!("current_input:{idx}:{tool_call_id}"),
+                    None,
+                    tool_call_id,
+                    RedactedToolKind::default(),
+                    ToolResultSource::CurrentInput,
+                    current_input_result_kind(result),
+                ));
+            }
+            AIAgentInput::AutoCodeDiffQuery { .. }
+            | AIAgentInput::InitProjectRules { .. }
+            | AIAgentInput::TriggerPassiveSuggestion { .. }
+            | AIAgentInput::CreateNewProject { .. }
+            | AIAgentInput::CloneRepository { .. }
+            | AIAgentInput::CodeReview { .. }
+            | AIAgentInput::FetchReviewComments { .. }
+            | AIAgentInput::StartFromAmbientRunPrompt { .. }
+            | AIAgentInput::MessagesReceivedFromAgents { .. }
+            | AIAgentInput::EventsFromAgents { .. }
+            | AIAgentInput::PassiveSuggestionResult { .. } => {}
+        }
+    }
+
+    builder.finish()
+}
+
+pub(crate) fn classify_byop_controller_readiness(params: &RequestParams) -> ReadinessReport {
+    classify_byop_controller_readiness_with_live_tool_calls(params, Vec::new())
+}
+
+pub(crate) fn classify_byop_controller_readiness_with_live_tool_calls(
+    params: &RequestParams,
+    live_tool_calls: Vec<LiveToolCall>,
+) -> ReadinessReport {
+    let skipped_cancellation_results = current_input_cancellation_result_keys(params);
+    let projection = build_controller_readiness_projection(params, &skipped_cancellation_results);
+    let mut live_tool_calls_for_context =
+        cancellation_live_tool_calls(params, &skipped_cancellation_results);
+    live_tool_calls_for_context.extend(live_tool_calls);
+    let context = ReadinessContext {
+        repair_records: params.byop_repair_state.repair_records().to_vec(),
+        live_tool_calls: live_tool_calls_for_context,
+    };
+    classify_projection(&projection, &context)
+}
+
+fn current_input_cancellation_result_keys(params: &RequestParams) -> HashSet<(String, String)> {
+    params
+        .input
+        .iter()
+        .filter_map(|input| {
+            let AIAgentInput::ActionResult { result, .. } = input else {
+                return None;
+            };
+            result
+                .result
+                .is_cancelled()
+                .then(|| (result.task_id.to_string(), result.id.to_string()))
+        })
+        .collect()
+}
+
+fn cancellation_live_tool_calls(
+    params: &RequestParams,
+    skipped_cancellation_results: &HashSet<(String, String)>,
+) -> Vec<LiveToolCall> {
+    use crate::ai::agent::task::helper::ToolCallExt;
+
+    params
+        .tasks
+        .iter()
+        .flat_map(|task| task.messages.iter())
+        .filter_map(|msg| {
+            let api::message::Message::ToolCall(tool_call) = msg.message.as_ref()? else {
+                return None;
+            };
+            if tool_call.subagent().is_some() {
+                return None;
+            }
+            if !skipped_cancellation_results
+                .contains(&(msg.task_id.clone(), tool_call.tool_call_id.clone()))
+            {
+                return None;
+            }
+            Some(LiveToolCall::new(
+                ToolCallRef::new(
+                    ToolCallKey::new(&msg.task_id, &msg.id, &tool_call.tool_call_id),
+                    redacted_tool_kind_for_tool_call(tool_call),
+                ),
+                LiveToolCallState::CancellationRequested,
+            ))
+        })
+        .collect()
+}
+
+fn build_controller_readiness_projection(
+    params: &RequestParams,
+    skipped_current_action_results: &HashSet<(String, String)>,
+) -> Vec<ProjectionItem> {
+    let mut builder = SerializerProjectionBuilder::new();
+
+    for msg in params.tasks.iter().flat_map(|task| task.messages.iter()) {
+        let Some(inner) = &msg.message else {
+            continue;
+        };
+
+        match inner {
+            api::message::Message::UserQuery(_) => {
+                builder.push_user_boundary(msg.task_id.clone(), msg.id.clone());
+            }
+            api::message::Message::AgentOutput(_) => {
+                builder.push_assistant_boundary(msg.task_id.clone(), msg.id.clone());
+            }
+            api::message::Message::AgentReasoning(_) => {}
+            api::message::Message::ToolCall(tool_call) => {
+                builder.push_tool_call(&msg.task_id, &msg.id, tool_call);
+            }
+            api::message::Message::ToolCallResult(tool_call_result) => {
+                if builder.should_skip_tool_result(&msg.task_id, &tool_call_result.tool_call_id) {
+                    continue;
+                }
+                builder.push_tool_result(ProjectedToolResult::new(
+                    msg.task_id.clone(),
+                    msg.id.clone(),
+                    None,
+                    tool_call_result.tool_call_id.clone(),
+                    RedactedToolKind::default(),
+                    ToolResultSource::PersistedHistory,
+                    persisted_tool_result_kind(msg, None),
+                ));
+            }
+            api::message::Message::ServerEvent(_)
+            | api::message::Message::SystemQuery(_)
+            | api::message::Message::UpdateTodos(_)
+            | api::message::Message::Summarization(_)
+            | api::message::Message::CodeReview(_)
+            | api::message::Message::UpdateReviewComments(_)
+            | api::message::Message::WebSearch(_)
+            | api::message::Message::WebFetch(_)
+            | api::message::Message::DebugOutput(_)
+            | api::message::Message::ArtifactEvent(_)
+            | api::message::Message::InvokeSkill(_)
+            | api::message::Message::MessagesReceivedFromAgents(_)
+            | api::message::Message::ModelUsed(_)
+            | api::message::Message::EventsFromAgents(_)
+            | api::message::Message::PassiveSuggestionResult(_) => {}
+        }
+    }
+
+    let current_task_id = current_input_task_id(params);
+    for (idx, input) in params.input.iter().enumerate() {
+        match input {
+            AIAgentInput::UserQuery { .. }
+            | AIAgentInput::InvokeSkill { .. }
+            | AIAgentInput::ResumeConversation { .. }
+            | AIAgentInput::SummarizeConversation { .. } => {
+                builder.push_user_boundary(
+                    current_task_id.clone(),
+                    format!("current_input:{idx}:user"),
+                );
+            }
+            AIAgentInput::ActionResult { result, .. } => {
+                let tool_call_id = result.id.to_string();
+                if skipped_current_action_results
+                    .contains(&(result.task_id.to_string(), tool_call_id.clone()))
+                {
+                    continue;
+                }
+                builder.push_tool_result(ProjectedToolResult::new(
+                    result.task_id.to_string(),
+                    format!("current_input:{idx}:{tool_call_id}"),
+                    None,
+                    tool_call_id,
+                    RedactedToolKind::default(),
+                    ToolResultSource::CurrentInput,
+                    current_input_result_kind(result),
+                ));
+            }
+            AIAgentInput::AutoCodeDiffQuery { .. }
+            | AIAgentInput::InitProjectRules { .. }
+            | AIAgentInput::TriggerPassiveSuggestion { .. }
+            | AIAgentInput::CreateNewProject { .. }
+            | AIAgentInput::CloneRepository { .. }
+            | AIAgentInput::CodeReview { .. }
+            | AIAgentInput::FetchReviewComments { .. }
+            | AIAgentInput::StartFromAmbientRunPrompt { .. }
+            | AIAgentInput::MessagesReceivedFromAgents { .. }
+            | AIAgentInput::EventsFromAgents { .. }
+            | AIAgentInput::PassiveSuggestionResult { .. } => {}
+        }
+    }
+
+    builder.finish()
+}
+
+fn validate_byop_serializer_readiness(
+    params: &RequestParams,
+    all_msgs: &[&api::Message],
+    summarize_head_end: Option<usize>,
+    summary_inserts: &HashMap<String, String>,
+    hidden_msg_ids: &std::collections::HashSet<String>,
+    compacted_tool_msg_ids: &std::collections::HashSet<String>,
+) -> Result<ReadinessReport, ConvertToAPITypeError> {
+    let projection = build_serializer_readiness_projection(
+        params,
+        all_msgs,
+        summarize_head_end,
+        summary_inserts,
+        hidden_msg_ids,
+        compacted_tool_msg_ids,
+    );
+    let conversation_id = params
+        .byop_conversation_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let request_attempt_id = params
+        .byop_readiness_attempt_id
+        .clone()
+        .unwrap_or_else(|| "serializer-unknown".to_owned());
+    validate_serializer_readiness_projection_with_repair_state(
+        projection,
+        &params.byop_repair_state,
+        &ReadinessDiagnosticContext::new(
+            &conversation_id,
+            &request_attempt_id,
+            ReadinessTriggerLayer::SerializerValidation,
+        ),
+    )
+}
+
+fn validate_serializer_readiness_projection(
+    projection: Vec<ProjectionItem>,
+) -> Result<ReadinessReport, ConvertToAPITypeError> {
+    validate_serializer_readiness_projection_with_repair_state(
+        projection,
+        &RepairStateStatus::default(),
+        &ReadinessDiagnosticContext::new(
+            "test-conversation",
+            "test-attempt",
+            ReadinessTriggerLayer::SerializerValidation,
+        ),
+    )
+}
+
+fn validate_serializer_readiness_projection_with_repair_state(
+    projection: Vec<ProjectionItem>,
+    repair_state: &RepairStateStatus,
+    diagnostic_context: &ReadinessDiagnosticContext<'_>,
+) -> Result<ReadinessReport, ConvertToAPITypeError> {
+    let context = ReadinessContext {
+        repair_records: repair_state.repair_records().to_vec(),
+        live_tool_calls: Vec::new(),
+    };
+    let report = classify_projection(&projection, &context);
+
+    match &report.state {
+        ReadinessState::Ready => {
+            if let Some(error_category) = repair_state.error_category() {
+                log::error!(
+                    "[byop-readiness] serializer continuing with invalid repair sidecar \
+                     category={error_category:?} projection_items={}",
+                    projection.len()
+                );
+            }
+            Ok(report)
+        }
+        ReadinessState::AcceptedHistoryRepair { repairs } => {
+            log_accepted_history_repair(repairs, diagnostic_context);
+            Ok(report)
+        }
+        ReadinessState::PendingToolResults { tool_calls: _ }
+        | ReadinessState::NeedsCancellationCommit { tool_calls: _ }
+        | ReadinessState::DuplicateToolResults {
+            tool_call: _,
+            results: _,
+        }
+        | ReadinessState::OrphanToolResult { result: _ }
+        | ReadinessState::OutOfOrderToolResult { result: _ }
+        | ReadinessState::MissingResultWithoutRepairSource {
+            tool_calls: _,
+            reason: _,
+        } => {
+            let category = report.state.category();
+            let mut diagnostics = ReadinessDiagnosticCoalescer::default();
+            diagnostics.log_state(
+                &report.state,
+                diagnostic_context,
+                ReadinessDiagnosticLevel::Error,
+            );
+            diagnostics.finish(diagnostic_context, ReadinessDiagnosticLevel::Error);
+            log::error!(
+                "[byop-readiness] serializer blocked request category={category:?} \
+                 projection_items={} ignored_repair_records={} trigger_layer=serializer_validation \
+                 request_attempt_id={}",
+                projection.len(),
+                report.ignored_repair_records.len(),
+                diagnostic_context.request_attempt_id
+            );
+
+            Err(ConvertToAPITypeError::Other(
+                BlockedByopReadinessError::new(category).into(),
+            ))
+        }
+    }
+}
+
+fn log_accepted_history_repair(
+    repairs: &[AcceptedRepair],
+    diagnostic_context: &ReadinessDiagnosticContext<'_>,
+) {
+    log::info!(
+        "{}",
+        accepted_history_repair_log_message(repairs, diagnostic_context)
+    );
+}
+
+fn accepted_history_repair_log_message(
+    repairs: &[AcceptedRepair],
+    diagnostic_context: &ReadinessDiagnosticContext<'_>,
+) -> String {
+    let forked_history_count = repairs
+        .iter()
+        .filter(|repair| matches!(repair.record.source, RepairSource::ForkedHistory))
+        .count();
+    let restored_legacy_history_count = repairs
+        .iter()
+        .filter(|repair| matches!(repair.record.source, RepairSource::RestoredLegacyHistory))
+        .count();
+
+    format!(
+        "[byop-readiness] serializer accepted history repair records={} \
+         category={:?} forked_history={} restored_legacy_history={} conversation_id={} \
+         trigger_layer=serializer_validation request_attempt_id={} repair_keys={:?}",
+        repairs.len(),
+        ReadinessCategory::AcceptedHistoryRepair,
+        forked_history_count,
+        restored_legacy_history_count,
+        diagnostic_context.conversation_id,
+        diagnostic_context.request_attempt_id,
+        repairs
+            .iter()
+            .map(|repair| format!(
+                "task_id={} assistant_tool_call_message_id={} tool_call_id={} redacted_tool_kind={}",
+                repair.tool_call.key.task_id,
+                repair.tool_call.key.assistant_tool_call_message_id,
+                repair.tool_call.key.tool_call_id,
+                repair.tool_call.redacted_tool_kind.as_str()
+            ))
+            .collect::<Vec<_>>()
+    )
+}
+
 /// 把 RequestParams 翻译为 genai `ChatRequest`(含 system + messages + tools)。
 ///
 /// `force_echo_reasoning`:由 `super::reasoning::model_requires_reasoning_echo`
@@ -528,7 +1186,7 @@ fn build_chat_request(
     force_echo_reasoning: bool,
     api_type: AgentProviderApiType,
     model_id: &str,
-) -> ChatRequest {
+) -> Result<ChatRequest, ConvertToAPITypeError> {
     let agent_ctx = latest_input_context(&params.input);
     let plan_mode = is_plan_mode_turn(&params.input);
     let tool_names = available_tool_names(params);
@@ -548,6 +1206,7 @@ fn build_chat_request(
     // 不在 system 这层重复硬编码 TUI 退出键之类,避免与 default.j2 的标准引导冲突或冗余。
 
     let mut messages: Vec<ChatMessage> = Vec::new();
+    let mut outbound_tool_groups: Vec<OutboundAssistantToolGroup> = Vec::new();
 
     // 收集所有 task 的 messages,经 `collect_linearized_task_messages` 做确定性
     // DFS 线性化 + UserQuery 去重(修复 Issue #94 —— 历史轮 user 消息被乱序排到
@@ -638,6 +1297,15 @@ fn build_chat_request(
         None
     };
 
+    let readiness_report = validate_byop_serializer_readiness(
+        params,
+        &all_msgs,
+        summarize_head_end,
+        &summary_inserts,
+        &hidden_msg_ids,
+        &compacted_tool_msg_ids,
+    )?;
+
     let mut buf = AssistantBuffer::new(force_echo_reasoning);
     // OpenWarp:历史里被 skip 掉的 subagent ToolCall 对应的 call_id —— 它们的
     // ToolCallResult 也必须 skip,否则会成为孤儿 tool_response,Anthropic 直接 400
@@ -654,7 +1322,7 @@ fn build_chat_request(
         }
         if hidden_msg_ids.contains(&msg.id) {
             if let Some(summary_text) = summary_inserts.get(&msg.id) {
-                buf.flush_into(&mut messages);
+                flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
                 messages.push(ChatMessage::user(
                     "Conversation history was compacted. Below is the structured summary of all prior turns.".to_string(),
                 ));
@@ -667,7 +1335,7 @@ fn build_chat_request(
         };
         match inner {
             api::message::Message::UserQuery(u) => {
-                buf.flush_into(&mut messages);
+                flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
                 // OpenWarp:历史轮多模态保活。warp 自家路径靠云端 server 重注入 InputContext,
                 // BYOP 直连没有那层,所以 `make_user_query_message` 持久化时把所有 binary
                 // (image / pdf / audio)塞进了 `UserQuery.context.images`,这里反向恢复成
@@ -736,7 +1404,7 @@ fn build_chat_request(
             }
             api::message::Message::AgentOutput(a) => {
                 if buf.text.is_some() || !buf.tool_calls.is_empty() {
-                    buf.flush_into(&mut messages);
+                    flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
                 }
                 buf.text = Some(a.text.clone());
             }
@@ -745,28 +1413,43 @@ fn build_chat_request(
                 // LRC tag-in 场景下,我们在 chat_stream 流头合成 `Tool::Subagent { metadata: Cli }`
                 // 写入 root.task.messages,只用于触发 conversation 创建 cli subtask + spawn 浮窗,
                 // 它不是模型实际产出的工具调用,模型看到会 confused(多余 tool call + 没法回应)。
-                // 同样它对应的 placeholder ToolResponse(由 sanitize_tool_call_pairs 补的)
-                // 也要由下面 ToolCallResult 分支的 skip 逻辑配合过滤,避免出现
+                // 同样它对应的 ToolCallResult 也要由下面分支过滤,避免出现
                 // "tool_response 找不到匹配的 tool_call" 的不平衡。
                 use crate::ai::agent::task::helper::ToolCallExt;
                 if tc.subagent().is_some() {
                     skipped_subagent_call_ids.insert(tc.tool_call_id.clone());
                     continue;
                 }
+                if buf
+                    .tool_call_keys
+                    .first()
+                    .is_some_and(|key| key.task_id != msg.task_id)
+                {
+                    flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
+                }
                 let (name, args_json) = serialize_outgoing_tool_call(
                     tc,
                     params.mcp_context.as_ref(),
                     &msg.server_message_data,
                 );
-                buf.tool_calls.push(ToolCall {
-                    call_id: tc.tool_call_id.clone(),
-                    fn_name: name,
-                    fn_arguments: args_json,
-                    thought_signatures: None,
-                });
+                let assistant_message_id = buf
+                    .tool_call_keys
+                    .first()
+                    .map(|key| key.assistant_tool_call_message_id.clone())
+                    .unwrap_or_else(|| msg.id.clone());
+                let key = ToolCallKey::new(&msg.task_id, assistant_message_id, &tc.tool_call_id);
+                buf.push_tool_call(
+                    ToolCall {
+                        call_id: tc.tool_call_id.clone(),
+                        fn_name: name,
+                        fn_arguments: args_json,
+                        thought_signatures: None,
+                    },
+                    key,
+                );
             }
             api::message::Message::ToolCallResult(tcr) => {
-                buf.flush_into(&mut messages);
+                flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
                 // OpenWarp:对应 ToolCall 已被 skip(subagent 虚拟 call)→ result 也 skip,
                 // 否则留下孤儿 tool_response 导致上游 400。
                 if skipped_subagent_call_ids.contains(&tcr.tool_call_id) {
@@ -795,7 +1478,7 @@ fn build_chat_request(
             }
         }
     }
-    buf.flush_into(&mut messages);
+    flush_assistant_buffer(&mut buf, &mut messages, &mut outbound_tool_groups);
 
     // 当前轮新输入 → 追加。
     for input in &params.input {
@@ -960,10 +1643,13 @@ fn build_chat_request(
         }
     }
 
-    // 防御性 sanitize: 确保每个 assistant tool_calls 后面跟着对应每个 call_id 的
-    // ToolResponse。warp 自家协议有时把 tool result 消化成下一轮 AgentOutput,
-    // 上游若未保留 ToolCallResult,会让 tool_calls 配对失败。
-    sanitize_tool_call_pairs(&mut messages);
+    if let ReadinessState::AcceptedHistoryRepair { repairs } = &readiness_report.state {
+        repair_tool_call_pairs_for_accepted_history_gaps(
+            &mut messages,
+            repairs,
+            &outbound_tool_groups,
+        );
+    }
 
     // 防御性 sanitize: 确保 messages 末尾不是 assistant。
     // Anthropic / 部分网关不接受末尾为 assistant 的请求(prefill 仅特定模型支持),
@@ -1030,13 +1716,47 @@ fn build_chat_request(
     if !tools_array.is_empty() {
         req = req.with_tools(tools_array);
     }
-    req
+    Ok(req)
 }
 
 const BYOP_DIAG_SNIPPET_CHARS: usize = 240;
+const REPAIR_PLACEHOLDER_NOTE: &str =
+    "tool result was unavailable in repaired conversation history";
 
 fn is_placeholder_tool_response_content(content: &str) -> bool {
-    content == "(tool 执行结果未保留)"
+    if content == "(tool 执行结果未保留)" {
+        return true;
+    }
+
+    let Ok(Value::Object(object)) = serde_json::from_str::<Value>(content) else {
+        return false;
+    };
+
+    object.len() == 3
+        && object.get("status").and_then(Value::as_str) == Some("unavailable")
+        && matches!(
+            object.get("reason").and_then(Value::as_str),
+            Some("forked_history_repair" | "restored_legacy_history_repair")
+        )
+        && object.get("note").and_then(Value::as_str) == Some(REPAIR_PLACEHOLDER_NOTE)
+}
+
+fn insert_preferred_tool_response(
+    responses_by_call_id: &mut HashMap<String, ToolResponse>,
+    response: &ToolResponse,
+) {
+    let should_replace = match responses_by_call_id.get(&response.call_id) {
+        None => true,
+        Some(existing) => should_replace_tool_response(existing, response),
+    };
+    if should_replace {
+        responses_by_call_id.insert(response.call_id.clone(), response.clone());
+    }
+}
+
+fn should_replace_tool_response(existing: &ToolResponse, candidate: &ToolResponse) -> bool {
+    is_placeholder_tool_response_content(&existing.content)
+        || !is_placeholder_tool_response_content(&candidate.content)
 }
 
 fn snippet_for_log(s: &str, max_chars: usize) -> String {
@@ -1422,165 +2142,171 @@ fn apply_caching_anthropic(messages: &mut Vec<ChatMessage>) {
         .collect();
 }
 
-/// 兜底:确保每个含 `tool_calls` 的 Assistant 后面紧跟一条覆盖**全部** call_id 的
-/// Tool message,缺失的 call_id 补 placeholder ToolResponse `"(tool 执行结果未保留)"`。
-/// 多条相邻 Tool message 会被合并为一条,并按 Assistant `tool_calls` 的 call_id 顺序
-/// 重组 ToolResponse 数组(与 Anthropic `tool_result` block 必须按 `tool_use` 序对齐的
-/// 语义一致)。
+/// 仅在 serializer 已判定为 `AcceptedHistoryRepair` 后运行:把被 RepairRecord
+/// 明确授权的历史缺口转换为 outbound-only 结构化 ToolResponse。
 ///
-/// **触发场景(全部是异常路径,正常 push 路径不会进入补码/合并分支)**:
-/// 1. `fork_conversation_at_exchange` 按 message_ids 截断对话,分叉点可能恰好落在
-///    Assistant 的 `tool_calls` 与 ToolCallResult 之间 — 截后只剩 Assistant 含
-///    tool_calls 但没有对应 Tool。
-/// 2. 历史 conversation 从 SQLite 反序列化时,某次写入失败漏了 ToolCallResult,
-///    加载回来是孤儿。
-/// 3. 持久化损坏 / 测试 stub 等其他异常路径。
-///
-/// **跨位置重排 Tool messages(本函数会做)**:把所有 Tool message 抽出到
-/// `call_id → response` 表(同 call_id 真实 result 优先于 placeholder),再按每个
-/// Assistant.tool_calls 顺序在 Assistant 后重装。早期实现刻意回避这一步,因为
-/// 旧云端路径 `build_chat_request` 会按 timestamp chronological 排序,跨位置重排
-/// 会与之冲突;OpenWarp 已移除云端,生产路径 `make_*_message` 一律填
-/// `timestamp: None`、`build_chat_request` 也不再排序,本函数才放开重排。
-///
-/// **触发该重排的真实场景**:用户在工具执行/取消结果落盘前提交新 query,
-/// `params.input` 顺序为 `[ActionResult, UserQuery]`,持久化后历史就会是
-/// `Assistant(tool_call) → UserQuery → ToolCallResult`。如果只看 Assistant 后
-/// 紧邻的 Tool message,会误把这条真实 result 当成孤儿并补一条 placeholder。
-/// 全局收集 → 按位置重装可避免该误判。
-///
-/// **对 Anthropic prompt cache 的影响**:跨位置重排会改变 messages 物理序,
-/// `apply_caching_anthropic` 对 last 2 non-system message 打 5m breakpoint 时,
-/// 同一会话跨轮的 cache prefix 字节序可能漂移 → 偶发 cache miss。这是已知
-/// 取舍:不重排 → tool_use/tool_result 配对失败上游直接 400(致命);重排 →
-/// 极少数竞态轮次 cache miss(可恢复)。日志里 `byop-diag` 的
-/// `reordered_call_ids=` 字段标记本轮是否发生重排,便于在
-/// `[byop-cache]` miss 突增时定位归因。
-fn sanitize_tool_call_pairs(messages: &mut Vec<ChatMessage>) {
-    use std::collections::HashMap;
+/// 普通缺失、重复、孤儿或跨边界乱序已经在 readiness validation 阶段阻断;
+/// 这里不再为 normal flow 生成占位结果,也不写回 conversation history。
+fn repair_tool_call_pairs_for_accepted_history_gaps(
+    messages: &mut Vec<ChatMessage>,
+    repairs: &[AcceptedRepair],
+    outbound_tool_groups: &[OutboundAssistantToolGroup],
+) {
+    use std::collections::{HashMap, HashSet};
 
-    let mut placeholders_inserted: Vec<String> = Vec::new();
-    let mut orphan_call_ids: Vec<String> = Vec::new();
-    // 记录每个 ToolResponse 在原 messages 中的索引,用于在重装后判定是否发生
-    // 跨位置重排(影响 prompt cache prefix 稳定性,见函数 doc)。
-    let mut original_positions: HashMap<String, usize> = HashMap::new();
-
-    fn is_placeholder_response(resp: &ToolResponse) -> bool {
-        is_placeholder_tool_response_content(&resp.content)
+    if repairs.is_empty() {
+        return;
     }
 
-    // 先全局收集所有 ToolResponse。真实场景里用户可在工具执行/取消结果落盘前
-    // 继续发送 query,历史会形成 Assistant(tool_call) → UserQuery → ToolCallResult。
-    // 只看 Assistant 后面的连续 Tool message 会误补 placeholder,并把真实 result 留成孤儿。
-    //
-    // 覆盖规则(语义保持不变,改写为更易读形式):
-    //   - 表里没有 → 写入
-    //   - 表里是 placeholder → 真实 / placeholder 都覆盖(后到为准)
-    //   - 表里是真实 → 仅当新值也是真实时覆盖(后到为准),placeholder 不能覆盖真实
-    let mut responses_by_call_id: HashMap<String, ToolResponse> = HashMap::new();
-    for (idx, msg) in messages.iter().enumerate() {
+    let repair_by_key: HashMap<ToolCallKey, &AcceptedRepair> = repairs
+        .iter()
+        .map(|repair| (repair.tool_call.key.clone(), repair))
+        .collect();
+    let group_by_message_index: HashMap<usize, &OutboundAssistantToolGroup> = outbound_tool_groups
+        .iter()
+        .map(|group| (group.message_index, group))
+        .collect();
+    let mut call_id_counts: HashMap<String, usize> = HashMap::new();
+    for group in outbound_tool_groups {
+        for key in &group.tool_call_keys {
+            *call_id_counts.entry(key.tool_call_id.clone()).or_default() += 1;
+        }
+    }
+    let mut placeholders_inserted: Vec<String> = Vec::new();
+    let mut orphan_call_ids: Vec<String> = Vec::new();
+    let mut missing_without_repair: Vec<String> = Vec::new();
+
+    let original = std::mem::take(messages);
+    let mut late_responses_by_unique_call_id: HashMap<String, ToolResponse> = HashMap::new();
+    let mut late_response_call_ids: HashSet<String> = HashSet::new();
+    for (idx, msg) in original.iter().enumerate() {
         if msg.role != genai::chat::ChatRole::Tool {
             continue;
         }
-        for resp in msg.content.tool_responses() {
-            let should_replace = match responses_by_call_id.get(&resp.call_id) {
-                None => true,
-                Some(existing) => {
-                    is_placeholder_response(existing) || !is_placeholder_response(resp)
-                }
-            };
-            if should_replace {
-                responses_by_call_id.insert(resp.call_id.clone(), (*resp).clone());
-            }
-            // 原位置只在首次见到该 call_id 时记录;若同 call_id 多次出现
-            // (持久化重复),保留最早出现的位置 — 该位置最能代表"上轮请求里它
-            // 落在哪里",用于判定跨位置重排。
-            original_positions.entry(resp.call_id.clone()).or_insert(idx);
-        }
-    }
 
-    // 重排追踪:记录被搬到 Assistant 后面但**原位置不在 Assistant 紧邻位**的 call_id。
-    let mut reordered_call_ids: Vec<String> = Vec::new();
-
-    let mut rewritten: Vec<ChatMessage> = Vec::with_capacity(messages.len());
-    for (orig_idx, msg) in messages.drain(..).enumerate() {
-        if msg.role == genai::chat::ChatRole::Tool {
+        let is_adjacent_to_group =
+            idx > 0 && group_by_message_index.contains_key(&(idx.saturating_sub(1)));
+        if is_adjacent_to_group {
             continue;
         }
 
-        let expected_call_ids: Vec<String> = if msg.role == genai::chat::ChatRole::Assistant {
-            msg.content
-                .tool_calls()
-                .iter()
-                .map(|tc| tc.call_id.clone())
-                .collect()
-        } else {
-            Vec::new()
+        for resp in msg.content.tool_responses() {
+            if call_id_counts.get(&resp.call_id) == Some(&1) {
+                insert_preferred_tool_response(&mut late_responses_by_unique_call_id, resp);
+                late_response_call_ids.insert(resp.call_id.clone());
+            }
+        }
+    }
+
+    let mut rewritten: Vec<ChatMessage> = Vec::with_capacity(original.len());
+    let mut idx = 0;
+    while idx < original.len() {
+        let msg = original[idx].clone();
+        if msg.role == genai::chat::ChatRole::Tool {
+            orphan_call_ids.extend(
+                msg.content
+                    .tool_responses()
+                    .iter()
+                    .filter(|response| !late_response_call_ids.contains(&response.call_id))
+                    .map(|response| response.call_id.clone()),
+            );
+            idx += 1;
+            continue;
+        }
+
+        let Some(group) = group_by_message_index.get(&idx).copied() else {
+            rewritten.push(msg);
+            idx += 1;
+            continue;
         };
 
         rewritten.push(msg);
+        idx += 1;
 
-        if expected_call_ids.is_empty() {
-            continue;
+        let mut responses_by_call_id: HashMap<String, ToolResponse> = HashMap::new();
+        while idx < original.len() && original[idx].role == genai::chat::ChatRole::Tool {
+            for resp in original[idx].content.tool_responses() {
+                insert_preferred_tool_response(&mut responses_by_call_id, resp);
+            }
+            idx += 1;
         }
 
-        // 按 Assistant.tool_calls 顺序重组,缺失补 placeholder。
-        // Assistant 重装后位于 rewritten 末尾;"紧邻"意味着原 messages 中
-        // Tool 落在 orig_idx + 1 处。其它位置即视为跨位置重排。
-        let expected_tool_idx = orig_idx + 1;
-        let bundled: Vec<ToolResponse> = expected_call_ids
-            .iter()
-            .map(|cid| {
-                match responses_by_call_id.remove(cid) {
-                    Some(resp) => {
-                        if let Some(orig_pos) = original_positions.get(cid) {
-                            if *orig_pos != expected_tool_idx {
-                                reordered_call_ids.push(cid.clone());
-                            }
+        let mut bundled: Vec<ToolResponse> = Vec::new();
+        for key in &group.tool_call_keys {
+            let cid = &key.tool_call_id;
+            let mut response = responses_by_call_id.remove(cid);
+            if call_id_counts.get(cid) == Some(&1) {
+                if let Some(late_response) = late_responses_by_unique_call_id.remove(cid) {
+                    response = match response {
+                        Some(existing)
+                            if !should_replace_tool_response(&existing, &late_response) =>
+                        {
+                            Some(existing)
                         }
-                        resp
-                    }
-                    None => {
+                        _ => Some(late_response),
+                    };
+                }
+            }
+
+            match response {
+                Some(resp) => bundled.push(resp),
+                None => {
+                    if let Some(repair) = repair_by_key.get(key) {
                         placeholders_inserted.push(cid.clone());
-                        ToolResponse::new(cid.clone(), "(tool 执行结果未保留)".to_owned())
+                        bundled.push(ToolResponse::new(
+                            cid.clone(),
+                            repair_placeholder_content(repair.record.source),
+                        ));
+                    } else {
+                        missing_without_repair.push(cid.clone());
                     }
                 }
-            })
-            .collect();
+            }
+        }
 
-        rewritten.push(ChatMessage::from(bundled));
+        if !bundled.is_empty() {
+            rewritten.push(ChatMessage::from(bundled));
+        }
+
+        if !responses_by_call_id.is_empty() {
+            orphan_call_ids.extend(responses_by_call_id.into_keys());
+        }
     }
 
-    if !responses_by_call_id.is_empty() {
-        orphan_call_ids.extend(responses_by_call_id.into_keys());
-    }
     *messages = rewritten;
 
     if !orphan_call_ids.is_empty() {
         log::warn!(
-            "[byop-diag] sanitize_tool_call_pairs: 丢弃 {} 个孤儿 ToolResponse: \
+            "[byop-diag] accepted_history_repair: 丢弃 {} 个孤儿 ToolResponse: \
              orphan_call_ids={:?}",
             orphan_call_ids.len(),
             orphan_call_ids
         );
     }
     if !placeholders_inserted.is_empty() {
-        log::warn!(
-            "[byop-diag] sanitize_tool_call_pairs: 给 {} 个 ToolCall 补 placeholder \
+        log::info!(
+            "[byop-diag] accepted_history_repair: 给 {} 个 ToolCall 补 repair placeholder \
              ToolResponse: missing_call_ids={:?}",
             placeholders_inserted.len(),
             placeholders_inserted
         );
     }
-    if !reordered_call_ids.is_empty() {
-        // 标记本轮发生跨位置重排,后续 `[byop-cache]` miss 突增时可与此关联。
-        log::warn!(
-            "[byop-diag] sanitize_tool_call_pairs: 跨位置重排 {} 个 ToolResponse(cache prefix \
-             可能漂移): reordered_call_ids={:?}",
-            reordered_call_ids.len(),
-            reordered_call_ids
+    if !missing_without_repair.is_empty() {
+        log::error!(
+            "[byop-diag] accepted_history_repair: readiness 未授权的缺失 ToolResponse: \
+             missing_call_ids={:?}",
+            missing_without_repair
         );
     }
+}
+
+fn repair_placeholder_content(source: RepairSource) -> String {
+    json!({
+        "status": "unavailable",
+        "reason": source.placeholder_reason(),
+        "note": REPAIR_PLACEHOLDER_NOTE,
+    })
+    .to_string()
 }
 
 /// 兜底:确保 messages 末尾是 user(或 tool 响应)。
@@ -2471,7 +3197,7 @@ pub async fn generate_byop_output(
     } = input;
 
     let force_echo_reasoning = super::reasoning::model_requires_reasoning_echo(api_type, &model_id);
-    let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, &model_id);
+    let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, &model_id)?;
     let conversation_id = params
         .conversation_token
         .as_ref()
@@ -4950,14 +5676,957 @@ mod cache_boundary_stability_tests {
     }
 }
 
-/// **`sanitize_tool_call_pairs` 行为验证**:
-///
-/// 本模块覆盖各种 push 路径 / fork 截断 / 持久化损坏场景下该函数的修复行为,
-/// 确保下游 Anthropic / OpenAI 不会踩到 "unexpected tool_use_id" / "tool_result
-/// without tool_use" 这类 400。
 #[cfg(test)]
-mod sanitize_tool_call_pairs_tests {
+mod serializer_readiness_tests {
     use super::*;
+    use crate::ai::agent::task::TaskId;
+    use crate::ai::agent::{AIAgentActionId, AIAgentActionResultType, RequestCommandOutputResult};
+    use crate::ai::byop_compaction::state::{CompactionState, CompletedCompaction};
+    use crate::ai::byop_readiness::{
+        PendingByopToolResultsError, RepairRecord, RepairState, ToolCallKey, ToolCallRef,
+        BLOCKED_BYOP_REQUEST_MESSAGE,
+    };
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+
+    fn kind() -> RedactedToolKind {
+        RedactedToolKind::new("shell")
+    }
+
+    fn assistant_calls(task_id: &str, assistant_id: &str, call_ids: &[&str]) -> ProjectionItem {
+        ProjectionItem::assistant_tool_calls(
+            task_id,
+            assistant_id,
+            call_ids
+                .iter()
+                .map(|call_id| ProjectedToolCall::new(task_id, assistant_id, *call_id, kind()))
+                .collect(),
+        )
+    }
+
+    fn result(
+        task_id: &str,
+        message_id: &str,
+        assistant_id: Option<&str>,
+        call_id: &str,
+        source: ToolResultSource,
+    ) -> ProjectionItem {
+        ProjectionItem::tool_result(ProjectedToolResult::new(
+            task_id,
+            message_id,
+            assistant_id.map(str::to_owned),
+            call_id,
+            kind(),
+            source,
+            TerminalResultKind::Real,
+        ))
+    }
+
+    fn assert_blocked_category(projection: Vec<ProjectionItem>, category: &str) {
+        let error = validate_serializer_readiness_projection(projection).unwrap_err();
+        assert!(
+            error.to_string().contains(BLOCKED_BYOP_REQUEST_MESSAGE),
+            "error should use blocked-request copy for {category}: {error}"
+        );
+    }
+
+    fn shell_tool() -> api::message::tool_call::Tool {
+        use api::message::tool_call::run_shell_command::WaitUntilCompleteValue;
+
+        api::message::tool_call::Tool::RunShellCommand(api::message::tool_call::RunShellCommand {
+            command: "echo hi".to_owned(),
+            is_read_only: true,
+            uses_pager: false,
+            is_risky: false,
+            citations: vec![],
+            wait_until_complete_value: Some(WaitUntilCompleteValue::WaitUntilComplete(true)),
+            risk_category: 0,
+        })
+    }
+
+    fn subagent_tool() -> api::message::tool_call::Tool {
+        api::message::tool_call::Tool::Subagent(api::message::tool_call::Subagent {
+            task_id: "subtask-1".to_owned(),
+            payload: String::new(),
+            metadata: Some(api::message::tool_call::subagent::Metadata::Cli(
+                api::message::tool_call::subagent::CliSubagent {
+                    command_id: "command-1".to_owned(),
+                },
+            )),
+        })
+    }
+
+    fn task_with_messages(messages: Vec<api::Message>) -> api::Task {
+        api::Task {
+            id: "task-1".to_owned(),
+            messages,
+            dependencies: None,
+            description: String::new(),
+            summary: String::new(),
+            server_data: String::new(),
+        }
+    }
+
+    fn user_query_input(query: &str) -> AIAgentInput {
+        AIAgentInput::UserQuery {
+            query: query.to_owned(),
+            context: Arc::<[AIAgentContext]>::from([]),
+            static_query_type: None,
+            referenced_attachments: HashMap::new(),
+            user_query_mode: UserQueryMode::default(),
+            running_command: None,
+            intended_agent: None,
+        }
+    }
+
+    fn cancelled_action_result_input(call_id: &str) -> AIAgentInput {
+        AIAgentInput::ActionResult {
+            result: AIAgentActionResult {
+                id: AIAgentActionId::from(call_id.to_owned()),
+                task_id: TaskId::new("task-1".to_owned()),
+                result: AIAgentActionResultType::RequestCommandOutput(
+                    RequestCommandOutputResult::CancelledBeforeExecution,
+                ),
+            },
+            context: Arc::<[AIAgentContext]>::from([]),
+        }
+    }
+
+    fn request_params(messages: Vec<api::Message>, input: Vec<AIAgentInput>) -> RequestParams {
+        RequestParams::new_for_test(input, vec![task_with_messages(messages)])
+    }
+
+    fn request_params_with_repair(
+        messages: Vec<api::Message>,
+        input: Vec<AIAgentInput>,
+        repair_state: RepairState,
+    ) -> RequestParams {
+        let mut params = request_params(messages, input);
+        params.byop_repair_state = RepairStateStatus::Valid(repair_state);
+        params
+    }
+
+    fn build_openai_request(params: &RequestParams) -> Result<ChatRequest, ConvertToAPITypeError> {
+        build_chat_request(params, false, AgentProviderApiType::OpenAi, "test-model")
+    }
+
+    fn assert_request_has_no_repair_placeholder(request: &ChatRequest) {
+        assert!(
+            !request.messages.iter().any(|message| {
+                message
+                    .content
+                    .tool_responses()
+                    .iter()
+                    .any(|response| is_placeholder_tool_response_content(&response.content))
+            }),
+            "normal request body must not emit placeholder tool results"
+        );
+    }
+
+    fn tool_response_contents(request: &ChatRequest, call_id: &str) -> Vec<String> {
+        request
+            .messages
+            .iter()
+            .flat_map(|message| message.content.tool_responses())
+            .filter(|response| response.call_id == call_id)
+            .map(|response| response.content.clone())
+            .collect()
+    }
+
+    fn assert_build_request_blocked(params: RequestParams, category: &str) {
+        let error = build_openai_request(&params).unwrap_err();
+        assert!(
+            error.to_string().contains(BLOCKED_BYOP_REQUEST_MESSAGE),
+            "error should use blocked-request copy for {category}: {error}"
+        );
+    }
+
+    #[test]
+    fn placeholder_then_cancellation_regression_blocks_waits_or_sends_real_cancellation() {
+        let user_message = make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]);
+        let tool_call_message = make_tool_call_message("task-1", "req-1", "call-1", shell_tool());
+        let assistant_message_id = tool_call_message.id.clone();
+
+        assert_build_request_blocked(
+            request_params(
+                vec![user_message.clone(), tool_call_message.clone()],
+                vec![user_query_input("continue")],
+            ),
+            "MissingResultWithoutRepairSource",
+        );
+
+        let pending_report = classify_byop_controller_readiness_with_live_tool_calls(
+            &request_params(
+                vec![user_message.clone(), tool_call_message.clone()],
+                vec![user_query_input("continue")],
+            ),
+            vec![LiveToolCall::new(
+                ToolCallRef::new(
+                    ToolCallKey::new("task-1", assistant_message_id, "call-1"),
+                    kind(),
+                ),
+                LiveToolCallState::Running,
+            )],
+        );
+        assert!(matches!(
+            pending_report.state,
+            ReadinessState::PendingToolResults { ref tool_calls }
+                if tool_calls.len() == 1 && tool_calls[0].key.tool_call_id == "call-1"
+        ));
+        let ReadinessState::PendingToolResults { tool_calls } = pending_report.state else {
+            panic!("expected pending tool results");
+        };
+        let pending_error = PendingByopToolResultsError::new(tool_calls.len());
+        assert_eq!(
+            pending_error.category(),
+            ReadinessCategory::PendingToolResults
+        );
+        assert_eq!(pending_error.tool_call_count(), 1);
+        assert!(
+            !pending_error
+                .to_string()
+                .contains(BLOCKED_BYOP_REQUEST_MESSAGE),
+            "pending wait must remain distinct from blocked user-facing errors"
+        );
+
+        let request = build_openai_request(&request_params(
+            vec![user_message, tool_call_message],
+            vec![
+                cancelled_action_result_input("call-1"),
+                user_query_input("continue"),
+            ],
+        ))
+        .expect("current cancellation result should serialize as a real tool result");
+        let errors = strict_chat_completions_ordering_errors(&request.messages);
+        assert!(
+            errors.is_empty(),
+            "request body ordering errors: {errors:?}"
+        );
+        assert_request_has_no_repair_placeholder(&request);
+
+        let contents = tool_response_contents(&request, "call-1");
+        assert_eq!(contents.len(), 1);
+        assert!(
+            contents[0].to_ascii_lowercase().contains("cancel"),
+            "expected real cancellation content, got {}",
+            contents[0]
+        );
+    }
+
+    #[test]
+    fn controller_readiness_requires_cancellation_commit_before_user_boundary() {
+        let tool_call_message = make_tool_call_message("task-1", "req-1", "call-1", shell_tool());
+        let params = request_params(
+            vec![tool_call_message],
+            vec![
+                cancelled_action_result_input("call-1"),
+                user_query_input("continue"),
+            ],
+        );
+
+        let report = classify_byop_controller_readiness(&params);
+
+        assert!(matches!(
+            report.state,
+            ReadinessState::NeedsCancellationCommit { ref tool_calls }
+                if tool_calls.len() == 1
+                    && tool_calls[0].key.tool_call_id == "call-1"
+        ));
+    }
+
+    #[test]
+    fn controller_readiness_ignores_duplicate_current_cancellation_after_persistence() {
+        let tool_call_message = make_tool_call_message("task-1", "req-1", "call-1", shell_tool());
+        let tool_result_message = make_tool_call_result_message(
+            "task-1",
+            "req-1",
+            "call-1".to_owned(),
+            r#"{"status":"cancelled"}"#.to_owned(),
+        );
+        let params = request_params(
+            vec![tool_call_message, tool_result_message],
+            vec![
+                cancelled_action_result_input("call-1"),
+                user_query_input("continue"),
+            ],
+        );
+
+        let report = classify_byop_controller_readiness(&params);
+
+        assert!(matches!(report.state, ReadinessState::Ready));
+    }
+
+    #[test]
+    fn controller_readiness_accepts_committed_local_interception_results() {
+        let carrier =
+            make_tool_call_carrier_message("task-1", "req-1", "call-1", "todowrite", "{}");
+        let local_result = make_tool_call_result_message(
+            "task-1",
+            "req-1",
+            "call-1".to_owned(),
+            r#"{"_byop_intercepted":true,"status":"ok"}"#.to_owned(),
+        );
+        let invalid_arguments_result = make_tool_call_result_message(
+            "task-1",
+            "req-1",
+            "call-2".to_owned(),
+            r#"{"error":"invalid_arguments","tool":"dummy"}"#.to_owned(),
+        );
+        let invalid_arguments_carrier =
+            make_tool_call_carrier_message("task-1", "req-1", "call-2", "dummy", "{}");
+        let params = request_params(
+            vec![
+                carrier,
+                local_result,
+                invalid_arguments_carrier,
+                invalid_arguments_result,
+            ],
+            vec![],
+        );
+
+        let report = classify_byop_controller_readiness(&params);
+
+        assert!(matches!(report.state, ReadinessState::Ready));
+    }
+
+    #[test]
+    fn controller_readiness_blocks_unreadable_local_interception_payload() {
+        let carrier =
+            make_tool_call_carrier_message("task-1", "req-1", "call-1", "todowrite", "{}");
+        let unreadable_result = make_tool_call_result_message(
+            "task-1",
+            "req-1",
+            "call-1".to_owned(),
+            r#"{"_byop_intercepted":true,"status":"ok""#.to_owned(),
+        );
+        let params = request_params(vec![carrier, unreadable_result], vec![]);
+
+        let report = classify_byop_controller_readiness(&params);
+
+        assert!(matches!(
+            report.state,
+            ReadinessState::MissingResultWithoutRepairSource {
+                reason: crate::ai::byop_readiness::MissingResultReason::UnreadableLocalInterception,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn controller_readiness_reports_pending_live_action() {
+        let tool_call_message = make_tool_call_message("task-1", "req-1", "call-1", shell_tool());
+        let assistant_message_id = tool_call_message.id.clone();
+        let params = request_params(vec![tool_call_message], vec![]);
+
+        let report = classify_byop_controller_readiness_with_live_tool_calls(
+            &params,
+            vec![LiveToolCall::new(
+                ToolCallRef::new(
+                    ToolCallKey::new("task-1", assistant_message_id, "call-1"),
+                    kind(),
+                ),
+                LiveToolCallState::Running,
+            )],
+        );
+
+        assert!(matches!(
+            report.state,
+            ReadinessState::PendingToolResults { ref tool_calls }
+                if tool_calls.len() == 1 && tool_calls[0].key.tool_call_id == "call-1"
+        ));
+    }
+
+    #[test]
+    fn normal_flow_missing_result_blocks_before_placeholder_repair() {
+        assert_blocked_category(
+            vec![assistant_calls("task-1", "assistant-1", &["call-1"])],
+            "MissingResultWithoutRepairSource",
+        );
+    }
+
+    #[test]
+    fn duplicate_orphan_and_out_of_order_results_block_serialization() {
+        assert_blocked_category(
+            vec![
+                assistant_calls("task-1", "assistant-1", &["call-1"]),
+                result(
+                    "task-1",
+                    "result-1",
+                    Some("assistant-1"),
+                    "call-1",
+                    ToolResultSource::PersistedHistory,
+                ),
+                result(
+                    "task-1",
+                    "result-2",
+                    Some("assistant-1"),
+                    "call-1",
+                    ToolResultSource::PersistedHistory,
+                ),
+            ],
+            "DuplicateToolResults",
+        );
+        assert_blocked_category(
+            vec![result(
+                "task-1",
+                "result-1",
+                Some("assistant-missing"),
+                "call-1",
+                ToolResultSource::PersistedHistory,
+            )],
+            "OrphanToolResult",
+        );
+        assert_blocked_category(
+            vec![
+                assistant_calls("task-1", "assistant-1", &["call-1"]),
+                ProjectionItem::user_boundary("task-1", "user-2"),
+                result(
+                    "task-1",
+                    "result-1",
+                    Some("assistant-1"),
+                    "call-1",
+                    ToolResultSource::PersistedHistory,
+                ),
+            ],
+            "OutOfOrderToolResult",
+        );
+    }
+
+    #[test]
+    fn visible_boundaries_block_pending_tool_groups_but_filtered_messages_do_not() {
+        assert_blocked_category(
+            vec![
+                assistant_calls("task-1", "assistant-1", &["call-1"]),
+                ProjectionItem::other_boundary("task-1", "visible-other"),
+            ],
+            "MissingResultWithoutRepairSource",
+        );
+
+        let report = validate_serializer_readiness_projection(vec![
+            assistant_calls("task-1", "assistant-1", &["call-1"]),
+            result(
+                "task-1",
+                "result-1",
+                Some("assistant-1"),
+                "call-1",
+                ToolResultSource::PersistedHistory,
+            ),
+        ])
+        .expect("filtered-out messages should not affect readiness");
+        assert_eq!(report.state, ReadinessState::Ready);
+    }
+
+    #[test]
+    fn current_input_action_result_satisfies_serializer_readiness() {
+        let report = validate_serializer_readiness_projection(vec![
+            assistant_calls("task-1", "assistant-1", &["call-1"]),
+            result(
+                "task-1",
+                "current_input:0:call-1",
+                None,
+                "call-1",
+                ToolResultSource::CurrentInput,
+            ),
+        ])
+        .expect("current input result should satisfy a visible tool call");
+        assert_eq!(report.state, ReadinessState::Ready);
+    }
+
+    #[test]
+    fn accepted_history_repair_is_sendable_but_distinct_from_ready() {
+        let repair = RepairRecord::new(
+            RepairSource::ForkedHistory,
+            ToolCallKey::new("task-1", "assistant-1", "call-1"),
+        );
+        let report = validate_serializer_readiness_projection_with_repair_state(
+            vec![assistant_calls("task-1", "assistant-1", &["call-1"])],
+            &RepairStateStatus::Valid(RepairState::new(vec![repair.clone()])),
+            &ReadinessDiagnosticContext::new(
+                "test-conversation",
+                "test-attempt",
+                ReadinessTriggerLayer::SerializerValidation,
+            ),
+        )
+        .expect("accepted repair should be sendable");
+
+        assert_eq!(
+            report.state,
+            ReadinessState::AcceptedHistoryRepair {
+                repairs: vec![AcceptedRepair {
+                    record: repair,
+                    tool_call: ToolCallRef::new(
+                        ToolCallKey::new("task-1", "assistant-1", "call-1"),
+                        kind(),
+                    ),
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_repair_sidecar_does_not_block_ready_projection() {
+        let report = validate_serializer_readiness_projection_with_repair_state(
+            vec![
+                assistant_calls("task-1", "assistant-1", &["call-1"]),
+                result(
+                    "task-1",
+                    "result-1",
+                    Some("assistant-1"),
+                    "call-1",
+                    ToolResultSource::PersistedHistory,
+                ),
+            ],
+            &RepairStateStatus::from_sidecar_json(Some("{not valid json".to_owned())),
+            &ReadinessDiagnosticContext::new(
+                "test-conversation",
+                "test-attempt",
+                ReadinessTriggerLayer::SerializerValidation,
+            ),
+        )
+        .expect("valid real results should not need repair authorization");
+
+        assert_eq!(report.state, ReadinessState::Ready);
+    }
+
+    fn make_tool_call(call_id: &str) -> ToolCall {
+        ToolCall {
+            call_id: call_id.to_owned(),
+            fn_name: "dummy".to_owned(),
+            fn_arguments: serde_json::json!({}),
+            thought_signatures: None,
+        }
+    }
+
+    fn assistant_with_calls(call_ids: &[&str]) -> ChatMessage {
+        ChatMessage::from(
+            call_ids
+                .iter()
+                .map(|call_id| make_tool_call(call_id))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn tool_response(call_id: &str) -> ChatMessage {
+        ChatMessage::from(ToolResponse::new(call_id.to_owned(), "{}".to_owned()))
+    }
+
+    fn strict_chat_completions_ordering_errors(messages: &[ChatMessage]) -> Vec<String> {
+        let mut errors = Vec::new();
+        let mut pending_call_ids: Vec<String> = Vec::new();
+        let mut seen_tool_results: HashSet<String> = HashSet::new();
+
+        for (idx, msg) in messages.iter().enumerate() {
+            if !pending_call_ids.is_empty() && msg.role != ChatRole::Tool {
+                errors.push(format!(
+                    "message {idx} role {:?} appeared before pending tool responses {:?}",
+                    msg.role, pending_call_ids
+                ));
+            }
+
+            if msg.role == ChatRole::Assistant {
+                let tool_call_ids: Vec<String> = msg
+                    .content
+                    .tool_calls()
+                    .iter()
+                    .map(|tool_call| tool_call.call_id.clone())
+                    .collect();
+                if !tool_call_ids.is_empty() {
+                    pending_call_ids = tool_call_ids;
+                }
+            } else if msg.role == ChatRole::Tool {
+                let responses = msg.content.tool_responses();
+                if pending_call_ids.is_empty() {
+                    errors.push(format!("message {idx} is an orphan tool response"));
+                }
+                for response in responses {
+                    if !seen_tool_results.insert(response.call_id.clone()) {
+                        errors.push(format!("duplicate tool result id {}", response.call_id));
+                    }
+                    match pending_call_ids.first() {
+                        Some(expected_call_id) if expected_call_id == &response.call_id => {
+                            pending_call_ids.remove(0);
+                        }
+                        Some(expected_call_id) => {
+                            if let Some(pos) = pending_call_ids
+                                .iter()
+                                .position(|call_id| call_id == &response.call_id)
+                            {
+                                errors.push(format!(
+                                    "out-of-order tool result id {} expected {}",
+                                    response.call_id, expected_call_id
+                                ));
+                                pending_call_ids.remove(pos);
+                            } else {
+                                errors.push(format!("orphan tool result id {}", response.call_id));
+                            }
+                        }
+                        None => {
+                            errors.push(format!("orphan tool result id {}", response.call_id));
+                        }
+                    }
+                }
+            }
+        }
+
+        if !pending_call_ids.is_empty() {
+            errors.push(format!(
+                "request ended with pending tool responses {:?}",
+                pending_call_ids
+            ));
+        }
+
+        errors
+    }
+
+    #[test]
+    fn strict_request_body_checker_accepts_ordered_tool_responses() {
+        let messages = vec![
+            ChatMessage::user("hi"),
+            assistant_with_calls(&["a", "b"]),
+            tool_response("a"),
+            tool_response("b"),
+            ChatMessage::user("continue"),
+        ];
+
+        assert!(strict_chat_completions_ordering_errors(&messages).is_empty());
+    }
+
+    #[test]
+    fn strict_request_body_checker_rejects_orphans_duplicates_and_early_boundaries() {
+        let orphan = vec![ChatMessage::user("hi"), tool_response("a")];
+        assert!(strict_chat_completions_ordering_errors(&orphan)
+            .iter()
+            .any(|error| error.contains("orphan")));
+
+        let duplicate = vec![
+            ChatMessage::user("hi"),
+            assistant_with_calls(&["a"]),
+            tool_response("a"),
+            tool_response("a"),
+        ];
+        assert!(strict_chat_completions_ordering_errors(&duplicate)
+            .iter()
+            .any(|error| error.contains("duplicate")));
+
+        let early_boundary = vec![
+            ChatMessage::user("hi"),
+            assistant_with_calls(&["a"]),
+            ChatMessage::user("too soon"),
+            tool_response("a"),
+        ];
+        assert!(strict_chat_completions_ordering_errors(&early_boundary)
+            .iter()
+            .any(|error| error.contains("before pending")));
+
+        let out_of_order = vec![
+            ChatMessage::user("hi"),
+            assistant_with_calls(&["a", "b"]),
+            tool_response("b"),
+            tool_response("a"),
+        ];
+        assert!(strict_chat_completions_ordering_errors(&out_of_order)
+            .iter()
+            .any(|error| error.contains("out-of-order")));
+    }
+
+    #[test]
+    fn build_chat_request_body_rejects_missing_duplicate_orphan_and_out_of_order_history() {
+        assert_build_request_blocked(
+            request_params(
+                vec![
+                    make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                    make_tool_call_message("task-1", "req-1", "call-1", shell_tool()),
+                ],
+                vec![],
+            ),
+            "MissingResultWithoutRepairSource",
+        );
+
+        assert_build_request_blocked(
+            request_params(
+                vec![
+                    make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                    make_tool_call_message("task-1", "req-1", "call-1", shell_tool()),
+                    make_tool_call_result_message(
+                        "task-1",
+                        "req-1",
+                        "call-1".to_owned(),
+                        r#"{"status":"ok"}"#.to_owned(),
+                    ),
+                    make_tool_call_result_message(
+                        "task-1",
+                        "req-1",
+                        "call-1".to_owned(),
+                        r#"{"status":"ok-again"}"#.to_owned(),
+                    ),
+                ],
+                vec![],
+            ),
+            "DuplicateToolResults",
+        );
+
+        assert_build_request_blocked(
+            request_params(
+                vec![
+                    make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                    make_tool_call_result_message(
+                        "task-1",
+                        "req-1",
+                        "call-1".to_owned(),
+                        r#"{"status":"orphan"}"#.to_owned(),
+                    ),
+                ],
+                vec![],
+            ),
+            "OrphanToolResult",
+        );
+
+        assert_build_request_blocked(
+            request_params(
+                vec![
+                    make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                    make_tool_call_message("task-1", "req-1", "call-1", shell_tool()),
+                    make_user_query_message("task-1", "req-2", "too soon".to_owned(), &[]),
+                    make_tool_call_result_message(
+                        "task-1",
+                        "req-2",
+                        "call-1".to_owned(),
+                        r#"{"status":"late"}"#.to_owned(),
+                    ),
+                ],
+                vec![],
+            ),
+            "OutOfOrderToolResult",
+        );
+    }
+
+    #[test]
+    fn build_chat_request_body_accepts_current_input_tool_result() {
+        let params = request_params(
+            vec![
+                make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                make_tool_call_message("task-1", "req-1", "call-1", shell_tool()),
+            ],
+            vec![
+                cancelled_action_result_input("call-1"),
+                user_query_input("continue"),
+            ],
+        );
+
+        let request = build_openai_request(&params).expect("current input result should serialize");
+        let errors = strict_chat_completions_ordering_errors(&request.messages);
+        assert!(
+            errors.is_empty(),
+            "request body ordering errors: {errors:?}"
+        );
+        assert_request_has_no_repair_placeholder(&request);
+    }
+
+    #[test]
+    fn build_chat_request_body_ignores_filtered_subagent_tool_call_result() {
+        let params = request_params(
+            vec![
+                make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                make_tool_call_message("task-1", "req-1", "subagent-call-1", subagent_tool()),
+                make_tool_call_result_message(
+                    "task-1",
+                    "req-1",
+                    "subagent-call-1".to_owned(),
+                    r#"{"status":"spawned"}"#.to_owned(),
+                ),
+            ],
+            vec![],
+        );
+
+        let request =
+            build_openai_request(&params).expect("filtered subagent result should not block");
+        let errors = strict_chat_completions_ordering_errors(&request.messages);
+        assert!(
+            errors.is_empty(),
+            "request body ordering errors: {errors:?}"
+        );
+        assert!(
+            request
+                .messages
+                .iter()
+                .flat_map(|message| message.content.tool_responses())
+                .all(|response| response.call_id != "subagent-call-1"),
+            "filtered subagent ToolCallResult must not be sent outbound"
+        );
+    }
+
+    #[test]
+    fn build_chat_request_body_emits_structured_repair_placeholder_only_for_accepted_repair() {
+        let tool_call_message = make_tool_call_message("task-1", "req-1", "call-1", shell_tool());
+        let assistant_message_id = tool_call_message.id.clone();
+        let repair = RepairRecord::new(
+            RepairSource::ForkedHistory,
+            ToolCallKey::new("task-1", assistant_message_id, "call-1"),
+        );
+        let params = request_params_with_repair(
+            vec![
+                make_user_query_message("task-1", "req-1", "hi".to_owned(), &[]),
+                tool_call_message,
+            ],
+            vec![],
+            RepairState::new(vec![repair]),
+        );
+
+        let request = build_openai_request(&params).expect("accepted repair should serialize");
+        let response = request
+            .messages
+            .iter()
+            .flat_map(|message| message.content.tool_responses())
+            .find(|response| response.call_id == "call-1")
+            .expect("repair placeholder response should be present");
+        let payload: serde_json::Value =
+            serde_json::from_str(&response.content).expect("placeholder should be JSON");
+        let object = payload
+            .as_object()
+            .expect("placeholder should be an object");
+
+        assert_eq!(
+            object.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from([
+                "status".to_string(),
+                "reason".to_string(),
+                "note".to_string()
+            ])
+        );
+        assert_eq!(payload["status"], "unavailable");
+        assert_eq!(payload["reason"], "forked_history_repair");
+        assert_eq!(
+            payload["note"],
+            "tool result was unavailable in repaired conversation history"
+        );
+        assert!(!response.content.contains("(tool 执行结果未保留)"));
+        assert!(
+            params.tasks[0].messages.iter().all(|message| !matches!(
+                message.message,
+                Some(api::message::Message::ToolCallResult(_))
+            )),
+            "accepted repair placeholders must remain outbound-only"
+        );
+    }
+
+    #[test]
+    fn accepted_repair_log_summary_includes_source_counts_and_redacted_keys() {
+        let repairs = vec![
+            AcceptedRepair {
+                record: RepairRecord::new(
+                    RepairSource::ForkedHistory,
+                    ToolCallKey::new("task-1", "assistant-1", "call-1"),
+                ),
+                tool_call: ToolCallRef::new(
+                    ToolCallKey::new("task-1", "assistant-1", "call-1"),
+                    kind(),
+                ),
+            },
+            AcceptedRepair {
+                record: RepairRecord::new(
+                    RepairSource::RestoredLegacyHistory,
+                    ToolCallKey::new("task-1", "assistant-2", "call-2"),
+                ),
+                tool_call: ToolCallRef::new(
+                    ToolCallKey::new("task-1", "assistant-2", "call-2"),
+                    RedactedToolKind::new("local_interception:webfetch"),
+                ),
+            },
+        ];
+        let context = ReadinessDiagnosticContext::new(
+            "conversation-1",
+            "attempt-1",
+            ReadinessTriggerLayer::SerializerValidation,
+        );
+
+        let message = accepted_history_repair_log_message(&repairs, &context);
+
+        assert!(message.contains("serializer accepted history repair"));
+        assert!(message.contains("records=2"));
+        assert!(message.contains("category=AcceptedHistoryRepair"));
+        assert!(message.contains("forked_history=1"));
+        assert!(message.contains("restored_legacy_history=1"));
+        assert!(message.contains("conversation_id=conversation-1"));
+        assert!(message.contains("trigger_layer=serializer_validation"));
+        assert!(message.contains("request_attempt_id=attempt-1"));
+        assert!(message.contains("task_id=task-1"));
+        assert!(message.contains("assistant_tool_call_message_id=assistant-1"));
+        assert!(message.contains("tool_call_id=call-1"));
+        assert!(message.contains("redacted_tool_kind=local_interception:webfetch"));
+        assert!(!message.contains(REPAIR_PLACEHOLDER_NOTE));
+        assert!(!message.contains("secret user prompt"));
+        assert!(!message.contains("raw tool arguments"));
+        assert!(!message.contains("raw tool output"));
+        assert!(!message.contains("raw local interception payload"));
+    }
+
+    #[test]
+    fn build_chat_request_body_honors_compaction_filtering_boundaries() {
+        let hidden_user = make_user_query_message("task-1", "req-1", "hidden".to_owned(), &[]);
+        let hidden_call = make_tool_call_message("task-1", "req-1", "hidden-call", shell_tool());
+        let summary_user = make_user_query_message("task-1", "req-2", "/compact".to_owned(), &[]);
+        let summary_assistant =
+            make_agent_output_message("task-1", "req-2", "redacted summary".to_owned());
+        let visible_user = make_user_query_message("task-1", "req-3", "visible".to_owned(), &[]);
+
+        let mut compaction_state = CompactionState::default();
+        compaction_state.push_completed(CompletedCompaction {
+            user_msg_id: summary_user.id.clone(),
+            assistant_msg_id: summary_assistant.id.clone(),
+            head_message_ids: vec![hidden_user.id.clone(), hidden_call.id.clone()],
+            tail_start_id: Some(visible_user.id.clone()),
+            summary_text: Some("redacted summary".to_owned()),
+            auto: false,
+            overflow: false,
+        });
+
+        let mut params = request_params(
+            vec![
+                hidden_user.clone(),
+                hidden_call.clone(),
+                summary_user.clone(),
+                summary_assistant.clone(),
+                visible_user.clone(),
+            ],
+            vec![],
+        );
+        params.compaction_state = Some(compaction_state.clone());
+
+        let request = build_openai_request(&params)
+            .expect("hidden historical tool-call gap should not block");
+        let errors = strict_chat_completions_ordering_errors(&request.messages);
+        assert!(
+            errors.is_empty(),
+            "request body ordering errors: {errors:?}"
+        );
+        assert_request_has_no_repair_placeholder(&request);
+
+        let visible_call = make_tool_call_message("task-1", "req-3", "visible-call", shell_tool());
+        let mut params = request_params(
+            vec![
+                hidden_user,
+                hidden_call,
+                summary_user,
+                summary_assistant,
+                visible_user,
+                visible_call,
+            ],
+            vec![],
+        );
+        params.compaction_state = Some(compaction_state);
+
+        assert_build_request_blocked(params, "MissingResultWithoutRepairSource");
+    }
+}
+
+/// **accepted history repair outbound 修复行为验证**:
+///
+/// 本模块只覆盖已经由 `RepairRecord` 明确授权的 outbound 修复。普通 normal flow
+/// 缺失结果必须先被 readiness 阻断,不能再走这里补占位。
+#[cfg(test)]
+mod accepted_history_repair_tests {
+    use super::*;
+    use crate::ai::byop_readiness::{RepairRecord, ToolCallKey, ToolCallRef};
     use genai::chat::{ChatMessage, ChatRole, ToolCall};
 
     fn make_tool_call(call_id: &str) -> ToolCall {
@@ -4987,6 +6656,70 @@ mod sanitize_tool_call_pairs_tests {
             .collect()
     }
 
+    fn accepted_repair(key: ToolCallKey, source: RepairSource) -> AcceptedRepair {
+        AcceptedRepair {
+            record: RepairRecord::new(source, key.clone()),
+            tool_call: ToolCallRef::new(key, RedactedToolKind::new("shell")),
+        }
+    }
+
+    fn outbound_groups_for_messages(messages: &[ChatMessage]) -> Vec<OutboundAssistantToolGroup> {
+        let mut groups = Vec::new();
+        let mut assistant_group_number = 0;
+        for (message_index, message) in messages.iter().enumerate() {
+            if message.role != ChatRole::Assistant || message.content.tool_calls().is_empty() {
+                continue;
+            }
+
+            assistant_group_number += 1;
+            let assistant_message_id = format!("assistant-{assistant_group_number}");
+            groups.push(OutboundAssistantToolGroup {
+                message_index,
+                tool_call_keys: message
+                    .content
+                    .tool_calls()
+                    .iter()
+                    .map(|tool_call| {
+                        ToolCallKey::new("task-1", &assistant_message_id, &tool_call.call_id)
+                    })
+                    .collect(),
+            });
+        }
+
+        groups
+    }
+
+    fn repairs_for_groups(groups: &[OutboundAssistantToolGroup]) -> Vec<AcceptedRepair> {
+        groups
+            .iter()
+            .flat_map(|group| {
+                group
+                    .tool_call_keys
+                    .iter()
+                    .cloned()
+                    .map(|key| accepted_repair(key, RepairSource::ForkedHistory))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    fn repair_messages(messages: &mut Vec<ChatMessage>) {
+        let groups = outbound_groups_for_messages(messages);
+        let repairs = repairs_for_groups(&groups);
+        repair_tool_call_pairs_for_accepted_history_gaps(messages, &repairs, &groups);
+    }
+
+    fn assert_structured_repair_payload(content: &str, reason: &str) {
+        let payload: serde_json::Value =
+            serde_json::from_str(content).expect("repair placeholder should be JSON");
+        assert_eq!(payload["status"], "unavailable");
+        assert_eq!(payload["reason"], reason);
+        assert_eq!(
+            payload["note"],
+            "tool result was unavailable in repaired conversation history"
+        );
+    }
+
     /// 正常 push 路径:[user, asst(a,b), tool_a, tool_b] → 合并为单条 bundled,不补码。
     #[test]
     fn normal_push_path_merges_adjacent_tool_messages_without_placeholder() {
@@ -4996,7 +6729,7 @@ mod sanitize_tool_call_pairs_tests {
             tool_response("a", "resp_a"),
             tool_response("b", "resp_b"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3, "两条相邻 Tool 合并为一条");
         assert_eq!(msgs[0].role, ChatRole::User);
@@ -5017,7 +6750,7 @@ mod sanitize_tool_call_pairs_tests {
     #[test]
     fn fork_truncated_missing_all_tool_responses_inserts_placeholders() {
         let mut msgs = vec![ChatMessage::user("q"), assistant_with_calls(&["a", "b"])];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3, "Assistant 后必须补一条 Tool message");
         assert_eq!(msgs[2].role, ChatRole::Tool);
@@ -5027,10 +6760,7 @@ mod sanitize_tool_call_pairs_tests {
             vec!["a".to_owned(), "b".to_owned()]
         );
         for (_, content) in &responses {
-            assert!(
-                content.contains("未保留"),
-                "placeholder 内容应含提示文本: {content}"
-            );
+            assert_structured_repair_payload(content, "forked_history_repair");
         }
     }
 
@@ -5043,14 +6773,14 @@ mod sanitize_tool_call_pairs_tests {
             assistant_with_calls(&["a", "b"]),
             tool_response("a", "real_a"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[2].role, ChatRole::Tool);
         let responses = responses_of(&msgs[2]);
         assert_eq!(responses[0], ("a".to_owned(), "real_a".to_owned()));
         assert_eq!(responses[1].0, "b".to_owned());
-        assert!(responses[1].1.contains("未保留"));
+        assert_structured_repair_payload(&responses[1].1, "forked_history_repair");
     }
 
     /// 孤儿 ToolResponse(call_id 不在 Assistant.tool_calls 里)被丢弃,不会污染输出。
@@ -5062,7 +6792,7 @@ mod sanitize_tool_call_pairs_tests {
             tool_response("a", "real_a"),
             tool_response("z", "orphan_z"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3, "两条相邻 Tool 合并,孤儿 z 丢弃");
         let responses = responses_of(&msgs[2]);
@@ -5083,7 +6813,7 @@ mod sanitize_tool_call_pairs_tests {
             tool_response("b", "real_b"),
             tool_response("a", "real_a"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3);
         assert_eq!(
@@ -5105,7 +6835,7 @@ mod sanitize_tool_call_pairs_tests {
             ChatMessage::user("interrupt"),
             tool_response("a", "real_a"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 4);
         assert_eq!(msgs[0].role, ChatRole::User);
@@ -5128,7 +6858,7 @@ mod sanitize_tool_call_pairs_tests {
             tool_response("a", "real_a_v1"),
             tool_response("a", "real_a_v2"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[2].role, ChatRole::Tool);
@@ -5150,7 +6880,7 @@ mod sanitize_tool_call_pairs_tests {
             tool_response("a", "real_a"),
             tool_response("a", "(tool 执行结果未保留)"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 3);
         assert_eq!(
@@ -5170,7 +6900,7 @@ mod sanitize_tool_call_pairs_tests {
             ChatMessage::user("interrupt"),
             tool_response("a", "real_a"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         assert_eq!(msgs.len(), 4);
         assert_eq!(msgs[2].role, ChatRole::Tool);
@@ -5193,7 +6923,7 @@ mod sanitize_tool_call_pairs_tests {
             assistant_with_calls(&["c"]),
             tool_response("c", "real_c"),
         ];
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
 
         // 期望结果:user, asst(a,b), bundled(a,b), user, asst(c), bundled(c)
         assert_eq!(msgs.len(), 6);
@@ -5220,10 +6950,79 @@ mod sanitize_tool_call_pairs_tests {
             ChatMessage::assistant("plain reply"),
         ];
         let before = msgs.len();
-        sanitize_tool_call_pairs(&mut msgs);
+        repair_messages(&mut msgs);
         assert_eq!(msgs.len(), before);
         assert_eq!(msgs[1].role, ChatRole::Assistant);
         assert!(msgs[1].content.tool_calls().is_empty());
+    }
+
+    #[test]
+    fn accepted_repair_placeholder_is_authorized_by_full_tool_call_key() {
+        let first_key = ToolCallKey::new("task-1", "assistant-1", "dup");
+        let second_key = ToolCallKey::new("task-2", "assistant-2", "dup");
+        let mut msgs = vec![
+            ChatMessage::user("q1"),
+            assistant_with_calls(&["dup"]),
+            ChatMessage::user("q2"),
+            assistant_with_calls(&["dup"]),
+            tool_response("dup", "real_second"),
+        ];
+        let groups = vec![
+            OutboundAssistantToolGroup {
+                message_index: 1,
+                tool_call_keys: vec![first_key.clone()],
+            },
+            OutboundAssistantToolGroup {
+                message_index: 3,
+                tool_call_keys: vec![second_key],
+            },
+        ];
+        let repairs = vec![accepted_repair(first_key, RepairSource::ForkedHistory)];
+
+        repair_tool_call_pairs_for_accepted_history_gaps(&mut msgs, &repairs, &groups);
+
+        assert_eq!(msgs.len(), 6);
+        assert_eq!(msgs[2].role, ChatRole::Tool);
+        let first_responses = responses_of(&msgs[2]);
+        assert_eq!(first_responses[0].0, "dup");
+        assert_structured_repair_payload(&first_responses[0].1, "forked_history_repair");
+        assert_eq!(msgs[5].role, ChatRole::Tool);
+        assert_eq!(
+            responses_of(&msgs[5]),
+            vec![("dup".to_owned(), "real_second".to_owned())],
+            "重复 call_id 的真实结果必须留在自己的 Assistant group 后"
+        );
+    }
+
+    #[test]
+    fn unavailable_json_with_non_repair_reason_is_not_placeholder() {
+        let real_unavailable =
+            r#"{"status":"unavailable","reason":"service_down","note":"try later"}"#;
+        assert!(!is_placeholder_tool_response_content(real_unavailable));
+        assert!(!is_placeholder_tool_response_content(
+            r#"{"status":"unavailable","reason":"forked_history_repair","note":"tool result was unavailable in repaired conversation history","extra":true}"#,
+        ));
+        assert!(is_placeholder_tool_response_content(
+            &repair_placeholder_content(RepairSource::ForkedHistory)
+        ));
+
+        let mut msgs = vec![
+            ChatMessage::user("q1"),
+            assistant_with_calls(&["a"]),
+            tool_response("a", real_unavailable),
+            tool_response(
+                "a",
+                &repair_placeholder_content(RepairSource::ForkedHistory),
+            ),
+        ];
+        repair_messages(&mut msgs);
+
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(
+            responses_of(&msgs[2]),
+            vec![("a".to_owned(), real_unavailable.to_owned())],
+            "真实 unavailable JSON 不能被 repair placeholder 覆盖"
+        );
     }
 }
 

--- a/app/src/ai/api_error.rs
+++ b/app/src/ai/api_error.rs
@@ -1,3 +1,4 @@
+use crate::ai::byop_readiness::BlockedByopReadinessError;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use warp_core::errors::{AnyhowErrorExt, ErrorExt};
@@ -161,9 +162,25 @@ impl AIApiError {
             | AIApiError::ServerOverloaded
             | AIApiError::Deserialization(_)
             | AIApiError::NoContextFound
-            | AIApiError::Other(_)
             | AIApiError::Stream { .. } => true,
+            AIApiError::Other(error) => error.downcast_ref::<BlockedByopReadinessError>().is_none(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::byop_readiness::{BlockedByopReadinessError, ReadinessCategory};
+
+    #[test]
+    fn byop_blocked_readiness_error_is_not_retryable() {
+        let error = AIApiError::Other(
+            BlockedByopReadinessError::new(ReadinessCategory::MissingResultWithoutRepairSource)
+                .into(),
+        );
+
+        assert!(!error.is_retryable());
     }
 }
 

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -579,6 +579,37 @@ impl BlocklistAIActionModel {
         has_pending || has_running
     }
 
+    pub(super) fn has_unfinished_action_for_tool_call(
+        &self,
+        conversation_id: AIConversationId,
+        task_id: &str,
+        action_id: &str,
+        app: &AppContext,
+    ) -> bool {
+        let action_id = crate::ai::agent::AIAgentActionId::from(action_id.to_owned());
+        let has_pending = self
+            .pending_actions
+            .get(&conversation_id)
+            .is_some_and(|queue| {
+                queue
+                    .iter()
+                    .any(|action| action.id == action_id && action.task_id.to_string() == task_id)
+            });
+        let has_running = self
+            .running_actions
+            .get(&conversation_id)
+            .is_some_and(|running| running.contains(&action_id))
+            && self
+                .executor
+                .as_ref(app)
+                .async_executing_action(&action_id)
+                .is_some_and(|action| {
+                    action.id == action_id && action.task_id.to_string() == task_id
+                });
+
+        has_pending || has_running
+    }
+
     /// Returns finished action results received from the most recent AI output for the active conversation.
     pub fn get_finished_action_results(
         &self,
@@ -1112,6 +1143,51 @@ impl BlocklistAIActionModel {
             .into_iter()
             .map(|result| (*result).clone())
             .collect_vec()
+    }
+
+    pub(super) fn finished_action_results_matching(
+        &self,
+        conversation_id: AIConversationId,
+        keys: &HashSet<(String, String)>,
+    ) -> Vec<AIAgentActionResult> {
+        self.finished_action_results
+            .get(&conversation_id)
+            .into_iter()
+            .flat_map(|results| results.iter())
+            .filter(|result| keys.contains(&(result.task_id.to_string(), result.id.to_string())))
+            .map(|result| (**result).clone())
+            .collect_vec()
+    }
+
+    pub(super) fn remove_finished_action_results_matching(
+        &mut self,
+        conversation_id: AIConversationId,
+        keys: &HashSet<(String, String)>,
+    ) -> usize {
+        let mut should_remove_bucket = false;
+        let mut removed = 0;
+        if let Some(results) = self.finished_action_results.get_mut(&conversation_id) {
+            let mut index = 0;
+            while index < results.len() {
+                let key = (
+                    results[index].task_id.to_string(),
+                    results[index].id.to_string(),
+                );
+                if keys.contains(&key) {
+                    let result = results.remove(index);
+                    self.past_action_results.insert(result.id.clone(), result);
+                    removed += 1;
+                } else {
+                    index += 1;
+                }
+            }
+            should_remove_bucket = results.is_empty();
+        }
+        if should_remove_bucket {
+            self.action_order.remove(&conversation_id);
+            self.finished_action_results.remove(&conversation_id);
+        }
+        removed
     }
 
     /// Clears finished action results for a conversation. Used when reverting.

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -32,6 +32,11 @@ use crate::ai::agent::{
 use crate::ai::agent::{DocumentContentAttachmentSource, FileContext};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::api_error::AIApiError;
+use crate::ai::byop_readiness::{
+    BlockedByopReadinessError, PendingByopToolResultsError, ReadinessCategory,
+    ReadinessDiagnosticCoalescer, ReadinessDiagnosticContext, ReadinessDiagnosticLevel,
+    ReadinessTriggerLayer, BLOCKED_BYOP_REQUEST_MESSAGE,
+};
 use crate::ai::document::ai_document_model::{
     AIDocumentId, AIDocumentModel, AIDocumentUserEditStatus,
 };
@@ -191,7 +196,7 @@ pub enum BlocklistAIControllerEvent {
     ExportConversationToFile { filename: Option<String> },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RequestInput {
     pub conversation_id: AIConversationId,
     pub input_messages: HashMap<TaskId, Vec<AIAgentInput>>,
@@ -204,6 +209,14 @@ pub struct RequestInput {
     pub request_start_ts: DateTime<Local>,
     pub supported_tools_override: Option<Vec<ToolType>>,
 }
+
+struct RequestConversationSnapshot {
+    conversation_data: api::ConversationData,
+    parent_agent_id: Option<String>,
+    agent_name: Option<String>,
+}
+
+const BYOP_PREFLIGHT_MAX_ITERATIONS: usize = 3;
 
 impl RequestInput {
     fn for_task(
@@ -261,6 +274,21 @@ impl RequestInput {
     pub fn with_supported_tools(mut self, tools: Vec<ToolType>) -> Self {
         self.supported_tools_override = Some(tools);
         self
+    }
+
+    fn remove_action_results_by_tool_call_id(&mut self, keys: &HashSet<(String, String)>) -> usize {
+        let mut removed = 0;
+        for inputs in self.input_messages.values_mut() {
+            let before = inputs.len();
+            inputs.retain(|input| {
+                let AIAgentInput::ActionResult { result, .. } = input else {
+                    return true;
+                };
+                !keys.contains(&(result.task_id.to_string(), result.id.to_string()))
+            });
+            removed += before - inputs.len();
+        }
+        removed
     }
 
     fn new_with_common_fields(
@@ -730,7 +758,16 @@ impl BlocklistAIController {
             is_queued_prompt,
             ctx,
         ) {
-            log::error!("Failed to send agent request: {e:?}");
+            if let Some(pending) = e.downcast_ref::<PendingByopToolResultsError>() {
+                log::debug!(
+                    "[byop-readiness] request is waiting for pending tool result(s) \
+                     category={:?} tool_calls={}",
+                    pending.category(),
+                    pending.tool_call_count()
+                );
+            } else {
+                log::error!("Failed to send agent request: {e:?}");
+            }
         }
     }
 
@@ -1770,6 +1807,763 @@ impl BlocklistAIController {
             .expect("Conversation exists- was just created.")
     }
 
+    fn conversation_snapshot_for_request(
+        &self,
+        request_input: &RequestInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<RequestConversationSnapshot> {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let Some(conversation) = history_model
+            .as_ref(ctx)
+            .conversation(&request_input.conversation_id)
+        else {
+            return Err(anyhow!(
+                "Tried to send request for non-existent conversation with ID {:?}",
+                request_input.conversation_id
+            ));
+        };
+
+        let active_tasks = conversation.compute_active_tasks();
+        let conversation_id = conversation.id();
+        let conversation_data = api::ConversationData {
+            id: conversation_id,
+            tasks: active_tasks,
+            server_conversation_token: conversation.server_conversation_token().cloned(),
+            forked_from_conversation_token: conversation
+                .forked_from_server_conversation_token()
+                .cloned(),
+            ambient_agent_task_id: self.ambient_agent_task_id,
+            existing_suggestions: history_model
+                .as_ref(ctx)
+                .existing_suggestions_for_conversation(conversation_id)
+                .cloned(),
+        };
+
+        Ok(RequestConversationSnapshot {
+            conversation_data,
+            parent_agent_id: conversation.parent_agent_id().map(str::to_string),
+            agent_name: conversation.agent_name().map(str::to_string),
+        })
+    }
+
+    fn build_request_params_for_input(
+        &self,
+        request_input: &RequestInput,
+        conversation_data: api::ConversationData,
+        query_metadata: Option<RequestMetadata>,
+        parent_agent_id: Option<String>,
+        agent_name: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) -> api::RequestParams {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let conversation_id = conversation_data.id;
+        let mut request_params = api::RequestParams::new(
+            Some(self.terminal_view_id),
+            SessionContext::from_session(self.active_session.as_ref(ctx), ctx),
+            request_input,
+            conversation_data,
+            query_metadata,
+            ctx,
+        );
+        request_params.parent_agent_id = parent_agent_id;
+        request_params.agent_name = agent_name;
+
+        let compaction_cfg = crate::ai::byop_compaction::CompactionConfig::from_settings(ctx);
+        history_model.update(ctx, |history_model, _ctx| {
+            if let Some(convo) = history_model.conversation_mut(&conversation_id) {
+                crate::ai::byop_compaction::commit::prune_now(convo, &compaction_cfg);
+            }
+        });
+        if let Some(convo) = history_model.as_ref(ctx).conversation(&conversation_id) {
+            request_params.compaction_state = Some(convo.compaction_state.clone());
+            request_params.byop_repair_state = convo.byop_repair_state.clone();
+        }
+
+        self.populate_lrc_request_params(&mut request_params, conversation_id);
+        request_params
+    }
+
+    fn populate_lrc_request_params(
+        &self,
+        request_params: &mut api::RequestParams,
+        conversation_id: AIConversationId,
+    ) {
+        let terminal_model = self.terminal_model.lock();
+        let active_block = terminal_model.block_list().active_block();
+        let is_lrc_tagged_in = active_block.is_agent_tagged_in();
+        let is_matching_lrc_agent = active_block.is_agent_in_control()
+            && active_block
+                .agent_interaction_metadata()
+                .is_some_and(|metadata| metadata.conversation_id() == &conversation_id);
+        if !is_lrc_tagged_in && !is_matching_lrc_agent {
+            return;
+        }
+
+        request_params.lrc_command_id = Some(active_block.id().to_string());
+        request_params.lrc_should_spawn_subagent = is_lrc_tagged_in;
+
+        if let Some(running_command) = byop_get_running_command_for_lrc(&terminal_model) {
+            request_params.lrc_running_command = Some(running_command.clone());
+            let total_inputs = request_params.input.len();
+            let mut filled_count = 0usize;
+            for input in request_params.input.iter_mut() {
+                if let crate::ai::agent::AIAgentInput::UserQuery {
+                    running_command: rc_slot @ None,
+                    ..
+                } = input
+                {
+                    *rc_slot = Some(running_command.clone());
+                    filled_count += 1;
+                }
+            }
+            log::info!(
+                "[byop-diag] LRC running_command filled: {filled_count}/{total_inputs} \
+                 UserQuery slot(s); should_spawn={} grid_contents_len={} command={:?} is_alt_screen={}",
+                request_params.lrc_should_spawn_subagent,
+                running_command.grid_contents.len(),
+                running_command.command,
+                running_command.is_alt_screen_active
+            );
+        } else {
+            log::warn!(
+                "[byop-diag] LRC detected but byop_get_running_command_for_lrc \
+                 returned None (active_block 状态不符)"
+            );
+        }
+    }
+
+    fn run_byop_request_preflight(
+        &mut self,
+        request_input: &mut RequestInput,
+        conversation_data: &mut api::ConversationData,
+        request_params: &mut api::RequestParams,
+        query_metadata: Option<RequestMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        if crate::ai::agent_providers::lookup_byop(ctx, &request_params.model).is_none() {
+            return Ok(());
+        }
+
+        let readiness_attempt_id = request_params
+            .byop_readiness_attempt_id
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        request_params.byop_readiness_attempt_id = Some(readiness_attempt_id.clone());
+        let conversation_id_for_log = conversation_data.id.to_string();
+        let mut diagnostics = ReadinessDiagnosticCoalescer::default();
+
+        for iteration in 0..BYOP_PREFLIGHT_MAX_ITERATIONS {
+            let removed_persisted = self.remove_persisted_byop_action_results_from_input(
+                conversation_data.id,
+                request_input,
+                ctx,
+            );
+            if removed_persisted > 0 {
+                log::debug!(
+                    "[byop-readiness] controller preflight removed {removed_persisted} \
+                     already-persisted action result(s) from current input \
+                     iteration={iteration}"
+                );
+                self.rebuild_request_after_byop_preflight(
+                    request_input,
+                    conversation_data,
+                    request_params,
+                    query_metadata.clone(),
+                    ctx,
+                )?;
+                request_params.byop_readiness_attempt_id = Some(readiness_attempt_id.clone());
+                continue;
+            }
+
+            let committed_current_results = self.commit_byop_current_action_results(
+                conversation_data.id,
+                request_input,
+                request_params,
+                ctx,
+            )?;
+            if committed_current_results > 0 {
+                log::debug!(
+                    "[byop-readiness] controller persisted current action result(s) \
+                     progress={committed_current_results} iteration={iteration}"
+                );
+                self.rebuild_request_after_byop_preflight(
+                    request_input,
+                    conversation_data,
+                    request_params,
+                    query_metadata.clone(),
+                    ctx,
+                )?;
+                request_params.byop_readiness_attempt_id = Some(readiness_attempt_id.clone());
+                continue;
+            }
+
+            let committed_finished_results = self.commit_byop_finished_action_results(
+                conversation_data.id,
+                request_params,
+                ctx,
+            )?;
+            if committed_finished_results > 0 {
+                log::debug!(
+                    "[byop-readiness] controller drained finished action result(s) \
+                     progress={committed_finished_results} iteration={iteration}"
+                );
+                self.rebuild_request_after_byop_preflight(
+                    request_input,
+                    conversation_data,
+                    request_params,
+                    query_metadata.clone(),
+                    ctx,
+                )?;
+                request_params.byop_readiness_attempt_id = Some(readiness_attempt_id.clone());
+                continue;
+            }
+
+            let live_tool_calls =
+                self.byop_unfinished_live_tool_calls(conversation_data.id, request_params, ctx);
+            let report =
+                crate::ai::agent_providers::chat_stream::classify_byop_controller_readiness_with_live_tool_calls(
+                    request_params,
+                    live_tool_calls,
+                );
+            match report.state {
+                crate::ai::byop_readiness::ReadinessState::Ready
+                | crate::ai::byop_readiness::ReadinessState::AcceptedHistoryRepair { .. } => {
+                    return Ok(());
+                }
+                crate::ai::byop_readiness::ReadinessState::NeedsCancellationCommit {
+                    tool_calls,
+                } => {
+                    let diagnostic_context = ReadinessDiagnosticContext::new(
+                        &conversation_id_for_log,
+                        &readiness_attempt_id,
+                        ReadinessTriggerLayer::ControllerPreflight,
+                    )
+                    .with_iteration(iteration);
+                    diagnostics.log_state(
+                        &crate::ai::byop_readiness::ReadinessState::NeedsCancellationCommit {
+                            tool_calls: tool_calls.clone(),
+                        },
+                        &diagnostic_context,
+                        ReadinessDiagnosticLevel::Debug,
+                    );
+                    let progress = self.commit_byop_cancellation_results(
+                        conversation_data.id,
+                        request_input,
+                        &tool_calls,
+                        ctx,
+                    )?;
+                    if progress == 0 {
+                        log::error!(
+                            "[byop-readiness] controller preflight made no cancellation progress \
+                             iteration={iteration} tool_calls={}",
+                            tool_calls.len()
+                        );
+                        diagnostics.finish(&diagnostic_context, ReadinessDiagnosticLevel::Error);
+                        return Err(BlockedByopReadinessError::new(
+                            ReadinessCategory::NeedsCancellationCommit,
+                        )
+                        .into());
+                    }
+                    log::debug!(
+                        "[byop-readiness] controller committed cancellation result(s) \
+                         progress={progress} iteration={iteration}"
+                    );
+                    self.rebuild_request_after_byop_preflight(
+                        request_input,
+                        conversation_data,
+                        request_params,
+                        query_metadata.clone(),
+                        ctx,
+                    )?;
+                    request_params.byop_readiness_attempt_id = Some(readiness_attempt_id.clone());
+                }
+                crate::ai::byop_readiness::ReadinessState::PendingToolResults { tool_calls } => {
+                    let diagnostic_context = ReadinessDiagnosticContext::new(
+                        &conversation_id_for_log,
+                        &readiness_attempt_id,
+                        ReadinessTriggerLayer::ControllerPreflight,
+                    )
+                    .with_iteration(iteration);
+                    diagnostics.log_state(
+                        &crate::ai::byop_readiness::ReadinessState::PendingToolResults {
+                            tool_calls: tool_calls.clone(),
+                        },
+                        &diagnostic_context,
+                        ReadinessDiagnosticLevel::Debug,
+                    );
+                    diagnostics.finish(&diagnostic_context, ReadinessDiagnosticLevel::Debug);
+                    return Err(PendingByopToolResultsError::new(tool_calls.len()).into());
+                }
+                state => {
+                    let category = state.category();
+                    let diagnostic_context = ReadinessDiagnosticContext::new(
+                        &conversation_id_for_log,
+                        &readiness_attempt_id,
+                        ReadinessTriggerLayer::ControllerPreflight,
+                    )
+                    .with_iteration(iteration);
+                    diagnostics.log_state(
+                        &state,
+                        &diagnostic_context,
+                        ReadinessDiagnosticLevel::Error,
+                    );
+                    diagnostics.finish(&diagnostic_context, ReadinessDiagnosticLevel::Error);
+                    log::error!(
+                        "[byop-readiness] controller blocked request category={category:?} \
+                         conversation_id={} trigger_layer=controller_preflight \
+                         request_attempt_id={} iteration={iteration}",
+                        conversation_id_for_log,
+                        readiness_attempt_id
+                    );
+                    return Err(BlockedByopReadinessError::new(category).into());
+                }
+            }
+        }
+
+        let diagnostic_context = ReadinessDiagnosticContext::new(
+            &conversation_id_for_log,
+            &readiness_attempt_id,
+            ReadinessTriggerLayer::ControllerPreflight,
+        );
+        diagnostics.log_category(
+            ReadinessCategory::ReadinessLoopDidNotConverge,
+            &diagnostic_context,
+            ReadinessDiagnosticLevel::Error,
+        );
+        diagnostics.finish(&diagnostic_context, ReadinessDiagnosticLevel::Error);
+        log::error!(
+            "[byop-readiness] controller preflight did not converge iterations={} \
+             conversation_id={} request_attempt_id={}",
+            BYOP_PREFLIGHT_MAX_ITERATIONS,
+            conversation_id_for_log,
+            readiness_attempt_id
+        );
+        Err(BlockedByopReadinessError::new(ReadinessCategory::ReadinessLoopDidNotConverge).into())
+    }
+
+    fn rebuild_request_after_byop_preflight(
+        &self,
+        request_input: &RequestInput,
+        conversation_data: &mut api::ConversationData,
+        request_params: &mut api::RequestParams,
+        query_metadata: Option<RequestMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let snapshot = self.conversation_snapshot_for_request(request_input, ctx)?;
+        *conversation_data = snapshot.conversation_data.clone();
+        *request_params = self.build_request_params_for_input(
+            request_input,
+            snapshot.conversation_data,
+            query_metadata,
+            snapshot.parent_agent_id,
+            snapshot.agent_name,
+            ctx,
+        );
+        Ok(())
+    }
+
+    fn remove_persisted_byop_action_results_from_input(
+        &self,
+        conversation_id: AIConversationId,
+        request_input: &mut RequestInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> usize {
+        let keys = request_input
+            .all_inputs()
+            .filter_map(|input| {
+                let AIAgentInput::ActionResult { result, .. } = input else {
+                    return None;
+                };
+                let task_id = result.task_id.to_string();
+                let tool_call_id = result.id.to_string();
+                self.has_persisted_tool_result(conversation_id, &task_id, &tool_call_id, ctx)
+                    .then_some((task_id, tool_call_id))
+            })
+            .collect::<HashSet<_>>();
+        request_input.remove_action_results_by_tool_call_id(&keys)
+    }
+
+    fn commit_byop_current_action_results(
+        &self,
+        conversation_id: AIConversationId,
+        request_input: &mut RequestInput,
+        request_params: &api::RequestParams,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<usize> {
+        let visible_tool_calls = Self::visible_byop_tool_result_keys(request_params);
+        let results = request_input
+            .all_inputs()
+            .filter_map(|input| {
+                let AIAgentInput::ActionResult { result, .. } = input else {
+                    return None;
+                };
+                if result.result.is_cancelled() {
+                    return None;
+                }
+                visible_tool_calls
+                    .contains(&(result.task_id.to_string(), result.id.to_string()))
+                    .then(|| result.clone())
+            })
+            .collect_vec();
+        let keys_to_remove = Self::action_result_keys(&results);
+        let appended = self.append_byop_action_result_messages(conversation_id, &results, ctx)?;
+        let removed = request_input.remove_action_results_by_tool_call_id(&keys_to_remove);
+        Ok(appended + removed)
+    }
+
+    fn commit_byop_finished_action_results(
+        &self,
+        conversation_id: AIConversationId,
+        request_params: &api::RequestParams,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<usize> {
+        let visible_tool_calls = Self::visible_byop_tool_result_keys(request_params);
+        let results = self
+            .action_model
+            .as_ref(ctx)
+            .finished_action_results_matching(conversation_id, &visible_tool_calls);
+        let keys_to_remove = Self::action_result_keys(&results);
+        let appended = self.append_byop_action_result_messages(conversation_id, &results, ctx)?;
+        let removed = self.action_model.update(ctx, |action_model, _| {
+            action_model.remove_finished_action_results_matching(conversation_id, &keys_to_remove)
+        });
+        Ok(appended + removed)
+    }
+
+    fn append_byop_action_result_messages(
+        &self,
+        conversation_id: AIConversationId,
+        results: &[AIAgentActionResult],
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<usize> {
+        let request_id = format!("byop-preflight:{}", uuid::Uuid::new_v4());
+        let mut grouped_messages: HashMap<TaskId, Vec<warp_multi_agent_api::Message>> =
+            HashMap::new();
+        for result in results {
+            let task_id = result.task_id.to_string();
+            let tool_call_id = result.id.to_string();
+            if self.has_persisted_tool_result(conversation_id, &task_id, &tool_call_id, ctx) {
+                continue;
+            }
+            grouped_messages
+                .entry(result.task_id.clone())
+                .or_default()
+                .push(Self::byop_action_result_message(&request_id, result));
+        }
+
+        let mut appended = 0;
+        for (task_id, messages) in grouped_messages {
+            appended +=
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.append_byop_preflight_messages_to_task(
+                        conversation_id,
+                        task_id,
+                        messages,
+                        ctx,
+                    )
+                })?;
+        }
+        Ok(appended)
+    }
+
+    fn byop_unfinished_live_tool_calls(
+        &self,
+        conversation_id: AIConversationId,
+        request_params: &api::RequestParams,
+        ctx: &mut ModelContext<Self>,
+    ) -> Vec<crate::ai::byop_readiness::LiveToolCall> {
+        use crate::ai::agent::task::helper::{ToolCallExt, ToolExt};
+
+        request_params
+            .tasks
+            .iter()
+            .flat_map(|task| task.messages.iter())
+            .filter_map(|msg| {
+                let message::Message::ToolCall(tool_call) = msg.message.as_ref()? else {
+                    return None;
+                };
+                if tool_call.subagent().is_some()
+                    || !self
+                        .action_model
+                        .as_ref(ctx)
+                        .has_unfinished_action_for_tool_call(
+                            conversation_id,
+                            &msg.task_id,
+                            &tool_call.tool_call_id,
+                            ctx,
+                        )
+                {
+                    return None;
+                }
+                Some(crate::ai::byop_readiness::LiveToolCall::new(
+                    crate::ai::byop_readiness::ToolCallRef::new(
+                        crate::ai::byop_readiness::ToolCallKey::new(
+                            &msg.task_id,
+                            &msg.id,
+                            &tool_call.tool_call_id,
+                        ),
+                        crate::ai::byop_readiness::RedactedToolKind::new(
+                            tool_call
+                                .tool
+                                .as_ref()
+                                .map(|tool| tool.name())
+                                .unwrap_or("unknown"),
+                        ),
+                    ),
+                    crate::ai::byop_readiness::LiveToolCallState::Running,
+                ))
+            })
+            .collect()
+    }
+
+    fn visible_byop_tool_result_keys(
+        request_params: &api::RequestParams,
+    ) -> HashSet<(String, String)> {
+        use crate::ai::agent::task::helper::ToolCallExt;
+
+        request_params
+            .tasks
+            .iter()
+            .flat_map(|task| task.messages.iter())
+            .filter_map(|msg| {
+                let message::Message::ToolCall(tool_call) = msg.message.as_ref()? else {
+                    return None;
+                };
+                if tool_call.subagent().is_some() {
+                    return None;
+                }
+                Some((msg.task_id.clone(), tool_call.tool_call_id.clone()))
+            })
+            .collect()
+    }
+
+    fn action_result_keys(results: &[AIAgentActionResult]) -> HashSet<(String, String)> {
+        results
+            .iter()
+            .map(|result| (result.task_id.to_string(), result.id.to_string()))
+            .collect()
+    }
+
+    fn commit_byop_cancellation_results(
+        &self,
+        conversation_id: AIConversationId,
+        request_input: &mut RequestInput,
+        tool_calls: &[crate::ai::byop_readiness::ToolCallRef],
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<usize> {
+        let wanted = tool_calls
+            .iter()
+            .map(|tool_call| {
+                (
+                    tool_call.key.task_id.clone(),
+                    tool_call.key.tool_call_id.clone(),
+                )
+            })
+            .collect::<HashSet<_>>();
+        let request_id = format!("byop-preflight:{}", uuid::Uuid::new_v4());
+        let mut grouped_messages: HashMap<TaskId, Vec<warp_multi_agent_api::Message>> =
+            HashMap::new();
+        let mut keys_to_remove = HashSet::new();
+
+        for input in request_input.all_inputs() {
+            let AIAgentInput::ActionResult { result, .. } = input else {
+                continue;
+            };
+            if !result.result.is_cancelled() {
+                continue;
+            }
+
+            let task_id = result.task_id.to_string();
+            let tool_call_id = result.id.to_string();
+            let key = (task_id.clone(), tool_call_id.clone());
+            if !wanted.contains(&key) {
+                continue;
+            }
+
+            keys_to_remove.insert(key.clone());
+            if self.has_persisted_tool_result(conversation_id, &task_id, &tool_call_id, ctx) {
+                continue;
+            }
+
+            grouped_messages
+                .entry(result.task_id.clone())
+                .or_default()
+                .push(Self::byop_action_result_message(&request_id, result));
+        }
+
+        let mut appended = 0;
+        for (task_id, messages) in grouped_messages {
+            appended +=
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.append_byop_preflight_messages_to_task(
+                        conversation_id,
+                        task_id,
+                        messages,
+                        ctx,
+                    )
+                })?;
+        }
+
+        let removed = request_input.remove_action_results_by_tool_call_id(&keys_to_remove);
+        Ok(appended + removed)
+    }
+
+    fn has_persisted_tool_result(
+        &self,
+        conversation_id: AIConversationId,
+        task_id: &str,
+        tool_call_id: &str,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let task_id = TaskId::new(task_id.to_owned());
+        BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|conversation| conversation.get_task(&task_id))
+            .is_some_and(|task| {
+                task.messages().any(|msg| {
+                    matches!(
+                        msg.message.as_ref(),
+                        Some(message::Message::ToolCallResult(result))
+                            if result.tool_call_id == tool_call_id
+                    )
+                })
+            })
+    }
+
+    fn byop_action_result_message(
+        request_id: &str,
+        result: &AIAgentActionResult,
+    ) -> warp_multi_agent_api::Message {
+        let structured_result =
+            crate::ai::agent_providers::tools::action_result_to_msg_result(result);
+        let server_message_data = if structured_result.is_none() {
+            let status = if result.result.is_cancelled() {
+                "cancelled"
+            } else {
+                "completed"
+            };
+            crate::ai::agent_providers::tools::serialize_action_result(result).unwrap_or_else(
+                || {
+                    serde_json::json!({
+                        "status": status,
+                        "result": result.result.to_string(),
+                    })
+                    .to_string()
+                },
+            )
+        } else {
+            String::new()
+        };
+
+        warp_multi_agent_api::Message {
+            id: uuid::Uuid::new_v4().to_string(),
+            task_id: result.task_id.to_string(),
+            server_message_data,
+            citations: vec![],
+            message: Some(message::Message::ToolCallResult(message::ToolCallResult {
+                tool_call_id: result.id.to_string(),
+                context: None,
+                result: structured_result,
+            })),
+            request_id: request_id.to_owned(),
+            timestamp: None,
+        }
+    }
+
+    fn complete_byop_blocked_request(
+        &mut self,
+        request_input: RequestInput,
+        conversation_id: AIConversationId,
+        model_id: LLMId,
+        is_queued_prompt: bool,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+        let response_stream_id = ResponseStreamId::new_local();
+        let input_contains_user_query = request_input
+            .all_inputs()
+            .any(|input| input.is_user_query());
+        let is_passive_request = request_input
+            .all_inputs()
+            .any(|input| input.is_passive_request());
+
+        for input in request_input.all_inputs() {
+            if let AIAgentInput::UserQuery {
+                referenced_attachments,
+                ..
+            } = input
+            {
+                self.maybe_populate_plans_for_ai_document_model(
+                    referenced_attachments,
+                    conversation_id,
+                    ctx,
+                );
+            }
+        }
+
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+            history_model.update_conversation_for_new_request_input(
+                request_input,
+                response_stream_id.clone(),
+                self.terminal_view_id,
+                ctx,
+            )?;
+            history_model.update_conversation_status(
+                self.terminal_view_id,
+                conversation_id,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            Ok::<(), anyhow::Error>(())
+        })?;
+
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+            history_model.mark_response_stream_completed_with_error(
+                RenderableAIError::Other {
+                    error_message: BLOCKED_BYOP_REQUEST_MESSAGE.to_owned(),
+                    will_attempt_resume: false,
+                    waiting_for_network: false,
+                },
+                &response_stream_id,
+                conversation_id,
+                self.terminal_view_id,
+                ctx,
+            );
+        });
+
+        if input_contains_user_query {
+            let pending_document_id = self.context_model.as_ref(ctx).pending_document_id();
+            self.context_model.update(ctx, |context_model, ctx| {
+                context_model.reset_context_to_default(ctx);
+            });
+            if let Some(doc_id) = pending_document_id {
+                AIDocumentModel::handle(ctx).update(ctx, |model, mctx| {
+                    model.set_user_edit_status(&doc_id, AIDocumentUserEditStatus::UpToDate, mctx);
+                });
+            }
+        }
+
+        ctx.emit(BlocklistAIControllerEvent::SentRequest {
+            contains_user_query: input_contains_user_query,
+            is_queued_prompt,
+            model_id,
+            stream_id: response_stream_id.clone(),
+        });
+        if !is_passive_request {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                history_model.mark_active_conversation_id(
+                    conversation_id,
+                    self.terminal_view_id,
+                    ctx,
+                )
+            });
+        }
+        if input_contains_user_query {
+            ctx.dispatch_global_action("workspace:save_app", ());
+        }
+
+        Ok((conversation_id, response_stream_id))
+    }
+
     /// Attempts to send a request to the AI model API. Adds context to the input if it
     /// contains a user query. Returns `Err` if the AI input was not able to be sent due to an
     /// existing in-flight request. Emits an event containing a receiver for the AI's output.
@@ -1783,7 +2577,7 @@ impl BlocklistAIController {
     /// flow that handles existing conversations properly.
     fn send_request_input(
         &mut self,
-        request_input: RequestInput,
+        mut request_input: RequestInput,
         query_metadata: Option<RequestMetadata>,
         default_to_follow_up_on_success: bool,
         can_attempt_resume_on_error: bool,
@@ -1791,37 +2585,9 @@ impl BlocklistAIController {
         ctx: &mut ModelContext<Self>,
     ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
-        let (
-            conversation_id,
-            conversation_server_token,
-            conversation_forked_from_token,
-            active_tasks,
-            parent_agent_id,
-            agent_name,
-        ) = {
-            let Some(conversation) = history_model
-                .as_ref(ctx)
-                .conversation(&request_input.conversation_id)
-            else {
-                return Err(anyhow!(
-                    "Tried to send request for non-existent conversation with ID {:?}",
-                    request_input.conversation_id
-                ));
-            };
-
-            let active_tasks = conversation.compute_active_tasks();
-
-            (
-                conversation.id(),
-                conversation.server_conversation_token().cloned(),
-                conversation
-                    .forked_from_server_conversation_token()
-                    .cloned(),
-                active_tasks,
-                conversation.parent_agent_id().map(str::to_string),
-                conversation.agent_name().map(str::to_string),
-            )
-        };
+        let request_snapshot = self.conversation_snapshot_for_request(&request_input, ctx)?;
+        let mut conversation_data = request_snapshot.conversation_data;
+        let conversation_id = conversation_data.id;
 
         // Cancel any pending auto-resume for this conversation, since the user is sending a new
         // request.
@@ -1840,13 +2606,15 @@ impl BlocklistAIController {
         {
             send_telemetry_from_ctx!(
                 TelemetryEvent::AIInputNotSent {
-                    entrypoint: query_metadata.map(|metadata| metadata.entrypoint),
+                    entrypoint: query_metadata.as_ref().map(|metadata| metadata.entrypoint),
                     inputs: request_input
                         .all_inputs()
                         .cloned()
                         .map(|input| input.into())
                         .collect(),
-                    active_server_conversation_id: conversation_server_token.clone(),
+                    active_server_conversation_id: conversation_data
+                        .server_conversation_token
+                        .clone(),
                     active_client_conversation_id: Some(conversation_id),
                 },
                 ctx
@@ -1857,18 +2625,6 @@ impl BlocklistAIController {
             return Err(anyhow::anyhow!(AI_INPUT_NOT_SENT_ERROR_STR));
         }
 
-        let conversation_data = api::ConversationData {
-            id: conversation_id,
-            tasks: active_tasks,
-            server_conversation_token: conversation_server_token,
-            forked_from_conversation_token: conversation_forked_from_token,
-            ambient_agent_task_id: self.ambient_agent_task_id,
-            existing_suggestions: history_model
-                .as_ref(ctx)
-                .existing_suggestions_for_conversation(conversation_id)
-                .cloned(),
-        };
-
         // Log an error if tool call results do not have corresponding tool calls in task context
         validate_tool_call_results(
             request_input.all_inputs(),
@@ -1876,85 +2632,56 @@ impl BlocklistAIController {
             &conversation_data.server_conversation_token,
         );
 
-        let mut request_params = api::RequestParams::new(
-            Some(self.terminal_view_id),
-            SessionContext::from_session(self.active_session.as_ref(ctx), ctx),
+        let mut request_params = self.build_request_params_for_input(
             &request_input,
             conversation_data.clone(),
-            query_metadata,
+            query_metadata.clone(),
+            request_snapshot.parent_agent_id,
+            request_snapshot.agent_name,
             ctx,
         );
-        request_params.parent_agent_id = parent_agent_id;
-        request_params.agent_name = agent_name;
-
-        // OpenWarp BYOP 本地会话压缩:
-        //   1. 自动 prune 旧 tool output(对齐 opencode `compaction.ts:297-341` prune)
-        //   2. 把 conversation.compaction_state.clone() 注入 request_params
-        //
-        // chat_stream::build_chat_request 会据此投影 messages(隐去已压缩区间 + 替换 compacted tool output);
-        // SummarizeConversation input 路径还会切 head + 拼 SUMMARY_TEMPLATE。
-        // 非 BYOP 路径(走 server protobuf)不读这个字段,无副作用。
-        let compaction_cfg = crate::ai::byop_compaction::CompactionConfig::from_settings(ctx);
-        history_model.update(ctx, |history_model, _ctx| {
-            if let Some(convo) = history_model.conversation_mut(&conversation_id) {
-                crate::ai::byop_compaction::commit::prune_now(convo, &compaction_cfg);
+        if let Err(error) = self.run_byop_request_preflight(
+            &mut request_input,
+            &mut conversation_data,
+            &mut request_params,
+            query_metadata.clone(),
+            ctx,
+        ) {
+            if let Some(pending) = error.downcast_ref::<PendingByopToolResultsError>() {
+                log::debug!(
+                    "[byop-readiness] BYOP request not opened; waiting for pending tool \
+                     result(s) category={:?} tool_calls={} conversation_id={} \
+                     request_attempt_id={}",
+                    pending.category(),
+                    pending.tool_call_count(),
+                    conversation_data.id,
+                    request_params
+                        .byop_readiness_attempt_id
+                        .as_deref()
+                        .unwrap_or("unknown")
+                );
+                return Err(error);
             }
-        });
-        if let Some(convo) = history_model.as_ref(ctx).conversation(&conversation_id) {
-            request_params.compaction_state = Some(convo.compaction_state.clone());
-        }
-
-        // OpenWarp BYOP:检测当前请求是否绑定 LRC(alt-screen 长命令)。
-        // - tag-in 首轮:注入 command_id + running_command,并让 chat_stream 合成 subagent
-        //   CreateTask 事件来升级 master 路径已经创建的 optimistic CLI subtask。
-        // - 已进入 agent control 的后续轮:auto-resume / tool result 仍要注入 command_id
-        //   与最新 PTY 快照,但不能重复 spawn subagent。
-        {
-            let terminal_model = self.terminal_model.lock();
-            let active_block = terminal_model.block_list().active_block();
-            let is_lrc_tagged_in = active_block.is_agent_tagged_in();
-            let is_matching_lrc_agent = active_block.is_agent_in_control()
-                && active_block
-                    .agent_interaction_metadata()
-                    .is_some_and(|metadata| metadata.conversation_id() == &conversation_id);
-            if is_lrc_tagged_in || is_matching_lrc_agent {
-                request_params.lrc_command_id = Some(active_block.id().to_string());
-                request_params.lrc_should_spawn_subagent = is_lrc_tagged_in;
-
-                // OpenWarp A3:把完整 RunningCommand 注入到本轮 UserQuery 中,
-                // 严格对齐上游 `get_running_command` 的 grid_contents 提取逻辑
-                // (alt-screen 走 alt_screen.grid_handler,非 alt-screen 走 output_grid)。
-                // 之前用 `output_to_string_force_full_grid_contents()` 在 nvim 等
-                // alt-screen TUI 下取到空字符串,导致 prefix 块为空,模型说看不到 command_id。
-                if let Some(running_command) = byop_get_running_command_for_lrc(&terminal_model) {
-                    request_params.lrc_running_command = Some(running_command.clone());
-                    let total_inputs = request_params.input.len();
-                    let mut filled_count = 0usize;
-                    for input in request_params.input.iter_mut() {
-                        if let crate::ai::agent::AIAgentInput::UserQuery {
-                            running_command: rc_slot @ None,
-                            ..
-                        } = input
-                        {
-                            *rc_slot = Some(running_command.clone());
-                            filled_count += 1;
-                        }
-                    }
-                    log::info!(
-                        "[byop-diag] LRC running_command filled: {filled_count}/{total_inputs} \
-                         UserQuery slot(s); should_spawn={} grid_contents_len={} command={:?} is_alt_screen={}",
-                        request_params.lrc_should_spawn_subagent,
-                        running_command.grid_contents.len(),
-                        running_command.command,
-                        running_command.is_alt_screen_active
-                    );
-                } else {
-                    log::warn!(
-                        "[byop-diag] LRC detected but byop_get_running_command_for_lrc \
-                         returned None (active_block 状态不符)"
-                    );
-                }
+            if let Some(blocked) = error.downcast_ref::<BlockedByopReadinessError>() {
+                log::error!(
+                    "[byop-readiness] rendering blocked request error category={:?} \
+                     conversation_id={} request_attempt_id={}",
+                    blocked.category(),
+                    conversation_data.id,
+                    request_params
+                        .byop_readiness_attempt_id
+                        .as_deref()
+                        .unwrap_or("unknown")
+                );
+                return self.complete_byop_blocked_request(
+                    request_input,
+                    conversation_data.id,
+                    request_params.model.clone(),
+                    is_queued_prompt,
+                    ctx,
+                );
             }
+            return Err(error);
         }
 
         let server_conversation_token_for_identifiers =

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -16,6 +16,7 @@ use crate::{
         AIAgentInput, AIIdentifiers, CancellationReason,
     },
     ai::blocklist::BlocklistAIHistoryModel,
+    ai::byop_readiness::BlockedByopReadinessError,
     network::NetworkStatus,
     report_error, send_telemetry_from_ctx,
 };
@@ -168,6 +169,10 @@ fn pending_title_generation_from_byop(
 pub struct ResponseStreamId(String);
 
 impl ResponseStreamId {
+    pub fn new_local() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
     pub fn for_shared_session(init_event: &response_event::StreamInit) -> Self {
         // Make the stream ID unique per viewing by appending a local UUID
         // This prevents collisions when replaying the same conversation multiple times
@@ -177,7 +182,7 @@ impl ResponseStreamId {
 
     #[cfg(test)]
     pub fn new_for_test() -> Self {
-        Self(Uuid::new_v4().to_string())
+        Self::new_local()
     }
 }
 
@@ -424,6 +429,10 @@ impl ResponseStream {
             }
             Err(e) => {
                 log::error!("Failed to send request to multi-agent API: {e:?}");
+                let api_error = convert_to_api_error(e);
+                ctx.emit(ResponseStreamEvent::ReceivedEvent(Consumable::new(Err(
+                    Arc::new(api_error),
+                ))));
                 self.on_response_stream_complete(request_id, ctx);
             }
         }
@@ -548,6 +557,22 @@ impl ResponseStream {
         }
         ctx.emit(ResponseStreamEvent::AfterStreamFinished { cancellation: None });
         self.cancellation_tx = None;
+    }
+}
+
+fn convert_to_api_error(error: ConvertToAPITypeError) -> AIApiError {
+    match &error {
+        ConvertToAPITypeError::Other(inner)
+            if inner.downcast_ref::<BlockedByopReadinessError>().is_some() =>
+        {
+            let blocked = inner
+                .downcast_ref::<BlockedByopReadinessError>()
+                .expect("checked blocked readiness error");
+            AIApiError::Other(BlockedByopReadinessError::new(blocked.category()).into())
+        }
+        ConvertToAPITypeError::Ignore
+        | ConvertToAPITypeError::Unimplemented(_)
+        | ConvertToAPITypeError::Other(_) => AIApiError::Other(anyhow!(error.to_string())),
     }
 }
 

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -28,6 +28,9 @@ use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::agent::CancellationReason;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
+use crate::ai::byop_readiness::{
+    RepairRecord, RepairSource, RepairState, RepairStateStatus, ToolCallKey,
+};
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::input_suggestions::HistoryOrder;
 use crate::persistence::model::AgentConversationData;
@@ -542,6 +545,22 @@ impl BlocklistAIHistoryModel {
         Ok(())
     }
 
+    pub fn append_byop_preflight_messages_to_task(
+        &mut self,
+        conversation_id: AIConversationId,
+        task_id: TaskId,
+        messages: Vec<warp_multi_agent_api::Message>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<usize, UpdateHistoryError> {
+        let conversation = self
+            .conversations_by_id
+            .get_mut(&conversation_id)
+            .ok_or(UpdateHistoryError::ConversationNotFound(conversation_id))?;
+        conversation
+            .append_byop_preflight_messages_to_task(task_id, messages, ctx)
+            .map_err(UpdateHistoryError::from)
+    }
+
     pub fn restore_conversations(
         &mut self,
         terminal_view_id: EntityId,
@@ -989,7 +1008,13 @@ impl BlocklistAIHistoryModel {
             .filter_map(|t| t.source().cloned())
             .collect();
 
-        let updated_tasks_with_new_ids = update_forked_task_properties(tasks, prefix);
+        let updated_tasks_with_new_ids = update_forked_task_properties(tasks.clone(), prefix);
+        let byop_repair_state_json = byop_fork_repair_state_json(
+            &tasks,
+            &updated_tasks_with_new_ids,
+            &source_conversation.byop_repair_state,
+            None,
+        );
         let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(app)
             .get()
             .model_event_sender
@@ -1044,6 +1069,7 @@ impl BlocklistAIHistoryModel {
             // forked conversation will establish its own cursor.
             last_event_sequence: None,
             compaction_state_json: None,
+            byop_repair_state_json,
         };
         let forked_conversation_id = AIConversationId::new();
         if let Err(e) = sqlite_sender.send(ModelEvent::UpdateMultiAgentConversation {
@@ -1120,11 +1146,17 @@ impl BlocklistAIHistoryModel {
         // Build truncated tasks by retaining only messages whose IDs are in
         // `allowed_message_ids`. Tasks whose message list becomes empty and
         // which are non-root tasks are dropped.
-        let truncated_tasks: Vec<warp_multi_agent_api::Task> = conversation
+        let source_tasks: Vec<warp_multi_agent_api::Task> = conversation
             .all_tasks()
+            .filter_map(|t| t.source().cloned())
+            .collect();
+        let truncated_tasks: Vec<warp_multi_agent_api::Task> = source_tasks
+            .iter()
             .filter_map(|t| {
-                if let Some(message_ids_to_retain) = message_ids_to_retain_by_task.get(t.id()) {
-                    let mut truncated_task = t.source().cloned()?;
+                if let Some(message_ids_to_retain) =
+                    message_ids_to_retain_by_task.get(&TaskId::new(t.id.clone()))
+                {
+                    let mut truncated_task = t.clone();
                     truncated_task
                         .messages
                         .retain(|m| message_ids_to_retain.contains(&MessageId::new(m.id.clone())));
@@ -1143,6 +1175,12 @@ impl BlocklistAIHistoryModel {
         }
 
         let updated_tasks_with_new_ids = update_forked_task_properties(truncated_tasks, prefix);
+        let byop_repair_state_json = byop_fork_repair_state_json(
+            &source_tasks,
+            &updated_tasks_with_new_ids,
+            &conversation.byop_repair_state,
+            Some(from_exchange_id.to_string()),
+        );
 
         let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(app)
             .get()
@@ -1200,6 +1238,7 @@ impl BlocklistAIHistoryModel {
             // forked conversation will establish its own cursor.
             last_event_sequence: None,
             compaction_state_json: None,
+            byop_repair_state_json,
         };
 
         let forked_conversation_id = AIConversationId::new();
@@ -2292,6 +2331,253 @@ fn update_forked_task_properties(
             t
         })
         .collect()
+}
+
+fn byop_fork_repair_state_json(
+    source_tasks: &[warp_multi_agent_api::Task],
+    forked_tasks: &[warp_multi_agent_api::Task],
+    source_repair_state: &RepairStateStatus,
+    exchange_id: Option<String>,
+) -> Option<String> {
+    let records = collect_byop_fork_repair_records(
+        source_tasks,
+        forked_tasks,
+        source_repair_state,
+        exchange_id,
+    );
+    RepairStateStatus::Valid(RepairState::new(records)).to_sidecar_json()
+}
+
+fn collect_byop_fork_repair_records(
+    source_tasks: &[warp_multi_agent_api::Task],
+    forked_tasks: &[warp_multi_agent_api::Task],
+    source_repair_state: &RepairStateStatus,
+    exchange_id: Option<String>,
+) -> Vec<RepairRecord> {
+    let source_tool_call_keys = byop_tool_call_keys_by_message_id(source_tasks);
+    let forked_tool_call_keys = byop_tool_call_keys_by_message_id(forked_tasks);
+    let source_result_message_ids = byop_result_message_ids_by_tool_call_key(source_tasks);
+    let retained_message_ids = byop_message_ids(forked_tasks);
+
+    let mut source_to_fork_key = HashMap::new();
+    for (message_id, fork_key) in &forked_tool_call_keys {
+        let Some(source_key) = source_tool_call_keys.get(message_id) else {
+            continue;
+        };
+        source_to_fork_key.insert(source_key.clone(), fork_key.clone());
+    }
+
+    let mut records = Vec::new();
+    let mut seen_keys = HashSet::new();
+    for (source_key, fork_key) in &source_to_fork_key {
+        let result_ids = source_result_message_ids
+            .get(source_key)
+            .cloned()
+            .unwrap_or_default();
+        if result_ids.is_empty()
+            || result_ids
+                .iter()
+                .any(|id| retained_message_ids.contains(id))
+        {
+            continue;
+        }
+
+        let mut record = RepairRecord::new(RepairSource::ForkedHistory, fork_key.clone());
+        record.exchange_id = exchange_id.clone();
+        push_unique_repair_record(&mut records, &mut seen_keys, record);
+    }
+
+    for record in source_repair_state.repair_records() {
+        let Some(fork_key) = source_to_fork_key.get(&record.key) else {
+            continue;
+        };
+        if source_result_message_ids
+            .get(&record.key)
+            .is_some_and(|ids| ids.iter().any(|id| retained_message_ids.contains(id)))
+        {
+            continue;
+        }
+
+        let mut translated = RepairRecord::new(record.source, fork_key.clone());
+        translated.fork_point_message_id = record.fork_point_message_id.clone();
+        translated.exchange_id = record.exchange_id.clone().or_else(|| exchange_id.clone());
+        push_unique_repair_record(&mut records, &mut seen_keys, translated);
+    }
+
+    records
+}
+
+fn push_unique_repair_record(
+    records: &mut Vec<RepairRecord>,
+    seen_keys: &mut HashSet<ToolCallKey>,
+    record: RepairRecord,
+) {
+    if seen_keys.insert(record.key.clone()) {
+        records.push(record);
+    }
+}
+
+fn byop_message_ids(tasks: &[warp_multi_agent_api::Task]) -> HashSet<String> {
+    tasks
+        .iter()
+        .flat_map(|task| task.messages.iter().map(|message| message.id.clone()))
+        .collect()
+}
+
+fn byop_result_message_ids_by_tool_call_key(
+    tasks: &[warp_multi_agent_api::Task],
+) -> HashMap<ToolCallKey, HashSet<String>> {
+    let mut result_ids = HashMap::new();
+    for task in tasks {
+        let mut active_task_id: Option<String> = None;
+        let mut active_assistant_message_id: Option<String> = None;
+        let mut active_tool_call_ids: Vec<String> = Vec::new();
+        let mut active_saw_tool_result = false;
+        for message in &task.messages {
+            match message.message.as_ref() {
+                Some(warp_multi_agent_api::message::Message::ToolCall(tool_call)) => {
+                    if tool_call.subagent().is_some() {
+                        continue;
+                    }
+
+                    if active_task_id
+                        .as_deref()
+                        .is_some_and(|task_id| task_id != message.task_id)
+                    {
+                        active_assistant_message_id = None;
+                        active_tool_call_ids.clear();
+                        active_saw_tool_result = false;
+                    }
+
+                    if active_saw_tool_result {
+                        active_task_id = None;
+                        active_assistant_message_id = None;
+                        active_tool_call_ids.clear();
+                        active_saw_tool_result = false;
+                    }
+
+                    if active_tool_call_ids.is_empty() {
+                        active_task_id = Some(message.task_id.clone());
+                        active_assistant_message_id = Some(message.id.clone());
+                    }
+                    active_tool_call_ids.push(tool_call.tool_call_id.clone());
+                }
+                Some(warp_multi_agent_api::message::Message::ToolCallResult(result)) => {
+                    let Some(assistant_message_id) = active_assistant_message_id.as_ref() else {
+                        continue;
+                    };
+                    if active_task_id.as_deref() != Some(message.task_id.as_str()) {
+                        continue;
+                    }
+                    let matching_count = active_tool_call_ids
+                        .iter()
+                        .filter(|tool_call_id| *tool_call_id == &result.tool_call_id)
+                        .count();
+                    if matching_count != 1 {
+                        continue;
+                    }
+
+                    result_ids
+                        .entry(ToolCallKey::new(
+                            message.task_id.clone(),
+                            assistant_message_id.clone(),
+                            result.tool_call_id.clone(),
+                        ))
+                        .or_insert_with(HashSet::new)
+                        .insert(message.id.clone());
+                    active_saw_tool_result = true;
+                }
+                Some(warp_multi_agent_api::message::Message::UserQuery(_))
+                | Some(warp_multi_agent_api::message::Message::AgentOutput(_)) => {
+                    active_task_id = None;
+                    active_assistant_message_id = None;
+                    active_tool_call_ids.clear();
+                    active_saw_tool_result = false;
+                }
+                Some(warp_multi_agent_api::message::Message::AgentReasoning(_))
+                | Some(warp_multi_agent_api::message::Message::ServerEvent(_))
+                | Some(warp_multi_agent_api::message::Message::SystemQuery(_))
+                | Some(warp_multi_agent_api::message::Message::UpdateTodos(_))
+                | Some(warp_multi_agent_api::message::Message::Summarization(_))
+                | Some(warp_multi_agent_api::message::Message::CodeReview(_))
+                | Some(warp_multi_agent_api::message::Message::UpdateReviewComments(_))
+                | Some(warp_multi_agent_api::message::Message::WebSearch(_))
+                | Some(warp_multi_agent_api::message::Message::WebFetch(_))
+                | Some(warp_multi_agent_api::message::Message::DebugOutput(_))
+                | Some(warp_multi_agent_api::message::Message::ArtifactEvent(_))
+                | Some(warp_multi_agent_api::message::Message::InvokeSkill(_))
+                | Some(warp_multi_agent_api::message::Message::MessagesReceivedFromAgents(_))
+                | Some(warp_multi_agent_api::message::Message::ModelUsed(_))
+                | Some(warp_multi_agent_api::message::Message::EventsFromAgents(_))
+                | Some(warp_multi_agent_api::message::Message::PassiveSuggestionResult(_))
+                | None => {}
+            }
+        }
+    }
+    result_ids
+}
+
+fn byop_tool_call_keys_by_message_id(
+    tasks: &[warp_multi_agent_api::Task],
+) -> HashMap<String, ToolCallKey> {
+    let mut keys = HashMap::new();
+    for task in tasks {
+        let mut pending_task_id: Option<String> = None;
+        let mut pending_assistant_message_id: Option<String> = None;
+        for message in &task.messages {
+            match message.message.as_ref() {
+                Some(warp_multi_agent_api::message::Message::ToolCall(tool_call)) => {
+                    if tool_call.subagent().is_some() {
+                        continue;
+                    }
+
+                    if pending_task_id
+                        .as_deref()
+                        .is_some_and(|task_id| task_id != message.task_id)
+                    {
+                        pending_assistant_message_id = None;
+                    }
+
+                    let assistant_message_id = pending_assistant_message_id
+                        .get_or_insert_with(|| message.id.clone())
+                        .clone();
+                    pending_task_id = Some(message.task_id.clone());
+                    keys.insert(
+                        message.id.clone(),
+                        ToolCallKey::new(
+                            message.task_id.clone(),
+                            assistant_message_id,
+                            tool_call.tool_call_id.clone(),
+                        ),
+                    );
+                }
+                Some(warp_multi_agent_api::message::Message::UserQuery(_))
+                | Some(warp_multi_agent_api::message::Message::AgentOutput(_))
+                | Some(warp_multi_agent_api::message::Message::ToolCallResult(_)) => {
+                    pending_task_id = None;
+                    pending_assistant_message_id = None;
+                }
+                Some(warp_multi_agent_api::message::Message::AgentReasoning(_))
+                | Some(warp_multi_agent_api::message::Message::ServerEvent(_))
+                | Some(warp_multi_agent_api::message::Message::SystemQuery(_))
+                | Some(warp_multi_agent_api::message::Message::UpdateTodos(_))
+                | Some(warp_multi_agent_api::message::Message::Summarization(_))
+                | Some(warp_multi_agent_api::message::Message::CodeReview(_))
+                | Some(warp_multi_agent_api::message::Message::UpdateReviewComments(_))
+                | Some(warp_multi_agent_api::message::Message::WebSearch(_))
+                | Some(warp_multi_agent_api::message::Message::WebFetch(_))
+                | Some(warp_multi_agent_api::message::Message::DebugOutput(_))
+                | Some(warp_multi_agent_api::message::Message::ArtifactEvent(_))
+                | Some(warp_multi_agent_api::message::Message::InvokeSkill(_))
+                | Some(warp_multi_agent_api::message::Message::MessagesReceivedFromAgents(_))
+                | Some(warp_multi_agent_api::message::Message::ModelUsed(_))
+                | Some(warp_multi_agent_api::message::Message::EventsFromAgents(_))
+                | Some(warp_multi_agent_api::message::Message::PassiveSuggestionResult(_))
+                | None => {}
+            }
+        }
+    }
+    keys
 }
 
 /// The default prefix used when forking a conversation.

--- a/app/src/ai/blocklist/history_model_test.rs
+++ b/app/src/ai/blocklist/history_model_test.rs
@@ -14,6 +14,7 @@ use crate::{
         },
         ambient_agents::AmbientAgentTaskId,
         blocklist::{controller::RequestInput, ResponseStreamId},
+        byop_readiness::{RepairRecord, RepairSource, RepairState, RepairStateStatus, ToolCallKey},
         llms::LLMId,
     },
     input_suggestions::HistoryInputSuggestion,
@@ -22,6 +23,7 @@ use crate::{
     test_util::settings::initialize_settings_for_tests,
     GlobalResourceHandles, GlobalResourceHandlesProvider,
 };
+use warp_multi_agent_api as api;
 
 use super::{
     AIConversationMetadata, AIQueryHistoryOutputStatus, BlocklistAIHistoryModel, PersistedAIInput,
@@ -90,6 +92,208 @@ fn create_exchange_with_query(
         computer_use_model_id: LLMId::from("test-computer-use-model"),
         response_initiator: None,
     }
+}
+
+fn byop_test_task(task_id: &str, messages: Vec<api::Message>) -> api::Task {
+    api::Task {
+        id: task_id.to_owned(),
+        messages,
+        dependencies: None,
+        description: String::new(),
+        summary: String::new(),
+        server_data: String::new(),
+    }
+}
+
+fn byop_tool_call_message(task_id: &str, message_id: &str, call_id: &str) -> api::Message {
+    api::Message {
+        id: message_id.to_owned(),
+        task_id: task_id.to_owned(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: call_id.to_owned(),
+            tool: None,
+        })),
+        request_id: "request-1".to_owned(),
+        timestamp: None,
+    }
+}
+
+fn byop_tool_result_message(task_id: &str, message_id: &str, call_id: &str) -> api::Message {
+    api::Message {
+        id: message_id.to_owned(),
+        task_id: task_id.to_owned(),
+        server_message_data: "{}".to_owned(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: call_id.to_owned(),
+                context: None,
+                result: None,
+            },
+        )),
+        request_id: "request-1".to_owned(),
+        timestamp: None,
+    }
+}
+
+#[test]
+fn byop_fork_repair_records_cover_tool_results_omitted_by_fork() {
+    let source_tasks = vec![byop_test_task(
+        "source-task",
+        vec![
+            byop_tool_call_message("source-task", "assistant-1", "call-a"),
+            byop_tool_call_message("source-task", "assistant-2", "call-b"),
+            byop_tool_result_message("source-task", "result-a", "call-a"),
+            byop_tool_result_message("source-task", "result-b", "call-b"),
+        ],
+    )];
+    let forked_tasks = vec![byop_test_task(
+        "fork-task",
+        vec![
+            byop_tool_call_message("fork-task", "assistant-1", "call-a"),
+            byop_tool_call_message("fork-task", "assistant-2", "call-b"),
+            byop_tool_result_message("fork-task", "result-a", "call-a"),
+        ],
+    )];
+
+    let records = super::collect_byop_fork_repair_records(
+        &source_tasks,
+        &forked_tasks,
+        &RepairStateStatus::default(),
+        Some("exchange-1".to_owned()),
+    );
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].source, RepairSource::ForkedHistory);
+    assert_eq!(
+        records[0].key,
+        ToolCallKey::new("fork-task", "assistant-1", "call-b")
+    );
+    assert_eq!(records[0].exchange_id.as_deref(), Some("exchange-1"));
+}
+
+#[test]
+fn byop_fork_repair_records_match_duplicate_call_ids_by_assistant_message() {
+    let source_tasks = vec![byop_test_task(
+        "source-task",
+        vec![
+            byop_tool_call_message("source-task", "assistant-1", "call-a"),
+            byop_tool_result_message("source-task", "result-a-1", "call-a"),
+            byop_tool_call_message("source-task", "assistant-2", "call-a"),
+            byop_tool_result_message("source-task", "result-a-2", "call-a"),
+        ],
+    )];
+    let forked_tasks = vec![byop_test_task(
+        "fork-task",
+        vec![
+            byop_tool_call_message("fork-task", "assistant-1", "call-a"),
+            byop_tool_result_message("fork-task", "result-a-1", "call-a"),
+            byop_tool_call_message("fork-task", "assistant-2", "call-a"),
+        ],
+    )];
+
+    let records = super::collect_byop_fork_repair_records(
+        &source_tasks,
+        &forked_tasks,
+        &RepairStateStatus::default(),
+        None,
+    );
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].key,
+        ToolCallKey::new("fork-task", "assistant-2", "call-a")
+    );
+}
+
+#[test]
+fn byop_fork_repair_records_do_not_convert_orphan_results() {
+    let source_tasks = vec![byop_test_task(
+        "source-task",
+        vec![byop_tool_result_message(
+            "source-task",
+            "orphan-result",
+            "call-a",
+        )],
+    )];
+    let forked_tasks = vec![byop_test_task(
+        "fork-task",
+        vec![byop_tool_result_message(
+            "fork-task",
+            "orphan-result",
+            "call-a",
+        )],
+    )];
+
+    let records = super::collect_byop_fork_repair_records(
+        &source_tasks,
+        &forked_tasks,
+        &RepairStateStatus::default(),
+        None,
+    );
+
+    assert!(records.is_empty());
+}
+
+#[test]
+fn byop_fork_repair_records_do_not_infer_unexplained_missing_results() {
+    let source_tasks = vec![byop_test_task(
+        "source-task",
+        vec![byop_tool_call_message(
+            "source-task",
+            "assistant-1",
+            "call-a",
+        )],
+    )];
+    let forked_tasks = vec![byop_test_task(
+        "fork-task",
+        vec![byop_tool_call_message("fork-task", "assistant-1", "call-a")],
+    )];
+
+    let records = super::collect_byop_fork_repair_records(
+        &source_tasks,
+        &forked_tasks,
+        &RepairStateStatus::default(),
+        None,
+    );
+
+    assert!(records.is_empty());
+}
+
+#[test]
+fn byop_fork_repair_records_translate_existing_repair_keys() {
+    let source_tasks = vec![byop_test_task(
+        "source-task",
+        vec![byop_tool_call_message(
+            "source-task",
+            "assistant-1",
+            "call-a",
+        )],
+    )];
+    let forked_tasks = vec![byop_test_task(
+        "fork-task",
+        vec![byop_tool_call_message("fork-task", "assistant-1", "call-a")],
+    )];
+    let source_record = RepairRecord::new(
+        RepairSource::RestoredLegacyHistory,
+        ToolCallKey::new("source-task", "assistant-1", "call-a"),
+    );
+
+    let records = super::collect_byop_fork_repair_records(
+        &source_tasks,
+        &forked_tasks,
+        &RepairStateStatus::Valid(RepairState::new(vec![source_record])),
+        None,
+    );
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].source, RepairSource::RestoredLegacyHistory);
+    assert_eq!(
+        records[0].key,
+        ToolCallKey::new("fork-task", "assistant-1", "call-a")
+    );
 }
 
 #[test]
@@ -944,6 +1148,7 @@ fn test_find_by_token_after_insert_forked_conversation_from_tasks() {
             autoexecute_override: None,
             last_event_sequence: None,
             compaction_state_json: None,
+            byop_repair_state_json: None,
         };
         let tasks = vec![warp_multi_agent_api::Task {
             id: "root-task".to_string(),

--- a/app/src/ai/byop_readiness/mod.rs
+++ b/app/src/ai/byop_readiness/mod.rs
@@ -1,0 +1,1282 @@
+//! BYOP 请求发送前的工具调用就绪性分类。
+//!
+//! 这个模块只处理已经投影出来的安全元数据,不读取原始 prompt、工具参数或工具输出,
+//! 也不修改 controller、serializer 或 conversation 状态。
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+pub const REPAIR_STATE_VERSION: u32 = 1;
+pub const BLOCKED_BYOP_REQUEST_MESSAGE: &str =
+    "OpenWarp did not send the BYOP request because a previous tool call is missing its recorded result.";
+pub const PENDING_BYOP_TOOL_RESULTS_MESSAGE: &str =
+    "OpenWarp is waiting for previous BYOP tool results before sending the next request.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReadinessTriggerLayer {
+    ControllerPreflight,
+    SerializerValidation,
+}
+
+impl ReadinessTriggerLayer {
+    fn as_str(self) -> &'static str {
+        match self {
+            ReadinessTriggerLayer::ControllerPreflight => "controller_preflight",
+            ReadinessTriggerLayer::SerializerValidation => "serializer_validation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadinessDiagnosticLevel {
+    Debug,
+    Info,
+    Error,
+}
+
+impl ReadinessDiagnosticLevel {
+    fn as_log_level(self) -> log::Level {
+        match self {
+            ReadinessDiagnosticLevel::Debug => log::Level::Debug,
+            ReadinessDiagnosticLevel::Info => log::Level::Info,
+            ReadinessDiagnosticLevel::Error => log::Level::Error,
+        }
+    }
+}
+
+pub struct ReadinessDiagnosticContext<'a> {
+    pub conversation_id: &'a str,
+    pub request_attempt_id: &'a str,
+    pub trigger_layer: ReadinessTriggerLayer,
+    pub iteration: Option<usize>,
+}
+
+impl<'a> ReadinessDiagnosticContext<'a> {
+    pub fn new(
+        conversation_id: &'a str,
+        request_attempt_id: &'a str,
+        trigger_layer: ReadinessTriggerLayer,
+    ) -> Self {
+        Self {
+            conversation_id,
+            request_attempt_id,
+            trigger_layer,
+            iteration: None,
+        }
+    }
+
+    pub fn with_iteration(mut self, iteration: usize) -> Self {
+        self.iteration = Some(iteration);
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{BLOCKED_BYOP_REQUEST_MESSAGE}")]
+pub struct BlockedByopReadinessError {
+    category: ReadinessCategory,
+}
+
+impl BlockedByopReadinessError {
+    pub fn new(category: ReadinessCategory) -> Self {
+        Self { category }
+    }
+
+    pub fn category(&self) -> ReadinessCategory {
+        self.category
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{PENDING_BYOP_TOOL_RESULTS_MESSAGE}")]
+pub struct PendingByopToolResultsError {
+    tool_call_count: usize,
+}
+
+impl PendingByopToolResultsError {
+    pub fn new(tool_call_count: usize) -> Self {
+        Self { tool_call_count }
+    }
+
+    pub fn category(&self) -> ReadinessCategory {
+        ReadinessCategory::PendingToolResults
+    }
+
+    pub fn tool_call_count(&self) -> usize {
+        self.tool_call_count
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolCallKey {
+    pub task_id: String,
+    pub assistant_tool_call_message_id: String,
+    pub tool_call_id: String,
+}
+
+impl ToolCallKey {
+    pub fn new(
+        task_id: impl Into<String>,
+        assistant_tool_call_message_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            assistant_tool_call_message_id: assistant_tool_call_message_id.into(),
+            tool_call_id: tool_call_id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RedactedToolKind(String);
+
+impl RedactedToolKind {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for RedactedToolKind {
+    fn default() -> Self {
+        Self::new("unknown")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallRef {
+    pub key: ToolCallKey,
+    pub redacted_tool_kind: RedactedToolKind,
+}
+
+impl ToolCallRef {
+    pub fn new(key: ToolCallKey, redacted_tool_kind: RedactedToolKind) -> Self {
+        Self {
+            key,
+            redacted_tool_kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolResultRef {
+    pub message_id: String,
+    pub source: ToolResultSource,
+    pub result_kind: TerminalResultKind,
+}
+
+impl ToolResultRef {
+    fn from_result(result: &ProjectedToolResult) -> Self {
+        Self {
+            message_id: result.message_id.clone(),
+            source: result.source,
+            result_kind: result.result_kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolResultSource {
+    PersistedHistory,
+    CurrentInput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TerminalResultKind {
+    Real,
+    Cancellation,
+    StructuredError,
+    LocalInterception,
+    Compacted,
+    UnreadableLocalInterception,
+}
+
+impl TerminalResultKind {
+    fn satisfies_readiness(self) -> bool {
+        match self {
+            TerminalResultKind::Real
+            | TerminalResultKind::Cancellation
+            | TerminalResultKind::StructuredError
+            | TerminalResultKind::LocalInterception
+            | TerminalResultKind::Compacted => true,
+            TerminalResultKind::UnreadableLocalInterception => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedToolCall {
+    pub key: ToolCallKey,
+    pub redacted_tool_kind: RedactedToolKind,
+}
+
+impl ProjectedToolCall {
+    pub fn new(
+        task_id: impl Into<String>,
+        assistant_tool_call_message_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        redacted_tool_kind: RedactedToolKind,
+    ) -> Self {
+        Self {
+            key: ToolCallKey::new(task_id, assistant_tool_call_message_id, tool_call_id),
+            redacted_tool_kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedToolResult {
+    pub task_id: String,
+    pub message_id: String,
+    pub assistant_tool_call_message_id: Option<String>,
+    pub tool_call_id: String,
+    pub redacted_tool_kind: RedactedToolKind,
+    pub source: ToolResultSource,
+    pub result_kind: TerminalResultKind,
+}
+
+impl ProjectedToolResult {
+    pub fn new(
+        task_id: impl Into<String>,
+        message_id: impl Into<String>,
+        assistant_tool_call_message_id: Option<String>,
+        tool_call_id: impl Into<String>,
+        redacted_tool_kind: RedactedToolKind,
+        source: ToolResultSource,
+        result_kind: TerminalResultKind,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            assistant_tool_call_message_id,
+            tool_call_id: tool_call_id.into(),
+            redacted_tool_kind,
+            source,
+            result_kind,
+        }
+    }
+
+    pub fn current_input(
+        index: usize,
+        task_id: impl Into<String>,
+        assistant_tool_call_message_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        redacted_tool_kind: RedactedToolKind,
+        result_kind: TerminalResultKind,
+    ) -> Self {
+        let task_id = task_id.into();
+        let assistant_tool_call_message_id = assistant_tool_call_message_id.into();
+        let tool_call_id = tool_call_id.into();
+        Self {
+            task_id,
+            message_id: format!("current_input:{index}:{tool_call_id}"),
+            assistant_tool_call_message_id: Some(assistant_tool_call_message_id),
+            tool_call_id,
+            redacted_tool_kind,
+            source: ToolResultSource::CurrentInput,
+            result_kind,
+        }
+    }
+
+    fn key(&self) -> Option<ToolCallKey> {
+        self.assistant_tool_call_message_id
+            .as_ref()
+            .map(|assistant_tool_call_message_id| {
+                ToolCallKey::new(
+                    self.task_id.clone(),
+                    assistant_tool_call_message_id.clone(),
+                    self.tool_call_id.clone(),
+                )
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectionItemKind {
+    UserBoundary,
+    AssistantBoundary,
+    SystemBoundary,
+    OtherBoundary,
+    AssistantToolCalls(Vec<ProjectedToolCall>),
+    ToolResult(ProjectedToolResult),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionItem {
+    pub task_id: String,
+    pub message_id: String,
+    pub kind: ProjectionItemKind,
+}
+
+impl ProjectionItem {
+    pub fn user_boundary(task_id: impl Into<String>, message_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            kind: ProjectionItemKind::UserBoundary,
+        }
+    }
+
+    pub fn assistant_boundary(task_id: impl Into<String>, message_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            kind: ProjectionItemKind::AssistantBoundary,
+        }
+    }
+
+    pub fn system_boundary(task_id: impl Into<String>, message_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            kind: ProjectionItemKind::SystemBoundary,
+        }
+    }
+
+    pub fn other_boundary(task_id: impl Into<String>, message_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            kind: ProjectionItemKind::OtherBoundary,
+        }
+    }
+
+    pub fn assistant_tool_calls(
+        task_id: impl Into<String>,
+        message_id: impl Into<String>,
+        tool_calls: Vec<ProjectedToolCall>,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            message_id: message_id.into(),
+            kind: ProjectionItemKind::AssistantToolCalls(tool_calls),
+        }
+    }
+
+    pub fn tool_result(result: ProjectedToolResult) -> Self {
+        Self {
+            task_id: result.task_id.clone(),
+            message_id: result.message_id.clone(),
+            kind: ProjectionItemKind::ToolResult(result),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepairSource {
+    ForkedHistory,
+    RestoredLegacyHistory,
+}
+
+impl RepairSource {
+    pub fn placeholder_reason(self) -> &'static str {
+        match self {
+            RepairSource::ForkedHistory => "forked_history_repair",
+            RepairSource::RestoredLegacyHistory => "restored_legacy_history_repair",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RepairRecord {
+    pub source: RepairSource,
+    #[serde(flatten)]
+    pub key: ToolCallKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_point_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exchange_id: Option<String>,
+}
+
+impl RepairRecord {
+    pub fn new(source: RepairSource, key: ToolCallKey) -> Self {
+        Self {
+            source,
+            key,
+            fork_point_message_id: None,
+            exchange_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepairState {
+    pub version: u32,
+    #[serde(default)]
+    pub records: Vec<RepairRecord>,
+}
+
+impl RepairState {
+    pub fn new(records: Vec<RepairRecord>) -> Self {
+        Self {
+            version: REPAIR_STATE_VERSION,
+            records,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+impl Default for RepairState {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RepairStateLoadError {
+    InvalidJson,
+    UnsupportedVersion,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct InvalidRepairState {
+    pub error_category: RepairStateLoadError,
+    raw_json: String,
+}
+
+impl std::fmt::Debug for InvalidRepairState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InvalidRepairState")
+            .field("error_category", &self.error_category)
+            .field(
+                "raw_json",
+                &format_args!("<redacted:{} bytes>", self.raw_json.len()),
+            )
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepairStateStatus {
+    Valid(RepairState),
+    Invalid(InvalidRepairState),
+}
+
+impl RepairStateStatus {
+    pub fn from_sidecar_json(sidecar_json: Option<String>) -> Self {
+        let Some(raw_json) = sidecar_json else {
+            return Self::Valid(RepairState::default());
+        };
+
+        let value = match serde_json::from_str::<serde_json::Value>(&raw_json) {
+            Ok(value) => value,
+            Err(_) => {
+                return Self::invalid(RepairStateLoadError::InvalidJson, raw_json);
+            }
+        };
+
+        let Some(version) = value.get("version").and_then(serde_json::Value::as_u64) else {
+            return Self::invalid(RepairStateLoadError::UnsupportedVersion, raw_json);
+        };
+
+        if version != u64::from(REPAIR_STATE_VERSION) {
+            return Self::invalid(RepairStateLoadError::UnsupportedVersion, raw_json);
+        }
+
+        match serde_json::from_value::<RepairState>(value) {
+            Ok(state) => Self::Valid(state),
+            Err(_) => Self::invalid(RepairStateLoadError::InvalidJson, raw_json),
+        }
+    }
+
+    pub fn repair_records(&self) -> &[RepairRecord] {
+        match self {
+            Self::Valid(state) => &state.records,
+            Self::Invalid(_) => &[],
+        }
+    }
+
+    pub fn to_sidecar_json(&self) -> Option<String> {
+        match self {
+            Self::Valid(state) if state.is_empty() => None,
+            Self::Valid(state) => serde_json::to_string(state)
+                .map_err(|e| {
+                    log::error!("[byop-repair] failed to serialize repair state: {e}");
+                })
+                .ok(),
+            Self::Invalid(invalid) => Some(invalid.raw_json.clone()),
+        }
+    }
+
+    pub fn error_category(&self) -> Option<RepairStateLoadError> {
+        match self {
+            Self::Valid(_) => None,
+            Self::Invalid(invalid) => Some(invalid.error_category),
+        }
+    }
+
+    fn invalid(error_category: RepairStateLoadError, raw_json: String) -> Self {
+        Self::Invalid(InvalidRepairState {
+            error_category,
+            raw_json,
+        })
+    }
+}
+
+impl Default for RepairStateStatus {
+    fn default() -> Self {
+        Self::Valid(RepairState::default())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LiveToolCallState {
+    Running,
+    CancellationRequested,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveToolCall {
+    pub tool_call: ToolCallRef,
+    pub state: LiveToolCallState,
+}
+
+impl LiveToolCall {
+    pub fn new(tool_call: ToolCallRef, state: LiveToolCallState) -> Self {
+        Self { tool_call, state }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReadinessContext {
+    pub repair_records: Vec<RepairRecord>,
+    pub live_tool_calls: Vec<LiveToolCall>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReadinessCategory {
+    Ready,
+    AcceptedHistoryRepair,
+    PendingToolResults,
+    NeedsCancellationCommit,
+    DuplicateToolResults,
+    OrphanToolResult,
+    OutOfOrderToolResult,
+    MissingResultWithoutRepairSource,
+    StaleRepairRecordIgnored,
+    ReadinessLoopDidNotConverge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MissingResultReason {
+    NoResult,
+    UnreadableLocalInterception,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ReadinessDiagnosticKey {
+    category: ReadinessCategory,
+    conversation_id: String,
+    task_id: String,
+    assistant_tool_call_message_id: String,
+    tool_call_id: String,
+    trigger_layer: ReadinessTriggerLayer,
+}
+
+#[derive(Debug, Clone)]
+struct ReadinessDiagnosticTarget {
+    task_id: String,
+    assistant_tool_call_message_id: String,
+    tool_call_id: String,
+    redacted_tool_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReadinessDiagnosticLogEntry {
+    level: ReadinessDiagnosticLevel,
+    message: String,
+}
+
+impl ReadinessDiagnosticLogEntry {
+    fn emit(&self) {
+        log::log!(self.level.as_log_level(), "{}", self.message);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ReadinessDiagnosticCoalescer {
+    suppressed_by_key: HashMap<ReadinessDiagnosticKey, usize>,
+}
+
+impl ReadinessDiagnosticCoalescer {
+    pub fn log_state(
+        &mut self,
+        state: &ReadinessState,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) {
+        for entry in self.log_category_targets(
+            state.category(),
+            readiness_state_targets(state),
+            context,
+            level,
+        ) {
+            entry.emit();
+        }
+    }
+
+    pub fn log_category(
+        &mut self,
+        category: ReadinessCategory,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) {
+        for entry in self.log_category_targets(
+            category,
+            vec![ReadinessDiagnosticTarget {
+                task_id: "unknown".to_owned(),
+                assistant_tool_call_message_id: "unknown".to_owned(),
+                tool_call_id: "unknown".to_owned(),
+                redacted_tool_kind: "unknown".to_owned(),
+            }],
+            context,
+            level,
+        ) {
+            entry.emit();
+        }
+    }
+
+    pub fn finish(self, context: &ReadinessDiagnosticContext<'_>, level: ReadinessDiagnosticLevel) {
+        for entry in self.finish_entries(context, level) {
+            entry.emit();
+        }
+    }
+
+    #[cfg(test)]
+    fn test_log_state_entries(
+        &mut self,
+        state: &ReadinessState,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) -> Vec<ReadinessDiagnosticLogEntry> {
+        self.log_category_targets(
+            state.category(),
+            readiness_state_targets(state),
+            context,
+            level,
+        )
+    }
+
+    #[cfg(test)]
+    fn test_finish_entries(
+        self,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) -> Vec<ReadinessDiagnosticLogEntry> {
+        self.finish_entries(context, level)
+    }
+
+    fn finish_entries(
+        self,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) -> Vec<ReadinessDiagnosticLogEntry> {
+        let mut entries = Vec::new();
+        for (key, suppressed_count) in self.suppressed_by_key {
+            if suppressed_count == 0 {
+                continue;
+            }
+            entries.push(ReadinessDiagnosticLogEntry {
+                level,
+                message: format!(
+                    "[byop-readiness] diagnostic coalesced suppressed_count={} \
+                     category={:?} conversation_id={} task_id={} \
+                     assistant_tool_call_message_id={} tool_call_id={} \
+                     redacted_tool_kind=omitted trigger_layer={} request_attempt_id={}",
+                    suppressed_count,
+                    key.category,
+                    key.conversation_id,
+                    key.task_id,
+                    key.assistant_tool_call_message_id,
+                    key.tool_call_id,
+                    key.trigger_layer.as_str(),
+                    context.request_attempt_id
+                ),
+            });
+        }
+        entries
+    }
+
+    fn log_category_targets(
+        &mut self,
+        category: ReadinessCategory,
+        targets: Vec<ReadinessDiagnosticTarget>,
+        context: &ReadinessDiagnosticContext<'_>,
+        level: ReadinessDiagnosticLevel,
+    ) -> Vec<ReadinessDiagnosticLogEntry> {
+        let mut entries = Vec::new();
+        for target in targets {
+            let key = ReadinessDiagnosticKey {
+                category,
+                conversation_id: context.conversation_id.to_owned(),
+                task_id: target.task_id.clone(),
+                assistant_tool_call_message_id: target.assistant_tool_call_message_id.clone(),
+                tool_call_id: target.tool_call_id.clone(),
+                trigger_layer: context.trigger_layer,
+            };
+
+            match self.suppressed_by_key.entry(key) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(0);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    *entry.get_mut() += 1;
+                    continue;
+                }
+            }
+
+            entries.push(ReadinessDiagnosticLogEntry {
+                level,
+                message: format!(
+                    "[byop-readiness] diagnostic category={category:?} conversation_id={} \
+                     task_id={} assistant_tool_call_message_id={} tool_call_id={} \
+                     redacted_tool_kind={} trigger_layer={} request_attempt_id={} \
+                     iteration={}",
+                    context.conversation_id,
+                    target.task_id,
+                    target.assistant_tool_call_message_id,
+                    target.tool_call_id,
+                    target.redacted_tool_kind,
+                    context.trigger_layer.as_str(),
+                    context.request_attempt_id,
+                    context
+                        .iteration
+                        .map(|iteration| iteration.to_string())
+                        .unwrap_or_else(|| "none".to_owned())
+                ),
+            });
+        }
+        entries
+    }
+}
+
+fn readiness_state_targets(state: &ReadinessState) -> Vec<ReadinessDiagnosticTarget> {
+    match state {
+        ReadinessState::Ready => Vec::new(),
+        ReadinessState::AcceptedHistoryRepair { repairs } => repairs
+            .iter()
+            .map(|repair| target_from_tool_call_ref(&repair.tool_call))
+            .collect(),
+        ReadinessState::PendingToolResults { tool_calls }
+        | ReadinessState::NeedsCancellationCommit { tool_calls }
+        | ReadinessState::MissingResultWithoutRepairSource {
+            tool_calls,
+            reason: _,
+        } => tool_calls.iter().map(target_from_tool_call_ref).collect(),
+        ReadinessState::DuplicateToolResults {
+            tool_call,
+            results: _,
+        } => vec![target_from_tool_call_ref(tool_call)],
+        ReadinessState::OrphanToolResult { result }
+        | ReadinessState::OutOfOrderToolResult { result } => {
+            vec![target_from_tool_result(result)]
+        }
+    }
+}
+
+fn target_from_tool_call_ref(tool_call: &ToolCallRef) -> ReadinessDiagnosticTarget {
+    ReadinessDiagnosticTarget {
+        task_id: tool_call.key.task_id.clone(),
+        assistant_tool_call_message_id: tool_call.key.assistant_tool_call_message_id.clone(),
+        tool_call_id: tool_call.key.tool_call_id.clone(),
+        redacted_tool_kind: tool_call.redacted_tool_kind.as_str().to_owned(),
+    }
+}
+
+fn target_from_tool_result(result: &ProjectedToolResult) -> ReadinessDiagnosticTarget {
+    ReadinessDiagnosticTarget {
+        task_id: result.task_id.clone(),
+        assistant_tool_call_message_id: result
+            .assistant_tool_call_message_id
+            .clone()
+            .unwrap_or_else(|| "unknown".to_owned()),
+        tool_call_id: result.tool_call_id.clone(),
+        redacted_tool_kind: result.redacted_tool_kind.as_str().to_owned(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcceptedRepair {
+    pub record: RepairRecord,
+    pub tool_call: ToolCallRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadinessState {
+    Ready,
+    AcceptedHistoryRepair {
+        repairs: Vec<AcceptedRepair>,
+    },
+    PendingToolResults {
+        tool_calls: Vec<ToolCallRef>,
+    },
+    NeedsCancellationCommit {
+        tool_calls: Vec<ToolCallRef>,
+    },
+    DuplicateToolResults {
+        tool_call: ToolCallRef,
+        results: Vec<ToolResultRef>,
+    },
+    OrphanToolResult {
+        result: ProjectedToolResult,
+    },
+    OutOfOrderToolResult {
+        result: ProjectedToolResult,
+    },
+    MissingResultWithoutRepairSource {
+        tool_calls: Vec<ToolCallRef>,
+        reason: MissingResultReason,
+    },
+}
+
+impl ReadinessState {
+    pub fn category(&self) -> ReadinessCategory {
+        match self {
+            ReadinessState::Ready => ReadinessCategory::Ready,
+            ReadinessState::AcceptedHistoryRepair { repairs: _ } => {
+                ReadinessCategory::AcceptedHistoryRepair
+            }
+            ReadinessState::PendingToolResults { tool_calls: _ } => {
+                ReadinessCategory::PendingToolResults
+            }
+            ReadinessState::NeedsCancellationCommit { tool_calls: _ } => {
+                ReadinessCategory::NeedsCancellationCommit
+            }
+            ReadinessState::DuplicateToolResults {
+                tool_call: _,
+                results: _,
+            } => ReadinessCategory::DuplicateToolResults,
+            ReadinessState::OrphanToolResult { result: _ } => ReadinessCategory::OrphanToolResult,
+            ReadinessState::OutOfOrderToolResult { result: _ } => {
+                ReadinessCategory::OutOfOrderToolResult
+            }
+            ReadinessState::MissingResultWithoutRepairSource {
+                tool_calls: _,
+                reason: _,
+            } => ReadinessCategory::MissingResultWithoutRepairSource,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgnoredRepairRecord {
+    pub record: RepairRecord,
+    pub category: ReadinessCategory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadinessReport {
+    pub state: ReadinessState,
+    pub ignored_repair_records: Vec<IgnoredRepairRecord>,
+}
+
+pub fn normalize_projection(mut items: Vec<ProjectionItem>) -> Vec<ProjectionItem> {
+    let mut active_group: Option<InferenceGroup> = None;
+
+    for item in &mut items {
+        let task_id = item.task_id.clone();
+        let message_id = item.message_id.clone();
+        match &mut item.kind {
+            ProjectionItemKind::AssistantToolCalls(tool_calls) => {
+                active_group = Some(InferenceGroup::new(task_id, message_id, tool_calls));
+            }
+            ProjectionItemKind::ToolResult(result) => {
+                if result.assistant_tool_call_message_id.is_none() {
+                    if let Some(group) = &active_group {
+                        if let Some(assistant_message_id) = group.infer_assistant_message_id(result)
+                        {
+                            result.assistant_tool_call_message_id = Some(assistant_message_id);
+                        }
+                    }
+                }
+            }
+            ProjectionItemKind::UserBoundary
+            | ProjectionItemKind::AssistantBoundary
+            | ProjectionItemKind::SystemBoundary
+            | ProjectionItemKind::OtherBoundary => {
+                active_group = None;
+            }
+        }
+    }
+
+    items
+}
+
+pub fn classify_projection(
+    items: &[ProjectionItem],
+    context: &ReadinessContext,
+) -> ReadinessReport {
+    let normalized_items = normalize_projection(items.to_vec());
+    let mut classifier = Classifier::new(context);
+
+    for item in normalized_items {
+        let state = match item.kind {
+            ProjectionItemKind::AssistantToolCalls(tool_calls) => {
+                let finished = classifier.finish_active_group(true);
+                if finished.is_none() && !tool_calls.is_empty() {
+                    classifier.start_group(item.task_id, item.message_id, tool_calls);
+                }
+                finished
+            }
+            ProjectionItemKind::ToolResult(result) => classifier.handle_tool_result(result),
+            ProjectionItemKind::UserBoundary
+            | ProjectionItemKind::AssistantBoundary
+            | ProjectionItemKind::SystemBoundary
+            | ProjectionItemKind::OtherBoundary => classifier.finish_active_group(true),
+        };
+
+        if let Some(state) = state {
+            return classifier.report(state);
+        }
+    }
+
+    if let Some(state) = classifier.finish_active_group(false) {
+        return classifier.report(state);
+    }
+
+    classifier.ready_report()
+}
+
+struct InferenceGroup {
+    task_id: String,
+    assistant_message_id: String,
+    tool_call_ids: Vec<String>,
+}
+
+impl InferenceGroup {
+    fn new(
+        task_id: String,
+        assistant_message_id: String,
+        tool_calls: &[ProjectedToolCall],
+    ) -> Self {
+        Self {
+            task_id,
+            assistant_message_id,
+            tool_call_ids: tool_calls
+                .iter()
+                .map(|tool_call| tool_call.key.tool_call_id.clone())
+                .collect(),
+        }
+    }
+
+    fn infer_assistant_message_id(&self, result: &ProjectedToolResult) -> Option<String> {
+        if result.task_id != self.task_id {
+            return None;
+        }
+
+        let matching_count = self
+            .tool_call_ids
+            .iter()
+            .filter(|tool_call_id| *tool_call_id == &result.tool_call_id)
+            .count();
+
+        if matching_count == 1 {
+            Some(self.assistant_message_id.clone())
+        } else {
+            None
+        }
+    }
+}
+
+struct ActiveToolCall {
+    tool_call: ToolCallRef,
+    results: Vec<ToolResultRef>,
+}
+
+impl ActiveToolCall {
+    fn new(tool_call: ToolCallRef) -> Self {
+        Self {
+            tool_call,
+            results: Vec::new(),
+        }
+    }
+}
+
+struct ActiveGroup {
+    task_id: String,
+    assistant_message_id: String,
+    calls: Vec<ActiveToolCall>,
+}
+
+impl ActiveGroup {
+    fn new(
+        task_id: String,
+        assistant_message_id: String,
+        tool_calls: Vec<ProjectedToolCall>,
+    ) -> Self {
+        Self {
+            task_id,
+            assistant_message_id,
+            calls: tool_calls
+                .into_iter()
+                .map(|tool_call| {
+                    ActiveToolCall::new(ToolCallRef::new(
+                        tool_call.key,
+                        tool_call.redacted_tool_kind,
+                    ))
+                })
+                .collect(),
+        }
+    }
+
+    fn matching_call_mut(&mut self, result: &ProjectedToolResult) -> Option<&mut ActiveToolCall> {
+        self.calls.iter_mut().find(|call| {
+            call.tool_call.key.task_id == result.task_id
+                && call.tool_call.key.tool_call_id == result.tool_call_id
+                && result
+                    .assistant_tool_call_message_id
+                    .as_ref()
+                    .map(|assistant_message_id| {
+                        assistant_message_id == &call.tool_call.key.assistant_tool_call_message_id
+                    })
+                    .unwrap_or(false)
+        })
+    }
+}
+
+struct Classifier<'a> {
+    context: &'a ReadinessContext,
+    active_group: Option<ActiveGroup>,
+    seen_tool_calls: HashSet<ToolCallKey>,
+    seen_task_tool_call_ids: HashSet<(String, String)>,
+    satisfied_tool_calls: HashSet<ToolCallKey>,
+    accepted_repairs: Vec<AcceptedRepair>,
+    deferred_missing_tool_calls: Vec<ToolCallRef>,
+    used_repair_indices: HashSet<usize>,
+    stale_repair_indices: HashSet<usize>,
+}
+
+impl<'a> Classifier<'a> {
+    fn new(context: &'a ReadinessContext) -> Self {
+        Self {
+            context,
+            active_group: None,
+            seen_tool_calls: HashSet::new(),
+            seen_task_tool_call_ids: HashSet::new(),
+            satisfied_tool_calls: HashSet::new(),
+            accepted_repairs: Vec::new(),
+            deferred_missing_tool_calls: Vec::new(),
+            used_repair_indices: HashSet::new(),
+            stale_repair_indices: HashSet::new(),
+        }
+    }
+
+    fn start_group(
+        &mut self,
+        task_id: String,
+        assistant_message_id: String,
+        tool_calls: Vec<ProjectedToolCall>,
+    ) {
+        for tool_call in &tool_calls {
+            self.seen_tool_calls.insert(tool_call.key.clone());
+            self.seen_task_tool_call_ids.insert((
+                tool_call.key.task_id.clone(),
+                tool_call.key.tool_call_id.clone(),
+            ));
+        }
+        self.active_group = Some(ActiveGroup::new(task_id, assistant_message_id, tool_calls));
+    }
+
+    fn handle_tool_result(&mut self, result: ProjectedToolResult) -> Option<ReadinessState> {
+        if self.active_group.is_none() {
+            return Some(self.unattached_result_state(result));
+        }
+
+        let active_group = self
+            .active_group
+            .as_mut()
+            .expect("active group checked above");
+        if result.task_id != active_group.task_id {
+            return Some(self.unattached_result_state(result));
+        }
+
+        if let Some(assistant_message_id) = &result.assistant_tool_call_message_id {
+            if assistant_message_id != &active_group.assistant_message_id {
+                return Some(self.unattached_result_state(result));
+            }
+        } else {
+            return Some(self.unattached_result_state(result));
+        }
+
+        let Some(active_call) = active_group.matching_call_mut(&result) else {
+            return Some(self.unattached_result_state(result));
+        };
+
+        if !result.result_kind.satisfies_readiness() {
+            return Some(ReadinessState::MissingResultWithoutRepairSource {
+                tool_calls: vec![active_call.tool_call.clone()],
+                reason: MissingResultReason::UnreadableLocalInterception,
+            });
+        }
+
+        self.satisfied_tool_calls
+            .insert(active_call.tool_call.key.clone());
+        active_call
+            .results
+            .push(ToolResultRef::from_result(&result));
+        if active_call.results.len() > 1 {
+            return Some(ReadinessState::DuplicateToolResults {
+                tool_call: active_call.tool_call.clone(),
+                results: active_call.results.clone(),
+            });
+        }
+
+        None
+    }
+
+    fn finish_active_group(&mut self, defer_unexplained_missing: bool) -> Option<ReadinessState> {
+        let active_group = self.active_group.take()?;
+        let mut repair_candidates = Vec::new();
+        let mut cancellation_needed = Vec::new();
+        let mut pending = Vec::new();
+        let mut missing = Vec::new();
+
+        for call in active_group.calls {
+            if call.results.len() == 1 {
+                continue;
+            }
+
+            if let Some(live_call) = self.live_call_for_key(&call.tool_call.key) {
+                match live_call.state {
+                    LiveToolCallState::CancellationRequested => {
+                        cancellation_needed.push(call.tool_call);
+                        continue;
+                    }
+                    LiveToolCallState::Running => {
+                        pending.push(call.tool_call);
+                        continue;
+                    }
+                }
+            }
+
+            if let Some((index, record)) = self.repair_record_for_key(&call.tool_call.key) {
+                repair_candidates.push(AcceptedRepair {
+                    record: record.clone(),
+                    tool_call: call.tool_call,
+                });
+                self.used_repair_indices.insert(index);
+                continue;
+            }
+
+            self.mark_stale_repair_records_for_visible_gap(&call.tool_call.key);
+
+            if defer_unexplained_missing {
+                self.deferred_missing_tool_calls.push(call.tool_call);
+            } else {
+                missing.push(call.tool_call);
+            }
+        }
+
+        if !cancellation_needed.is_empty() {
+            return Some(ReadinessState::NeedsCancellationCommit {
+                tool_calls: cancellation_needed,
+            });
+        }
+
+        if !pending.is_empty() {
+            return Some(ReadinessState::PendingToolResults {
+                tool_calls: pending,
+            });
+        }
+
+        if !missing.is_empty() {
+            return Some(ReadinessState::MissingResultWithoutRepairSource {
+                tool_calls: missing,
+                reason: MissingResultReason::NoResult,
+            });
+        }
+
+        self.accepted_repairs.extend(repair_candidates);
+        None
+    }
+
+    fn unattached_result_state(&self, result: ProjectedToolResult) -> ReadinessState {
+        let exact_key_seen = result
+            .key()
+            .map(|key| self.seen_tool_calls.contains(&key))
+            .unwrap_or(false);
+        let task_tool_call_seen = self
+            .seen_task_tool_call_ids
+            .contains(&(result.task_id.clone(), result.tool_call_id.clone()));
+
+        if exact_key_seen || task_tool_call_seen {
+            ReadinessState::OutOfOrderToolResult { result }
+        } else {
+            ReadinessState::OrphanToolResult { result }
+        }
+    }
+
+    fn live_call_for_key(&self, key: &ToolCallKey) -> Option<&LiveToolCall> {
+        self.context
+            .live_tool_calls
+            .iter()
+            .find(|live_call| &live_call.tool_call.key == key)
+    }
+
+    fn repair_record_for_key(&self, key: &ToolCallKey) -> Option<(usize, &RepairRecord)> {
+        self.context
+            .repair_records
+            .iter()
+            .enumerate()
+            .find(|(_, record)| &record.key == key)
+    }
+
+    fn mark_stale_repair_records_for_visible_gap(&mut self, key: &ToolCallKey) {
+        for (index, record) in self.context.repair_records.iter().enumerate() {
+            if record.key.tool_call_id == key.tool_call_id && record.key != *key {
+                self.stale_repair_indices.insert(index);
+            }
+        }
+    }
+
+    fn ready_report(self) -> ReadinessReport {
+        let state = if !self.deferred_missing_tool_calls.is_empty() {
+            ReadinessState::MissingResultWithoutRepairSource {
+                tool_calls: self.deferred_missing_tool_calls.clone(),
+                reason: MissingResultReason::NoResult,
+            }
+        } else if self.accepted_repairs.is_empty() {
+            ReadinessState::Ready
+        } else {
+            ReadinessState::AcceptedHistoryRepair {
+                repairs: self.accepted_repairs.clone(),
+            }
+        };
+        self.report(state)
+    }
+
+    fn report(self, state: ReadinessState) -> ReadinessReport {
+        let ignored_repair_records = self
+            .context
+            .repair_records
+            .iter()
+            .enumerate()
+            .filter(|(index, record)| {
+                self.stale_repair_indices.contains(index)
+                    || (!self.used_repair_indices.contains(index)
+                        && self.satisfied_tool_calls.contains(&record.key))
+            })
+            .map(|(_, record)| IgnoredRepairRecord {
+                record: record.clone(),
+                category: ReadinessCategory::StaleRepairRecordIgnored,
+            })
+            .collect();
+
+        ReadinessReport {
+            state,
+            ignored_repair_records,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "mod_test.rs"]
+mod tests;

--- a/app/src/ai/byop_readiness/mod_test.rs
+++ b/app/src/ai/byop_readiness/mod_test.rs
@@ -1,0 +1,637 @@
+use super::*;
+
+fn kind(name: &str) -> RedactedToolKind {
+    RedactedToolKind::new(name)
+}
+
+fn key(task_id: &str, assistant_message_id: &str, tool_call_id: &str) -> ToolCallKey {
+    ToolCallKey::new(task_id, assistant_message_id, tool_call_id)
+}
+
+fn call(task_id: &str, assistant_message_id: &str, tool_call_id: &str) -> ProjectedToolCall {
+    ProjectedToolCall::new(task_id, assistant_message_id, tool_call_id, kind("shell"))
+}
+
+fn call_ref(task_id: &str, assistant_message_id: &str, tool_call_id: &str) -> ToolCallRef {
+    ToolCallRef::new(
+        key(task_id, assistant_message_id, tool_call_id),
+        kind("shell"),
+    )
+}
+
+fn assistant_with_one_call() -> ProjectionItem {
+    ProjectionItem::assistant_tool_calls(
+        "task-1",
+        "assistant-1",
+        vec![call("task-1", "assistant-1", "call-1")],
+    )
+}
+
+fn persisted_result(message_id: &str, result_kind: TerminalResultKind) -> ProjectionItem {
+    ProjectionItem::tool_result(ProjectedToolResult::new(
+        "task-1",
+        message_id,
+        Some("assistant-1".to_string()),
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        result_kind,
+    ))
+}
+
+fn classify(items: Vec<ProjectionItem>) -> ReadinessReport {
+    classify_projection(&items, &ReadinessContext::default())
+}
+
+#[test]
+fn complete_real_result_is_ready() {
+    let report = classify(vec![
+        assistant_with_one_call(),
+        persisted_result("result-1", TerminalResultKind::Real),
+    ]);
+
+    assert_eq!(report.state, ReadinessState::Ready);
+    assert!(report.ignored_repair_records.is_empty());
+}
+
+#[test]
+fn current_input_result_uses_synthetic_projection_id_and_satisfies_readiness() {
+    let result = ProjectedToolResult::current_input(
+        3,
+        "task-1",
+        "assistant-1",
+        "call-1",
+        kind("shell"),
+        TerminalResultKind::Cancellation,
+    );
+    assert_eq!(result.message_id, "current_input:3:call-1");
+    assert_eq!(result.source, ToolResultSource::CurrentInput);
+
+    let report = classify(vec![
+        assistant_with_one_call(),
+        ProjectionItem::tool_result(result),
+    ]);
+
+    assert_eq!(report.state, ReadinessState::Ready);
+}
+
+#[test]
+fn compacted_structured_error_and_local_interception_results_satisfy_readiness() {
+    for result_kind in [
+        TerminalResultKind::Compacted,
+        TerminalResultKind::StructuredError,
+        TerminalResultKind::LocalInterception,
+    ] {
+        let report = classify(vec![
+            assistant_with_one_call(),
+            persisted_result("result-1", result_kind),
+        ]);
+        assert_eq!(report.state, ReadinessState::Ready);
+    }
+}
+
+#[test]
+fn accepted_history_repair_is_distinct_from_ready() {
+    let repair = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        key("task-1", "assistant-1", "call-1"),
+    );
+    let context = ReadinessContext {
+        repair_records: vec![repair.clone()],
+        live_tool_calls: Vec::new(),
+    };
+
+    let report = classify_projection(&[assistant_with_one_call()], &context);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::AcceptedHistoryRepair {
+            repairs: vec![AcceptedRepair {
+                record: repair,
+                tool_call: call_ref("task-1", "assistant-1", "call-1"),
+            }],
+        }
+    );
+}
+
+#[test]
+fn repair_record_must_match_full_key_not_only_tool_call_id() {
+    let stale_repair = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        key("other-task", "assistant-1", "call-1"),
+    );
+    let context = ReadinessContext {
+        repair_records: vec![stale_repair.clone()],
+        live_tool_calls: Vec::new(),
+    };
+
+    let report = classify_projection(&[assistant_with_one_call()], &context);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::MissingResultWithoutRepairSource {
+            tool_calls: vec![call_ref("task-1", "assistant-1", "call-1")],
+            reason: MissingResultReason::NoResult,
+        }
+    );
+    assert_eq!(
+        report.ignored_repair_records,
+        vec![IgnoredRepairRecord {
+            record: stale_repair,
+            category: ReadinessCategory::StaleRepairRecordIgnored,
+        }]
+    );
+}
+
+#[test]
+fn stale_repair_record_for_satisfied_visible_call_is_ignored() {
+    let stale_repair = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        key("task-1", "assistant-1", "call-1"),
+    );
+    let context = ReadinessContext {
+        repair_records: vec![stale_repair.clone()],
+        live_tool_calls: Vec::new(),
+    };
+
+    let report = classify_projection(
+        &[
+            assistant_with_one_call(),
+            persisted_result("result-1", TerminalResultKind::Real),
+        ],
+        &context,
+    );
+
+    assert_eq!(report.state, ReadinessState::Ready);
+    assert_eq!(
+        report.ignored_repair_records,
+        vec![IgnoredRepairRecord {
+            record: stale_repair,
+            category: ReadinessCategory::StaleRepairRecordIgnored,
+        }]
+    );
+}
+
+#[test]
+fn hidden_repair_record_is_unused_without_stale_diagnostic() {
+    let hidden_repair = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        key("task-1", "assistant-hidden", "call-hidden"),
+    );
+    let context = ReadinessContext {
+        repair_records: vec![hidden_repair],
+        live_tool_calls: Vec::new(),
+    };
+
+    let report = classify_projection(&[], &context);
+
+    assert_eq!(report.state, ReadinessState::Ready);
+    assert!(report.ignored_repair_records.is_empty());
+}
+
+#[test]
+fn running_live_action_is_pending() {
+    let context = ReadinessContext {
+        repair_records: Vec::new(),
+        live_tool_calls: vec![LiveToolCall::new(
+            call_ref("task-1", "assistant-1", "call-1"),
+            LiveToolCallState::Running,
+        )],
+    };
+
+    let report = classify_projection(&[assistant_with_one_call()], &context);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::PendingToolResults {
+            tool_calls: vec![call_ref("task-1", "assistant-1", "call-1")],
+        }
+    );
+}
+
+#[test]
+fn cancellation_requested_returns_needs_cancellation_commit() {
+    let context = ReadinessContext {
+        repair_records: Vec::new(),
+        live_tool_calls: vec![LiveToolCall::new(
+            call_ref("task-1", "assistant-1", "call-1"),
+            LiveToolCallState::CancellationRequested,
+        )],
+    };
+
+    let report = classify_projection(&[assistant_with_one_call()], &context);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::NeedsCancellationCommit {
+            tool_calls: vec![call_ref("task-1", "assistant-1", "call-1")],
+        }
+    );
+}
+
+#[test]
+fn duplicate_tool_results_block_readiness() {
+    let report = classify(vec![
+        assistant_with_one_call(),
+        persisted_result("result-1", TerminalResultKind::Real),
+        persisted_result("result-2", TerminalResultKind::Cancellation),
+    ]);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::DuplicateToolResults {
+            tool_call: call_ref("task-1", "assistant-1", "call-1"),
+            results: vec![
+                ToolResultRef {
+                    message_id: "result-1".to_string(),
+                    source: ToolResultSource::PersistedHistory,
+                    result_kind: TerminalResultKind::Real,
+                },
+                ToolResultRef {
+                    message_id: "result-2".to_string(),
+                    source: ToolResultSource::PersistedHistory,
+                    result_kind: TerminalResultKind::Cancellation,
+                },
+            ],
+        }
+    );
+}
+
+#[test]
+fn duplicate_projection_preserves_result_source() {
+    let current_result = ProjectedToolResult::current_input(
+        0,
+        "task-1",
+        "assistant-1",
+        "call-1",
+        kind("shell"),
+        TerminalResultKind::Cancellation,
+    );
+
+    let report = classify(vec![
+        assistant_with_one_call(),
+        persisted_result("result-1", TerminalResultKind::Real),
+        ProjectionItem::tool_result(current_result),
+    ]);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::DuplicateToolResults {
+            tool_call: call_ref("task-1", "assistant-1", "call-1"),
+            results: vec![
+                ToolResultRef {
+                    message_id: "result-1".to_string(),
+                    source: ToolResultSource::PersistedHistory,
+                    result_kind: TerminalResultKind::Real,
+                },
+                ToolResultRef {
+                    message_id: "current_input:0:call-1".to_string(),
+                    source: ToolResultSource::CurrentInput,
+                    result_kind: TerminalResultKind::Cancellation,
+                },
+            ],
+        }
+    );
+}
+
+#[test]
+fn orphan_tool_result_blocks_readiness() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        Some("assistant-unknown".to_string()),
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::Real,
+    );
+
+    let report = classify(vec![ProjectionItem::tool_result(result.clone())]);
+
+    assert_eq!(report.state, ReadinessState::OrphanToolResult { result });
+}
+
+#[test]
+fn tool_result_after_user_boundary_is_out_of_order() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        Some("assistant-1".to_string()),
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::Real,
+    );
+
+    let report = classify(vec![
+        assistant_with_one_call(),
+        ProjectionItem::user_boundary("task-1", "user-2"),
+        ProjectionItem::tool_result(result.clone()),
+    ]);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::OutOfOrderToolResult { result }
+    );
+}
+
+#[test]
+fn unreadable_local_interception_does_not_satisfy_readiness() {
+    let report = classify(vec![
+        assistant_with_one_call(),
+        persisted_result("result-1", TerminalResultKind::UnreadableLocalInterception),
+    ]);
+
+    assert_eq!(
+        report.state,
+        ReadinessState::MissingResultWithoutRepairSource {
+            tool_calls: vec![call_ref("task-1", "assistant-1", "call-1")],
+            reason: MissingResultReason::UnreadableLocalInterception,
+        }
+    );
+}
+
+#[test]
+fn projection_infers_backref_for_unique_valid_pending_call() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        None,
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::Real,
+    );
+    let normalized = normalize_projection(vec![
+        assistant_with_one_call(),
+        ProjectionItem::tool_result(result),
+    ]);
+
+    let ProjectionItemKind::ToolResult(result) = &normalized[1].kind else {
+        panic!("expected tool result");
+    };
+    assert_eq!(
+        result.assistant_tool_call_message_id.as_deref(),
+        Some("assistant-1")
+    );
+}
+
+#[test]
+fn projection_does_not_infer_backref_across_boundary() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        None,
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::Real,
+    );
+    let normalized = normalize_projection(vec![
+        assistant_with_one_call(),
+        ProjectionItem::assistant_boundary("task-1", "assistant-2"),
+        ProjectionItem::tool_result(result),
+    ]);
+
+    let ProjectionItemKind::ToolResult(result) = &normalized[2].kind else {
+        panic!("expected tool result");
+    };
+    assert!(result.assistant_tool_call_message_id.is_none());
+}
+
+#[test]
+fn projection_does_not_infer_ambiguous_backref() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        None,
+        "call-1",
+        kind("shell"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::Real,
+    );
+    let normalized = normalize_projection(vec![
+        ProjectionItem::assistant_tool_calls(
+            "task-1",
+            "assistant-1",
+            vec![
+                call("task-1", "assistant-1", "call-1"),
+                call("task-1", "assistant-1", "call-1"),
+            ],
+        ),
+        ProjectionItem::tool_result(result.clone()),
+    ]);
+
+    let ProjectionItemKind::ToolResult(normalized_result) = &normalized[1].kind else {
+        panic!("expected tool result");
+    };
+    assert!(normalized_result.assistant_tool_call_message_id.is_none());
+
+    let report = classify_projection(&normalized, &ReadinessContext::default());
+    assert_eq!(
+        report.state,
+        ReadinessState::OutOfOrderToolResult { result }
+    );
+}
+
+#[test]
+fn projection_does_not_store_raw_prompt_or_tool_payload() {
+    let result = ProjectedToolResult::new(
+        "task-1",
+        "result-1",
+        Some("assistant-1".to_string()),
+        "call-1",
+        kind("local_interception:websearch"),
+        ToolResultSource::PersistedHistory,
+        TerminalResultKind::LocalInterception,
+    );
+    let debug = format!("{result:?}");
+
+    assert!(debug.contains("local_interception:websearch"));
+    assert!(!debug.contains("secret user prompt"));
+    assert!(!debug.contains("raw tool output"));
+    assert!(!debug.contains("raw tool arguments"));
+}
+
+#[test]
+fn repair_state_missing_sidecar_loads_as_valid_empty_state() {
+    let status = RepairStateStatus::from_sidecar_json(None);
+
+    assert_eq!(status, RepairStateStatus::Valid(RepairState::default()));
+    assert!(status.repair_records().is_empty());
+    assert_eq!(status.to_sidecar_json(), None);
+}
+
+#[test]
+fn repair_state_accepts_version_one_and_roundtrips_records() {
+    let record = RepairRecord::new(
+        RepairSource::ForkedHistory,
+        key("task-1", "assistant-1", "call-1"),
+    );
+    let json = serde_json::to_string(&RepairState::new(vec![record.clone()])).unwrap();
+    let status = RepairStateStatus::from_sidecar_json(Some(json));
+
+    assert_eq!(
+        status,
+        RepairStateStatus::Valid(RepairState::new(vec![record.clone()]))
+    );
+    assert_eq!(status.repair_records(), &[record]);
+    assert!(status.to_sidecar_json().unwrap().contains("\"version\":1"));
+}
+
+#[test]
+fn repair_state_invalid_json_is_invalid_and_preserved() {
+    let raw_json = "{not valid json".to_string();
+    let status = RepairStateStatus::from_sidecar_json(Some(raw_json.clone()));
+
+    assert!(matches!(
+        status,
+        RepairStateStatus::Invalid(InvalidRepairState {
+            error_category: RepairStateLoadError::InvalidJson,
+            ..
+        })
+    ));
+    assert!(status.repair_records().is_empty());
+    assert_eq!(status.to_sidecar_json(), Some(raw_json));
+}
+
+#[test]
+fn repair_state_missing_or_unsupported_version_is_unsupported_and_preserved() {
+    for raw_json in [
+        r#"{"records":[]}"#.to_string(),
+        r#"{"version":2,"records":[]}"#.to_string(),
+    ] {
+        let status = RepairStateStatus::from_sidecar_json(Some(raw_json.clone()));
+
+        assert!(matches!(
+            status,
+            RepairStateStatus::Invalid(InvalidRepairState {
+                error_category: RepairStateLoadError::UnsupportedVersion,
+                ..
+            })
+        ));
+        assert!(status.repair_records().is_empty());
+        assert_eq!(status.to_sidecar_json(), Some(raw_json));
+    }
+}
+
+#[test]
+fn repair_source_maps_to_stable_placeholder_reasons() {
+    assert_eq!(
+        RepairSource::ForkedHistory.placeholder_reason(),
+        "forked_history_repair"
+    );
+    assert_eq!(
+        RepairSource::RestoredLegacyHistory.placeholder_reason(),
+        "restored_legacy_history_repair"
+    );
+}
+
+#[test]
+fn diagnostics_for_observed_gap_use_categories_and_redacted_metadata() {
+    let state = ReadinessState::MissingResultWithoutRepairSource {
+        tool_calls: vec![ToolCallRef::new(
+            key("task-1", "assistant-1", "call-1"),
+            kind("local_interception:websearch"),
+        )],
+        reason: MissingResultReason::NoResult,
+    };
+
+    assert_eq!(
+        state.category(),
+        ReadinessCategory::MissingResultWithoutRepairSource
+    );
+    let targets = readiness_state_targets(&state);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].task_id, "task-1");
+    assert_eq!(targets[0].assistant_tool_call_message_id, "assistant-1");
+    assert_eq!(targets[0].tool_call_id, "call-1");
+    assert_eq!(
+        targets[0].redacted_tool_kind,
+        "local_interception:websearch"
+    );
+
+    let rendered = format!("{:?} {:?}", state.category(), targets[0]);
+    assert!(!rendered.contains("secret user prompt"));
+    assert!(!rendered.contains("raw tool arguments"));
+    assert!(!rendered.contains("raw tool output"));
+    assert!(!rendered.contains("raw local interception payload"));
+
+    let context = ReadinessDiagnosticContext::new(
+        "conversation-1",
+        "attempt-1",
+        ReadinessTriggerLayer::SerializerValidation,
+    )
+    .with_iteration(3);
+    let mut coalescer = ReadinessDiagnosticCoalescer::default();
+    let entries =
+        coalescer.test_log_state_entries(&state, &context, ReadinessDiagnosticLevel::Error);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].level, ReadinessDiagnosticLevel::Error);
+    let message = &entries[0].message;
+    assert!(message.contains("category=MissingResultWithoutRepairSource"));
+    assert!(message.contains("conversation_id=conversation-1"));
+    assert!(message.contains("task_id=task-1"));
+    assert!(message.contains("assistant_tool_call_message_id=assistant-1"));
+    assert!(message.contains("tool_call_id=call-1"));
+    assert!(message.contains("redacted_tool_kind=local_interception:websearch"));
+    assert!(message.contains("trigger_layer=serializer_validation"));
+    assert!(message.contains("request_attempt_id=attempt-1"));
+    assert!(message.contains("iteration=3"));
+    assert!(!message.contains("secret user prompt"));
+    assert!(!message.contains("raw tool arguments"));
+    assert!(!message.contains("raw tool output"));
+    assert!(!message.contains("raw local interception payload"));
+}
+
+#[test]
+fn diagnostic_coalescing_uses_request_local_safe_key() {
+    let state = ReadinessState::MissingResultWithoutRepairSource {
+        tool_calls: vec![call_ref("task-1", "assistant-1", "call-1")],
+        reason: MissingResultReason::NoResult,
+    };
+    let context = ReadinessDiagnosticContext::new(
+        "conversation-1",
+        "attempt-1",
+        ReadinessTriggerLayer::ControllerPreflight,
+    )
+    .with_iteration(2);
+    let mut coalescer = ReadinessDiagnosticCoalescer::default();
+
+    coalescer.log_state(&state, &context, ReadinessDiagnosticLevel::Error);
+    coalescer.log_state(&state, &context, ReadinessDiagnosticLevel::Error);
+
+    let (key, suppressed_count) = coalescer
+        .suppressed_by_key
+        .iter()
+        .next()
+        .expect("duplicate diagnostic should be coalesced");
+    assert_eq!(*suppressed_count, 1);
+    assert_eq!(
+        key.category,
+        ReadinessCategory::MissingResultWithoutRepairSource
+    );
+    assert_eq!(key.conversation_id, "conversation-1");
+    assert_eq!(key.task_id, "task-1");
+    assert_eq!(key.assistant_tool_call_message_id, "assistant-1");
+    assert_eq!(key.tool_call_id, "call-1");
+    assert_eq!(
+        key.trigger_layer,
+        ReadinessTriggerLayer::ControllerPreflight
+    );
+
+    let summary_entries = coalescer.test_finish_entries(&context, ReadinessDiagnosticLevel::Error);
+    assert_eq!(summary_entries.len(), 1);
+    assert_eq!(summary_entries[0].level, ReadinessDiagnosticLevel::Error);
+    let message = &summary_entries[0].message;
+    assert!(message.contains("diagnostic coalesced"));
+    assert!(message.contains("suppressed_count=1"));
+    assert!(message.contains("category=MissingResultWithoutRepairSource"));
+    assert!(message.contains("conversation_id=conversation-1"));
+    assert!(message.contains("task_id=task-1"));
+    assert!(message.contains("assistant_tool_call_message_id=assistant-1"));
+    assert!(message.contains("tool_call_id=call-1"));
+    assert!(message.contains("redacted_tool_kind=omitted"));
+    assert!(message.contains("trigger_layer=controller_preflight"));
+    assert!(message.contains("request_attempt_id=attempt-1"));
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -18,6 +18,7 @@ pub mod aws_credentials;
 pub(crate) mod block_context;
 pub(crate) mod blocklist;
 pub(crate) mod byop_compaction;
+pub(crate) mod byop_readiness;
 pub mod control_code_parser;
 pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_status_ui;

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -980,6 +980,7 @@ impl TerminalView {
             autoexecute_override: None,
             last_event_sequence: None,
             compaction_state_json: None,
+            byop_repair_state_json: None,
         };
 
         match AIConversation::new_restored(conversation_id, tasks, Some(conversation_data)) {

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1008,6 +1008,9 @@ pub struct AgentConversationData {
     /// `None` means no compaction has occurred.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction_state_json: Option<String>,
+    /// Opaque serialized BYOP repair sidecar. The app layer owns validation semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub byop_repair_state_json: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1314,6 +1317,7 @@ mod tests {
             autoexecute_override: None,
             last_event_sequence: Some(42),
             compaction_state_json: None,
+            byop_repair_state_json: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
@@ -1328,6 +1332,7 @@ mod tests {
         let data: AgentConversationData =
             serde_json::from_str(legacy_json).expect("legacy rows must deserialize");
         assert_eq!(data.last_event_sequence, None);
+        assert_eq!(data.byop_repair_state_json, None);
     }
 
     #[test]
@@ -1345,11 +1350,39 @@ mod tests {
             autoexecute_override: None,
             last_event_sequence: None,
             compaction_state_json: None,
+            byop_repair_state_json: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         assert!(
             !json.contains("last_event_sequence"),
             "None should be skipped in serialized output: {json}"
+        );
+    }
+
+    #[test]
+    fn agent_conversation_data_roundtrips_byop_repair_sidecar() {
+        let data = AgentConversationData {
+            server_conversation_token: None,
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: None,
+            agent_name: None,
+            parent_conversation_id: None,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            compaction_state_json: None,
+            byop_repair_state_json: Some(r#"{"version":1,"records":[]}"#.to_string()),
+        };
+
+        let json = serde_json::to_string(&data).expect("serialize");
+        let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(
+            roundtripped.byop_repair_state_json.as_deref(),
+            Some(r#"{"version":1,"records":[]}"#)
         );
     }
 }

--- a/specs/byop-placeholder-tool-results/ADR.md
+++ b/specs/byop-placeholder-tool-results/ADR.md
@@ -1,0 +1,7 @@
+# Explicit Repair Records Gate BYOP Placeholder Tool Results
+
+Status: accepted
+
+Normal BYOP request flow must not fabricate placeholder tool results when a model tool call is missing its recorded result. OpenWarp will block normal-flow serialization until the tool call has a real terminal result, while placeholder tool results remain available only for explicit history repair backed by per-tool-call Repair Records.
+
+The rejected alternative was to keep the broad sanitizer behavior and infer repair from a missing result. That keeps provider payloads protocol-valid, but it lets the model reason from an artificial observation and hides timing, persistence, fork, or restore bugs. Requiring explicit Repair Records makes repair rarer and more work to set up, but it keeps normal agent execution grounded in real results and leaves a durable explanation for every placeholder that is intentionally emitted.

--- a/specs/byop-placeholder-tool-results/ISSUES.md
+++ b/specs/byop-placeholder-tool-results/ISSUES.md
@@ -1,0 +1,213 @@
+# BYOP Placeholder Tool Results Local Issues
+
+本文件记录 `$to-issues` 已确认的本地 implementation issues。它们不发布到 GitHub。
+
+Source artifacts:
+
+- `CONTEXT.md`
+- `specs/byop-placeholder-tool-results/PRODUCT.md`
+- `specs/byop-placeholder-tool-results/TECH.md`
+- `specs/byop-placeholder-tool-results/ADR.md`
+
+## BYOP-PR-1: BYOP Request Readiness 核心分类器
+
+Type: AFK
+
+## What to build
+
+Create the core BYOP request-readiness classifier as a pure implementation slice. It should normalize the BYOP Chat-visible conversation projection into safe metadata, classify tool-call readiness without mutating controller or serializer state, and preserve the accepted terminology around Terminal Tool Result, Placeholder Tool Result, Repair Record, and Request Readiness.
+
+This slice must not wire controller preflight or serializer dispatch behavior yet. Its output is a focused, independently testable module that later slices can call.
+
+## Acceptance criteria
+
+- [x] A `byop_readiness` module exposes normalized projection types that carry task ID, message ID, assistant tool-call message ID, tool call ID, redacted tool kind, result source, and projected message kind.
+- [x] The projection and classifier do not carry raw user prompt text, tool arguments, tool output, raw carrier payloads, or raw local interception payloads.
+- [x] The classifier covers `Ready`, `AcceptedHistoryRepair`, `PendingToolResults`, `NeedsCancellationCommit`, `DuplicateToolResults`, `OrphanToolResult`, `OutOfOrderToolResult`, `MissingResultWithoutRepairSource`, and non-blocking stale repair-record ignored behavior.
+- [x] Repair matching requires task ID, assistant tool-call message ID, and tool call ID; tool-call ID alone is insufficient.
+- [x] Unit tests cover complete, pending, cancelled, duplicate, orphan, out-of-order, corrupted, compacted, current-input, structured-error, local-interception, unreadable-local-interception, and accepted-repair groups.
+- [x] This slice does not create or persist Repair Records and does not insert Placeholder Tool Results.
+
+## Blocked by
+
+None - can start immediately.
+
+## BYOP-PR-2: Serializer 阻断普通流程缺失 Tool Result
+
+Type: AFK
+
+## What to build
+
+Apply BYOP request readiness at the serializer boundary so normal request flow cannot send Placeholder Tool Results for missing, duplicate, orphaned, or out-of-order tool results. Validation must run over the final outbound BYOP Chat projection after compaction/filtering and current request input have been accounted for.
+
+This slice keeps explicit history repair unavailable until the repair sidecar slice adds durable Repair Records.
+
+## Acceptance criteria
+
+- [x] BYOP Chat request serialization runs readiness validation before provider `ChatMessage` construction or sanitizer repair.
+- [x] Normal-flow missing tool results are blocked before placeholder insertion.
+- [x] Duplicate, orphan, and out-of-order tool results are blocked rather than reordered or silently deduplicated.
+- [x] Serializer validation treats visible unknown or readiness-irrelevant outbound messages as ordering boundaries, while filtered-out messages do not affect readiness.
+- [x] Current `RequestParams.input` action results can satisfy readiness when they are valid visible Terminal Tool Results.
+- [x] Request-body tests prove strict Chat Completions ordering: no orphan tool responses, no duplicate tool result IDs, and no user/assistant message before required tool responses.
+
+## Blocked by
+
+- BYOP-PR-1
+
+## BYOP-PR-3: Repair Sidecar 与 Accepted History Repair
+
+Type: AFK
+
+## What to build
+
+Add durable BYOP repair metadata and allow Placeholder Tool Results only for explicit accepted History Repair. Repair state should load, validate, and persist as an app-layer sidecar while persistence only stores opaque optional JSON. Accepted repair placeholders are outbound-only structured JSON and must not be written back as conversation history.
+
+## Acceptance criteria
+
+- [x] `RepairState`, `RepairRecord`, `RepairSource`, and `RepairStateStatus` support version `1`, missing sidecar as valid empty state, invalid JSON as invalid status, and unsupported/missing versions as unsupported status.
+- [x] `AgentConversationData` roundtrips the optional repair sidecar, and legacy payloads without the field still deserialize.
+- [x] `AIConversation` loads, preserves, and saves valid or invalid repair sidecar state without collapsing invalid state to empty.
+- [x] `RequestParams` carries a read-only repair-state snapshot for BYOP serializer validation.
+- [x] Accepted history repair remains distinct from ordinary `Ready` in validation, diagnostics, and tests.
+- [x] The broad sanitizer is renamed or extracted so only accepted history repair can emit placeholders.
+- [x] Repair placeholders are structured JSON containing only `status`, `reason`, and `note`, with `status = "unavailable"` and stable snake_case reason values.
+- [x] Repair placeholders are not persisted as task messages or conversation history.
+
+## Blocked by
+
+- BYOP-PR-1
+- BYOP-PR-2
+
+## BYOP-PR-4: User Continuation 取消路径提交真实 Cancellation Result
+
+Type: AFK
+
+## What to build
+
+Add controller preflight behavior for the user-continuation case where a prior Model Tool Call must be cancelled before the next BYOP request is serialized. The controller should commit a real Cancellation Result while it owns mutable conversation/action state, persist it, rebuild request parameters, and rerun readiness.
+
+## Acceptance criteria
+
+- [x] Controller preflight detects `NeedsCancellationCommit` from readiness and commits a Cancellation Result keyed to the original tool call.
+- [x] Cancellation-result commit is idempotent by tool call ID and avoids duplicate persisted or outbound tool results.
+- [x] Cancellation-result persistence must succeed before BYOP dispatch continues.
+- [x] If cancellation persistence fails, BYOP dispatch is blocked and does not proceed with in-memory-only state or current-input fallback.
+- [x] After successful persistence, old `RequestParams` are discarded, `RequestParams` are rebuilt from updated conversation state, and readiness is rerun.
+- [x] Corrupted or unexplained history from this path does not open a provider request and does not schedule retry or auto-resume.
+
+## Blocked by
+
+- BYOP-PR-1
+- BYOP-PR-2
+
+## BYOP-PR-5: Finished Result Drain 与 Auto-Resume Readiness
+
+Type: AFK
+
+## What to build
+
+Extend controller preflight to drain finished action results and coordinate pending/live action state with BYOP readiness. Auto-resume and locally intercepted tool paths should only proceed once the relevant Terminal Tool Result is represented in the outbound projection as real, compacted, structured-error, or local-interception result.
+
+## Acceptance criteria
+
+- [x] Finished action results needed for readiness are persisted before BYOP dispatch.
+- [x] Finished-result persistence failure blocks BYOP dispatch and cannot be bypassed by reintroducing the result through current `RequestParams.input`.
+- [x] Pending tool results do not open a provider request and remain in the existing wait or auto-resume path.
+- [x] Live action matching requires current conversation, task ID, and tool call or action ID so another task cannot satisfy the missing result.
+- [x] Successful drain or cancellation persistence causes `RequestParams` rebuild and avoids projecting both current-input and persisted-history copies of the same result.
+- [x] Committed local interception results, including structured invalid-arguments results, satisfy readiness; unreadable local interception payloads block without logging raw payloads.
+- [x] The readiness rerun loop is bounded to the accepted initial maximum and blocks with non-sensitive diagnostics if no progress is made.
+
+## Blocked by
+
+- BYOP-PR-1
+- BYOP-PR-2
+- BYOP-PR-4
+
+## BYOP-PR-6: Fork/Legacy Restore 创建 Repair Records
+
+Type: AFK
+
+## What to build
+
+Create Repair Records only at explicit history transformation boundaries: fork creation and legacy restore/conversion. The records should authorize only retained Model Tool Calls whose matching Terminal Tool Results were intentionally unavailable due to that transformation.
+
+## Acceptance criteria
+
+- [x] Fork creation records `ForkedHistory` repair only for retained assistant tool calls whose matching results were intentionally omitted by the fork operation.
+- [x] Fork creation does not convert retained orphan tool results into repair records.
+- [ ] Legacy restore/conversion records `RestoredLegacyHistory` repair only for gaps proven by conversion-time input or documented legacy format behavior.
+- [x] Restored conversations with unexplained missing tool results are treated as corrupted persisted history by default.
+- [x] Repair records survive conversation serialization and remain available after fork routing tokens are cleared.
+- [x] Repair records authorize only exact task ID, assistant tool-call message ID, and tool call ID matches.
+
+Review note: no current legacy restore/conversion input in this checkout proves a missing result came from documented legacy behavior, so this slice intentionally does not create `RestoredLegacyHistory` records from unexplained restored gaps.
+
+## Blocked by
+
+- BYOP-PR-3
+
+## BYOP-PR-7: Blocked Request Error 与 Readiness Logs
+
+Type: AFK
+
+## What to build
+
+Add user-visible blocked-request behavior and non-sensitive readiness diagnostics. Corrupted or unexplained history should be reported as a local no-send condition, not as a provider rejection, and should not automatically retry or resume. Logs should distinguish accepted repair, pending live work, cancellation commit, and corrupted history without exposing sensitive content.
+
+## Acceptance criteria
+
+- [x] Corrupted or unexplained readiness failures map to `RenderableAIError::Other` with `will_attempt_resume = false`.
+- [x] Blocked-request copy states that OpenWarp did not send the BYOP request because a previous tool call is missing its recorded result.
+- [x] The initial blocked-request UI does not expose automatic retry or ordinary retry behavior.
+- [x] Manual continuation still passes through readiness and cannot bypass the same blocked state.
+- [x] Diagnostics include readiness category, conversation ID, task ID, assistant tool-call message ID, tool call ID, redacted tool kind, trigger layer, and a non-persistent request-attempt ID where available.
+- [x] Diagnostics omit tool arguments, tool output, raw user prompt text, raw carrier payloads, and raw local interception payloads.
+- [x] Repeated blocked diagnostics are coalesced within one request attempt and summarize suppressed counts without sensitive content.
+- [x] Accepted history repair logs one summarized `info` diagnostic per request with record count and repair-source counts.
+
+## Blocked by
+
+- BYOP-PR-2
+- BYOP-PR-3
+- BYOP-PR-4
+- BYOP-PR-5
+
+## BYOP-PR-8: Placeholder-Then-Cancellation 回归与 Strict Ordering Harness
+
+Type: AFK
+
+## What to build
+
+Add end-to-end regression coverage for the observed placeholder-then-cancellation shape using synthetic, minimal, redacted fixtures. The test harness should verify that normal BYOP requests never emit placeholder tool results for live or unexplained gaps, while accepted repair remains provider-compatible and outbound-only.
+
+## Acceptance criteria
+
+- [x] A synthetic regression fixture reproduces the structure where one request previously would have contained `(tool 执行结果未保留)` before a later request saw the real cancellation result.
+- [x] The same fixture now proves the immediate BYOP request is blocked, waits, or contains a real Cancellation Result, depending on controller state, but never sends a normal-flow Placeholder Tool Result.
+- [x] Strict Chat Completions ordering helper validates generated request bodies for orphan tools, duplicate tool results, and pending tool calls before user/assistant messages.
+- [x] Tests cover accepted repair placeholders, including structured JSON semantics and outbound-only behavior.
+- [x] Tests cover compaction/filtering boundaries so hidden historical gaps do not block while visible assistant tool calls still require a result or repair record.
+- [x] Log-focused assertions verify diagnostic categories and redaction for the observed shape.
+- [x] Project-required validation is documented for the implementation branch, at minimum `cargo check`.
+
+Validation:
+
+- 2026-05-18: `cargo test -p warp serializer_readiness_tests --lib`
+- 2026-05-18: `cargo test -p warp byop_readiness --lib`
+- 2026-05-18: `cargo check -p warp --lib`
+- 2026-05-18: `git diff --check -- app\src\ai\agent_providers\chat_stream.rs app\src\ai\byop_readiness\mod_test.rs specs\byop-placeholder-tool-results\ISSUES.md`
+- 2026-05-19 follow-up review fixes: `cargo test -p warp serializer_readiness_tests --lib`
+- 2026-05-19 follow-up review fixes: `cargo test -p warp byop_readiness --lib`
+- 2026-05-19 follow-up review fixes: `cargo check -p warp --lib`
+- 2026-05-19 follow-up review fixes: `git diff --check -- app\src\ai\agent_providers\chat_stream.rs app\src\ai\byop_readiness\mod.rs app\src\ai\byop_readiness\mod_test.rs app\src\ai\blocklist\controller.rs specs\byop-placeholder-tool-results\ISSUES.md`
+
+## Blocked by
+
+- BYOP-PR-2
+- BYOP-PR-3
+- BYOP-PR-4
+- BYOP-PR-5
+- BYOP-PR-6
+- BYOP-PR-7

--- a/specs/byop-placeholder-tool-results/PRODUCT.md
+++ b/specs/byop-placeholder-tool-results/PRODUCT.md
@@ -1,0 +1,403 @@
+# Prevent BYOP Placeholder Tool Results From Reaching Normal Agent Requests
+
+Technical implementation details are tracked in `TECH.md`. The core repair-boundary decision is recorded in `ADR.md`.
+
+## Problem Statement
+
+OpenWarp BYOP Agent can construct a follow-up request before a real asynchronous tool result has been persisted. To keep the OpenAI Chat tool-call sequence valid, the current request sanitizer may insert a placeholder tool result: `(tool 执行结果未保留)`.
+
+This avoids upstream protocol rejection, but it gives the model an artificial observation. From the user's perspective, the agent appears to continue normally while reasoning from incomplete or misleading tool output. This can cause repeated actions, weaker follow-up decisions, or confusion in long-running command workflows.
+
+## Solution
+
+OpenWarp should only send real terminal tool states to BYOP providers during normal agent execution. Before a BYOP request is sent, every model-produced tool call that is still relevant to the conversation should have a real terminal result: success, cancellation, or structured error.
+
+Placeholder tool results should remain available as a defensive repair mechanism for explicitly recorded forked or restored legacy history gaps. They should not be produced for ordinary in-flight tool execution, user continuation, auto-resume flow, corrupted persisted history, or compacted tool output.
+
+## User Stories
+
+1. As an OpenWarp user, I want the agent to see real tool results, so that it can continue from accurate context.
+2. As a BYOP user, I want OpenWarp to preserve strict OpenAI Chat tool-call ordering, so that strict providers accept my requests.
+3. As a DeepSeek BYOP user, I want `assistant(tool_calls) -> tool -> user` ordering to remain valid, so that my requests are not rejected for malformed history.
+4. As an agent user, I want cancelled tool execution to be recorded as a real cancellation result, so that the model understands why no normal output was produced.
+5. As a user who sends a new prompt while tools are running, I want OpenWarp to drain or cancel prior tool actions before the next request is built, so that history stays coherent.
+6. As a user working in a long-running command session, I want the model to receive the latest real PTY tool result, so that it does not act on stale or missing terminal state.
+7. As a user using LRC tag-in, I want auto-accepted tools to finish their result persistence before auto-resume, so that the next model turn has complete observations.
+8. As a user, I want the agent to avoid retrying work only because it saw a placeholder result, so that it does not repeat commands unnecessarily.
+9. As a user, I want placeholders to be rare and diagnosable, so that I can trust normal agent runs are based on real results.
+10. As a developer, I want placeholder insertion to be classified by cause, so that I can distinguish expected history repair from a normal-flow bug.
+11. As a developer, I want BYOP request readiness to be checked before request serialization, so that protocol balancing is not the only guardrail.
+12. As a developer, I want the request sanitizer to remain a final safety net, so that explicitly repairable history still cannot produce invalid provider payloads.
+13. As a maintainer, I want a small testable module for tool-call readiness, so that the behavior can be validated without constructing full UI state.
+14. As a maintainer, I want deterministic request-body tests, so that future changes do not reintroduce orphan tools, late tool results, or placeholder use in normal paths.
+15. As a support engineer, I want logs to identify when a placeholder was inserted and why, so that log-based diagnosis is fast.
+16. As a support engineer, I want normal in-flight tool waits to be logged differently from damaged historical state, so that user reports are easier to triage.
+17. As a BYOP provider integrator, I want OpenWarp to emit provider-compatible tool result bundles, so that adapters do not need to compensate for malformed conversation state.
+18. As a tester, I want regression coverage using the observed placeholder scenario, so that the specific failure shape cannot silently return.
+19. As a user of local tool interception, I want intercepted tool results to auto-resume only after they are represented as real tool results, so that the model sees the intended feedback.
+20. As an OpenWarp user, I want long conversations to continue without fabricated observations, so that agent quality does not degrade unexpectedly.
+
+## Implementation Decisions
+
+- Build or extract a request-readiness module for BYOP tool-call groups. It should expose a small interface that reports whether a request can be serialized, should wait, should persist cancellation results, or should fall back to history repair.
+- The initial readiness result classification should distinguish at least: ready, pending tool results, needs cancellation-result commit, accepted history repair, duplicate tool results, orphan tool result, out-of-order tool result, missing result without repair source, and stale repair record ignored.
+- `AcceptedHistoryRepair` should be represented as a distinct sendable readiness state rather than folded into ordinary `Ready`.
+- Serializer validation may proceed for `AcceptedHistoryRepair`, but it should carry the accepted repair records forward so outbound placeholder generation, logs, and tests can identify that the request depended on history repair.
+- The readiness module should remain a pure classifier. It should return `NeedsCancellationCommit` with enough tool-call metadata for the controller to act, rather than mutating action state or conversation history directly.
+- `NeedsCancellationCommit` metadata should include at least conversation ID, task ID, tool call ID or action result ID, assistant tool-call message ID where available, tool kind, and cancellation reason.
+- `NeedsCancellationCommit` metadata should not include tool arguments or tool output.
+- Core tool-call pairing, ordering classification, and blocking decisions should live in production readiness or serializer-validation code, not only in test helpers.
+- Controller preflight should perform synchronous cancellation-result commits while it safely owns mutable action and conversation state, then rerun readiness before BYOP serialization.
+- Synchronous cancellation-result commit must succeed in the conversation/request state and persist successfully before serializer validation proceeds.
+- If cancellation-result persistence fails, controller preflight should block the BYOP request and surface an error rather than continuing with only in-memory cancellation state.
+- The initial implementation should not send a request that depends on a cancellation result that was committed only in memory but failed to persist, because a retry or restart could recreate the missing-result gap.
+- Finished action results drained by controller preflight must also persist successfully before BYOP serialization when the current request depends on them to satisfy readiness.
+- If finished-result persistence fails, controller preflight should block the BYOP request rather than sending a payload that is valid only in memory.
+- After controller preflight successfully persists drained finished results or cancellation results, it should discard the old `RequestParams`, rebuild `RequestParams` from the updated conversation state, and rerun readiness.
+- Controller preflight should not patch the old `RequestParams.input` in place after persistence, because that can leave both current-input results and newly persisted history results in the same outbound projection.
+- Controller preflight readiness reruns should be bounded and require observable progress on each iteration, such as successfully persisting a drained result, committing a cancellation result, or completing known duplicate deduplication.
+- The initial controller preflight readiness loop should use `max_iterations = 3`.
+- If controller preflight receives the same actionable readiness state again without progress, it should block BYOP dispatch and log an internal readiness-loop diagnostic rather than looping indefinitely or opening a provider request.
+- Readiness-loop diagnostics should include iteration count and final readiness category, but must not include raw message content, tool arguments, tool output, or user prompt text.
+- Readiness-loop non-convergence should use a distinct internal diagnostic category such as `ReadinessLoopDidNotConverge`.
+- User-visible errors for readiness-loop non-convergence should use the same generalized blocked-request copy as other corrupted or unexplained history states, rather than exposing internal loop state.
+- If tool-result persistence succeeds but later BYOP request serialization or dispatch fails, the persisted tool result should not be rolled back.
+- A persisted tool result is a real conversation fact. Keeping it allows the next request attempt to continue from consistent history, while rolling it back could recreate a missing-result gap.
+- Place the shared readiness implementation in a new `crate::ai::byop_readiness` module rather than inside `agent_providers::chat_stream`.
+- The readiness module should be usable by both the blocklist controller preflight and BYOP serializer validation without depending on provider execution internals.
+- The readiness module should classify a normalized internal projection rather than directly inspecting provider `ChatMessage` values or raw `api::Message` shapes.
+- The normalized projection should preserve readiness metadata such as task ID, message ID, assistant tool-call message ID, tool call ID, redacted tool kind, source location, and whether a result came from persisted history or current `RequestParams.input`.
+- The initial normalized projection should cover only the BYOP Chat readiness message kinds needed for tool-call validation, such as user boundary messages, assistant tool-call messages, tool result messages, and other assistant/system boundary messages.
+- Unknown or readiness-irrelevant message kinds should preserve ordering boundaries where needed but should not force a full abstraction of every raw `api::Message` variant in the initial implementation.
+- Unknown or readiness-irrelevant message kinds should be treated according to final outbound visibility. If they become visible non-tool-response Chat messages in the outbound payload, they are ordering boundaries and should block any pending tool-call group before them.
+- If an unknown or readiness-irrelevant raw message kind is fully filtered out before the final outbound projection, it should not affect tool-call group readiness.
+- In the normalized projection, `message_id` should identify the current projected item's source message.
+- For an assistant tool-call item, `message_id` and `assistant_tool_call_message_id` are the same ID.
+- For a tool-result item, `message_id` is the `ToolCallResult` message's own ID, while `assistant_tool_call_message_id` points back to the assistant message that produced the matching tool call when that mapping is known.
+- Projection construction may fill a missing tool-result `assistant_tool_call_message_id` by matching the `tool_call_id` to a unique pending assistant tool call in the same task when the order is valid.
+- Valid ordering means the tool result appears after the assistant tool-call item in the same task and before any later user message or assistant message.
+- All visible tool calls in an assistant tool-call group must be satisfied before the next user or assistant message appears in the outbound projection.
+- A tool result that appears before its assistant tool-call item, crosses a later user message, crosses a later assistant message, or attaches to a different tool-call group should be classified as out-of-order or orphaned rather than repaired.
+- If the assistant back-reference is ambiguous, crosses an invalid ordering boundary, or cannot be uniquely inferred, projection construction should leave it unknown and readiness should classify the result as orphan, out-of-order, or corrupted as appropriate.
+- Repair record authorization must not rely on an ambiguous or non-unique inferred assistant back-reference.
+- The normalized projection should distinguish real results from persisted task history and real results from current `RequestParams.input`. Both satisfy readiness, but the distinction is required for diagnostics and duplicate-projection detection.
+- The normalized projection should not carry full message content, tool output, tool arguments, or user prompt text.
+- If diagnostics need content-related context, the projection may carry safe derived fields such as byte length, token estimate, or non-reversible hash, but not raw content.
+- Provider `ChatMessage` construction should remain the final serialization step after readiness and accepted-history repair decisions have already been made.
+- Apply request readiness in two layers: a controller-level preflight after `RequestParams` construction and before BYOP dispatch, plus a serializer-level validation before sanitizer repair inside request serialization.
+- Controller-level preflight should check normal-flow activity state and the currently relevant task history before BYOP dispatch. It owns pending action, cancellation, and drain decisions.
+- Serializer-level validation should check the final outbound BYOP message projection after compaction and filtering have been applied.
+- Serializer-level normalized projection should be constructed after compaction/filtering, or should be constructed from inputs that already encode the final post-compaction/filtering outbound visibility.
+- Controller preflight may use an un-compacted current task/activity view for pending, drainable, and cancellation decisions, but that view must not replace serializer validation over the final outbound projection.
+- Serializer-level validation should evaluate the merged outbound projection that includes both persisted task messages and current `RequestParams.input` action results.
+- A real terminal result already present in current request input should satisfy readiness for its matching tool call even if that result has not yet appeared in persisted task history.
+- Current `RequestParams.input` action results remain supported for existing valid request-construction paths and transition cases, but they must not become a fallback for results that controller preflight attempted and failed to persist.
+- Controller preflight should persist drainable finished results before BYOP serialization whenever it can do so. If that persistence attempt fails, the failed result should not be reintroduced through current `RequestParams.input` to bypass the persistence requirement.
+- Current `RequestParams.input` action results that do not yet have persisted message IDs should receive stable diagnostic-only synthetic projection IDs, such as `current_input:{index}:{tool_call_id}`.
+- Current-input synthetic projection IDs only need to be stable within a single request construction and serializer-validation pass.
+- Current-input synthetic projection IDs should not be treated as stable across requests or app restarts.
+- Synthetic projection IDs for current input results should be marked with source `CurrentInput`, should not be written back to conversation history, and should not participate in durable repair-record matching.
+- After a current input action result is persisted as a real `ToolCallResult` message, the next projection should use that persisted message ID with source `PersistedHistory`, not the previous synthetic projection ID.
+- Request construction should avoid carrying both the old current input result and the newly persisted history result for the same tool call in the same outbound projection.
+- Repair-record matching must continue to use task ID, assistant tool-call message ID, and tool call ID, not current-input synthetic projection IDs.
+- If the same tool call result appears both in persisted task history and current `RequestParams.input`, request construction should avoid projecting both copies.
+- Serializer validation should treat duplicate tool responses in the same outbound projection as duplicate tool results and block, even if one copy came from history and the other from current input.
+- Serializer validation should not guess which duplicate result is newer or more authoritative.
+- Controller preflight should still prefer to drain and commit finished action results where possible, but serializer validation must not misclassify current input action results as missing.
+- Historical tool-call gaps that are fully covered by compaction or filtering and will not appear in the outbound provider payload should not block the current request.
+- Compaction or filtering that hides an assistant tool-call message must also hide its corresponding tool results from the outbound projection.
+- If compaction or filtering leaves a tool result visible after hiding its assistant tool-call message, serializer validation should block as orphan or corrupted history.
+- Compaction or filtering that keeps an assistant tool-call message visible must also keep a real or compacted tool result visible for each visible tool call, unless the missing result is backed by an existing forked-history or restored-legacy repair record that was created before compaction/filtering.
+- A pre-existing repair record should participate in serializer validation only when its assistant tool-call message remains visible in the current outbound projection and its matching result is missing.
+- If compaction or filtering hides the assistant tool-call message referenced by a repair record, the record should remain unused for the current request and should not be treated as stale or consumed.
+- Hidden-call repair records may produce debug diagnostics, but should not trigger cleanup or affect request readiness for the current projection.
+- Compaction or filtering should not create new repair-record dependence by hiding a tool result while keeping its assistant tool-call message visible.
+- If compaction or filtering hides a tool result and leaves its assistant tool-call message visible without a pre-existing repair record, this is a projection bug and should block rather than fall back to placeholder repair.
+- Any assistant tool call that remains in the outbound provider payload must have a real terminal result or an exactly matching repair record before the payload is sent.
+- For an assistant message with multiple tool calls, readiness should evaluate each tool call independently. Existing real terminal results should remain real results, while missing tool calls may use placeholder repair only when each missing call has an exactly matching repair record.
+- If any visible tool call in a multi-call group lacks both a real terminal result and an exactly matching repair record, the entire outbound BYOP request must be blocked.
+- For a sendable multi-tool-call group, serializer output should emit tool responses in the same order as the assistant message's `tool_calls`: use the real terminal result when present, and insert the structured repair placeholder at the corresponding position only for accepted repair records.
+- This ordered outbound bundle rule does not authorize arbitrary persisted-history reordering. If persisted real tool results are orphaned, duplicated, or cross a later user or assistant boundary, serializer validation should block instead of reshuffling the history.
+- If a visible tool call has multiple persisted tool results, readiness should classify it as corrupted or unexplained history and block request serialization rather than silently selecting the first or last result.
+- The controller may deduplicate a known late-cancellation duplicate only while it safely owns mutable conversation state. Serializer validation should receive an already-deduplicated projection or block the request.
+- Serializer validation must not reorder persisted `ToolCallResult` messages to repair history. It may only authorize outbound placeholder insertion for accepted repair records.
+- If a real `ToolCallResult` appears before its assistant tool call or after a later user message in the outbound projection, serializer validation should block the request as corrupted or unexplained history.
+- Controller code may repair known normal-flow ordering defects only while it safely owns mutable conversation state, before serializer validation receives the projected messages.
+- The initial controller auto-repair scope should be limited to deterministic normal-flow fixes: draining and committing finished action results, and idempotently deduplicating known late-cancellation duplicates for the same tool call.
+- The initial controller auto-repair scope should not reorder arbitrary persisted history, delete unknown duplicate tool results, or move late tool results across a later user turn. Those cases should block as corrupted or unexplained history.
+- The controller-level preflight should own normal-flow state handling, including synchronous cancellation-result persistence, waiting for auto-resume prerequisites, or returning a categorized not-ready result without opening a provider request.
+- Controller-level preflight must not block the UI thread while waiting for pending tool results, and must not open a BYOP provider request while tool results are still unresolved.
+- For normal-flow pending tool results, controller preflight should first drain and persist any finished action results. If relevant actions are still running, it should leave the conversation in its existing waiting or auto-resume path and retry request construction only after those action results are committed.
+- Controller preflight may classify a missing result as pending only when the live action model shows a matching running action, or as drainable when a matching finished action result exists but has not yet been committed.
+- Controller preflight should match running actions and finished action results within the current conversation, then require task ID plus tool call ID or action ID to match the missing result.
+- Controller preflight should not globally match only by action ID or tool call ID, because forked, restored, or multi-task conversations can otherwise drain the wrong action result into the current gap.
+- Assistant tool-call message ID should be included in diagnostics for live-action matching decisions, and may be used as an additional guard when that mapping is available.
+- If controller preflight finds a missing tool result but there is no running action, no finished result to drain, and no repair record authorizing history repair, it should classify the gap as corrupted or unexplained persisted history rather than continue waiting indefinitely.
+- Serializer validation does not have live action-model state, so it should not classify projected gaps as pending. It should treat the final outbound projection as ready, accepted history repair, or corrupted/unexplained history.
+- The serializer-level validation should not mutate controller state. It should classify projected message gaps as either accepted history repair or a normal-flow defect before sanitizer placeholder insertion.
+- Readiness not-ready results should be handled by category. Pending tool results and missing auto-resume prerequisites should wait without showing a user-visible error. Cancellation-related gaps should first attempt synchronous cancellation-result persistence and only surface an error if persistence fails. Corrupted or unexplained missing results should block the request and surface a user-visible error.
+- User-visible readiness errors should reuse `RenderableAIError::Other` with `will_attempt_resume=false` and `waiting_for_network=false`. Detailed readiness categories should remain in the readiness result type, logs, and tests rather than becoming UI error variants.
+- UI error mapping may collapse corrupted or unexplained readiness categories into the same `RenderableAIError::Other`, but logs, diagnostics, and tests should preserve the precise readiness category.
+- Corrupted or unexplained missing-result messages should state that no BYOP request was sent because a previous tool call is missing its recorded result.
+- User-visible blocked-request copy should clearly distinguish local OpenWarp blocking from provider/model errors.
+- Blocked-request copy should include both facts: OpenWarp did not send the BYOP request, and a previous tool call is missing a recorded result.
+- Corrupted or unexplained history should be treated as a terminal blocked-request state for the current run. It should not trigger automatic resume or retry, because retrying would rebuild the same invalid history and can loop.
+- The initial blocked-request UI should not offer an automatic retry or ordinary retry action, because retrying the same damaged history will not make it valid.
+- Users may still manually continue the conversation, but the next request must go through the same readiness gate and should remain blocked until the underlying history state is resolved.
+- If a user manually continues while the same blocked history state remains unresolved, OpenWarp may show the blocked-request error again so the user receives clear feedback for that attempt.
+- Repeated blocked-request diagnostics for the same conversation, task, tool call, and readiness category should be rate-limited or coalesced in logs to avoid high-severity log spam.
+- Duplicate blocked-request diagnostics should be keyed by conversation ID, task ID, assistant tool-call message ID, tool call ID, readiness category, and trigger layer.
+- The diagnostic coalescing key should not include raw message content, tool arguments, tool output, user prompt text, or raw payloads.
+- Diagnostic coalescing should record the first occurrence with full non-sensitive metadata, increment a suppressed count for repeated matching diagnostics, and emit a summary containing `suppressed_count` when the coalescing window ends or the readiness category changes.
+- The initial diagnostic coalescing window should be a single request attempt, not a time-based window.
+- A later manual continuation is a new request attempt and may produce a new first full non-sensitive diagnostic for the same blocked state.
+- Readiness diagnostics should include a non-persistent request-attempt identifier, such as a generated `readiness_attempt_id` or an existing response/request stream ID, to correlate controller preflight and serializer validation logs for one attempt.
+- The request-attempt identifier is diagnostic-only. It must not participate in repair matching, readiness identity, or conversation persistence.
+- The request-attempt identifier should be logged with readiness diagnostics but should not be part of the duplicate-diagnostic coalescing key, because the coalescing window is already scoped to a single request attempt.
+- `AcceptedHistoryRepair` diagnostics should log at `info`, because it is an expected but rare repair path.
+- `AcceptedHistoryRepair` should not use blocked-request coalescing because it is sendable rather than blocked.
+- If one request uses multiple accepted repair records, log one summarized `info` diagnostic with repair record count and non-sensitive identifiers instead of one log per record.
+- The summarized `AcceptedHistoryRepair` diagnostic should include repair-source counts, such as counts for forked-history repair and restored-legacy-history repair.
+- `AcceptedHistoryRepair` diagnostics should not include placeholder payload content, tool arguments, tool output, user prompt text, or raw payloads.
+- `PendingToolResults` diagnostics should log at `debug` or avoid high-frequency logging, because waiting for live tools is normal control flow.
+- `NeedsCancellationCommit` diagnostics should initially log at `debug`, because it is a normal controller preflight action when the controller can commit the cancellation result and rerun readiness.
+- Successful cancellation-result commit followed by a ready rerun should not escalate log level.
+- Cancellation-result persistence failure, repeated `NeedsCancellationCommit` without progress, or readiness-loop non-convergence should log at `error`.
+- `StaleRepairRecordIgnored` diagnostics should log at `debug` when the stale or unused record does not itself block the current request.
+- If a stale or irrelevant repair record leaves a visible missing result unauthorized, the blocking readiness category such as `MissingResultWithoutRepairSource` should produce the `error` diagnostic.
+- Corrupted or unexplained categories such as `DuplicateToolResults`, `OrphanToolResult`, `OutOfOrderToolResult`, `MissingResultWithoutRepairSource`, invalid repair sidecar, and `ReadinessLoopDidNotConverge` should log at `error`.
+- Coalescing summaries should preserve the same non-sensitive key fields and should not include raw content, tool arguments, tool output, user prompt text, or raw payloads.
+- A future explicit repair-and-continue action should be a separate user/developer action with its own repair source, confirmation, and diagnostics.
+- Pending tool results may enter the waiting or auto-resume path; corrupted or unexplained history must stop and require explicit user or developer intervention.
+- Keep the existing sanitizer as a final provider-protocol repair step. It should still handle explicitly recorded forked-history and restored-legacy-history repair sources.
+- Rename or extract the existing broad sanitizer entry point so its name reflects accepted history repair, for example `repair_tool_call_pairs_for_accepted_history_gaps`, rather than implying that normal missing results can be sanitized.
+- Calls into the repair sanitizer should occur only after readiness and repair-source validation have classified the gap as accepted history repair.
+- Placeholder-producing history repair must require an explicit repair source. A missing tool result by itself should not be treated as sufficient evidence for placeholder insertion.
+- Accepted repair sources should be represented as enumerable categories such as forked history and restored legacy history.
+- The initial repair-source enum should allow only forked history and restored legacy history.
+- The initial implementation should not include broad repair-source values such as corrupted history, unknown, or manual repair.
+- A future explicit "repair and continue" action should introduce a separate precise source, such as user-approved corrupted-history repair, with its own UI and logging confirmation.
+- Repair records should be created only at explicit history transformation points, such as fork creation and legacy restore/conversion.
+- Fork creation code should scan the retained forked task/message set after the fork is built, identify tool calls whose matching results were intentionally omitted by the fork operation, and persist `ForkedHistory` repair records for those exact calls.
+- Fork creation code should avoid producing orphan tool results where a `ToolCallResult` is retained but the corresponding assistant tool call was removed.
+- If retained forked history contains an orphan tool result, it should be treated as a fork projection bug and classified as corrupted or unexplained history. It should not create a repair record or placeholder tool result.
+- Repair records should only cover the case where an assistant tool call is retained and its matching tool result is intentionally missing.
+- Legacy restore/conversion code should create `RestoredLegacyHistory` repair records only while converting known legacy restored history gaps.
+- A known legacy gap requires evidence available during conversion, such as legacy input that retains an assistant tool call while the old format has no recoverable matching tool-result field, or a documented old-version behavior that dropped that result.
+- Legacy restore/conversion should not infer a `RestoredLegacyHistory` repair record solely from a missing result observed after conversion.
+- If conversion cannot prove the missing result comes from known legacy format behavior, the gap should remain corrupted or unexplained history and block request serialization by default.
+- Readiness, serializer validation, and sanitizer code must not lazily create repair records when they discover a missing result. They may only consume existing records or block the request.
+- Forked-history repair sources should be persisted with the forked conversation in `conversation_data` JSON, rather than inferred from `forked_from_server_conversation_token`.
+- Forked-history repair metadata should be stored as per-missing-tool-call records, not as a conversation-level flag.
+- Each forked-history repair record should identify at least the source category, task ID, assistant tool-call message ID, and tool call ID. It may also include fork point or exchange ID metadata for diagnostics.
+- A forked-history repair record should authorize placeholder repair only for the recorded missing tool call, not for unrelated future gaps in the same conversation.
+- Repair record authorization should require an exact match on task ID, assistant tool-call message ID, and tool call ID. A record that matches only by tool call ID should be treated as stale or irrelevant and should not authorize placeholder insertion.
+- Restored-legacy-history repair metadata should also be stored as per-missing-tool-call records, not as a restored-conversation-level flag.
+- Restore/conversion code should create restored-legacy repair records only for specific retained tool calls that are known to come from legacy restored history and lack matching tool results.
+- If restore/conversion cannot establish a specific restored-legacy repair source for a missing result, the gap should be treated as corrupted persisted history and block serialization by default.
+- Persisting forked-history repair sources should not require a SQL migration; it should extend the existing serialized conversation metadata shape, similar to the compaction sidecar.
+- Placeholder tool results generated from repair records should be outbound-payload artifacts only. They should not be persisted back into conversation history.
+- Placeholder tool results generated for accepted history repair should use a minimal structured JSON payload instead of the legacy bare text `(tool 执行结果未保留)`.
+- The structured repair payload should include `status: "unavailable"`, a `reason` derived from the accepted repair source, and a short generic note such as `tool result was unavailable in repaired conversation history`.
+- Structured repair payload `status` should always be the fixed string `"unavailable"`.
+- Repair-source-specific information should be represented only in the `reason` field, not by varying `status`.
+- Structured repair payload `reason` values should use provider-payload-friendly snake_case strings: `forked_history_repair` for `RepairSource::ForkedHistory` and `restored_legacy_history_repair` for `RepairSource::RestoredLegacyHistory`.
+- Internal repair-source enums may use Rust-style names such as `ForkedHistory` and `RestoredLegacyHistory`; outbound JSON reasons should remain stable snake_case strings.
+- Structured repair payload `note` should be fixed English machine-facing text and should not be localized.
+- Placeholder payload content should not vary by UI locale, so provider/model behavior and tests remain stable.
+- Structured repair payloads should contain only `status`, `reason`, and `note`.
+- Structured repair payloads should not include the raw tool name. Diagnostics may use a separate redacted tool kind.
+- Tests for structured repair payloads should parse JSON and compare the field set and values rather than depending on object field order.
+- The structured repair payload shape is an implementation and serialization constraint; it does not need to be promoted into `CONTEXT.md` as domain language.
+- Structured repair payloads must not include tool arguments, tool output, user prompt text, or other sensitive content.
+- Repair records, not persisted placeholder messages, should provide the durable explanation for why a missing tool result was repaired.
+- Repair records should not be consumed after a single outbound request. A record remains valid while its referenced tool call still exists and still lacks a real terminal tool result.
+- If a real terminal tool result later appears for a recorded tool call, readiness should ignore or remove the repair record. If the referenced tool call no longer exists, readiness should log a diagnostic and ignore or clean up the stale record.
+- Readiness and serializer validation should treat stale repair records as read-only diagnostics: ignore the record for the current authorization decision and log that it is stale or irrelevant.
+- Serializer validation must not mutate repair metadata in order to clean stale records.
+- Controller code may perform best-effort stale repair-record cleanup when it safely owns mutable `AIConversation` state, and the cleanup should persist with the next normal conversation save rather than becoming a request-sending prerequisite.
+- Corrupted persisted history should block request serialization by default. It should log at high severity with conversation, task, and tool call identifiers rather than automatically producing a placeholder.
+- A future explicit "repair and continue" user/developer action may opt into corrupted-history placeholder repair, but the initial implementation should not silently continue.
+- Compacted tool output should be represented as a compacted tool result, not as placeholder-based history repair. A compacted tool result should satisfy request readiness because it projects an existing real tool result rather than replacing a missing result.
+- In normal request flow, readiness failures caused by missing tool results should block BYOP request serialization instead of falling through to sanitizer placeholder insertion.
+- Treat placeholder tool results in normal request flow as a defect signal. If a placeholder is inserted, logs should include a reason category and enough metadata to identify the relevant tool call without dumping sensitive output.
+- Readiness and serializer diagnostics should include the readiness category, conversation ID, task ID, assistant tool-call message ID, tool call ID, redacted tool name or tool kind, and trigger layer such as controller preflight, serializer validation, or sanitizer repair.
+- Readiness and serializer diagnostics should not include tool arguments, tool output, or user prompt text.
+- Local interception results should use stable redacted diagnostic tool kinds such as `local_interception:todowrite`, `local_interception:webfetch`, `local_interception:websearch`, and `local_interception:invalid_arguments`.
+- Diagnostics for local interception results should not log model-provided raw tool names, tool arguments, or carrier payloads.
+- Before sending a user-initiated continuation, drain finished action results and persist them before appending the new user query to the request history.
+- If a user continuation cancels an in-flight tool, synchronously commit an explicit cancellation result before request serialization instead of relying on a later executor event or a placeholder.
+- Cancellation result persistence must be idempotent by tool call ID, so a late executor cancellation event cannot create duplicate tool results.
+- For action-backed tool results, the idempotency key should be the serialized `ToolCallResult.tool_call_id`, which is currently derived from `AIAgentActionResult.id`. Persistence should keep at most one final terminal result for a given conversation, task, and tool call ID.
+- Auto-resume should not build a provider request until locally intercepted tool results and asynchronous tool results for the prior turn have been committed to conversation history.
+- Locally intercepted BYOP tool results, including `todowrite`, `webfetch`, `websearch`, and `invalid_arguments` carrier results, should count as real terminal tool results once their structured `server_message_data` has been committed.
+- `invalid_arguments` carrier results should satisfy request readiness as real structured error results. They represent a final client-side observation for the tool call, not a missing result or placeholder repair.
+- If a local interception result's structured `server_message_data` cannot be deserialized or interpreted, readiness should not count it as a real terminal tool result.
+- Unreadable local interception payloads should block as corrupted or unexplained history, not fall back to placeholder repair.
+- Diagnostics for unreadable local interception payloads should include the stable redacted tool kind, tool call ID, assistant tool-call message ID where available, message ID, and error category, but must not log the raw payload.
+- If auto-resume or another normal request path finds an unresolved tool call, it should wait or return a categorized not-ready result rather than emit a provider request.
+- Preserve strict provider sequencing in the final payload: assistant tool calls must be followed by corresponding tool responses before any later user or assistant message.
+- Do not remove placeholder support entirely. It is still required for defensive repair when explicitly recorded forked-history or restored-legacy-history gaps lack tool results.
+- No SQL migration or new persistence table/column is required for the initial implementation.
+- The implementation should extend the existing `AgentConversationData` / `conversation_data` JSON metadata with BYOP repair records.
+- New repair metadata fields should use serde-compatible defaults, such as `#[serde(default, skip_serializing_if = "Option::is_none")]`, so legacy conversation rows deserialize as having no repair records.
+- Define BYOP repair metadata types in `crate::ai::byop_readiness::state`, not in `byop_compaction` and not as domain-owned types inside `crates/persistence`.
+- Store repair metadata in `AgentConversationData` as an optional serialized sidecar field such as `byop_repair_state_json: Option<String>`.
+- `RepairState` should include an explicit version field, initially version `1`, following the existing compaction sidecar pattern.
+- Missing `byop_repair_state_json` in legacy conversation data should deserialize as an empty repair state.
+- Invalid or unreadable `byop_repair_state_json` should not be treated as authorization for repair. It should be logged and any affected missing-result gaps should block as corrupted or unexplained history.
+- Invalid or unreadable repair sidecar data should block only when the current outbound projection needs repair-record authorization for a visible missing result.
+- If all visible tool calls in the current outbound projection have real terminal results, invalid repair sidecar data should not block the request, but should still produce a high-severity diagnostic.
+- `AIConversation` should preserve repair sidecar load status explicitly, such as valid empty state, valid state with records, or invalid/unreadable state with an error category.
+- Invalid repair sidecar data should not be collapsed into an empty repair state, because serializer validation must distinguish "no repair records" from "repair metadata could not be read."
+- The initial repair sidecar load categories should distinguish missing sidecar, invalid JSON, and unsupported version.
+- Missing sidecar is a valid empty repair state, not an error. Invalid JSON and unsupported version should not authorize repair.
+- The initial reader should support only repair state version `1`.
+- A present repair sidecar with no version field should be treated as unsupported version rather than best-effort parsed.
+- A present repair sidecar with version greater than `1` should be treated as unsupported version until an explicit migration or reader is implemented.
+- Unknown repair state versions must not authorize placeholder repair.
+- Repair sidecar load diagnostics should record the load category without logging raw sidecar JSON.
+- `AIConversation` should own the deserialized BYOP repair sidecar, following the existing `compaction_state_json` / `compaction_state` pattern.
+- `RequestParams` should carry a read-only BYOP repair state snapshot to readiness and serializer validation so request construction does not need to deserialize persistence metadata.
+- The current provider scope is the BYOP/OpenAI-compatible Chat serialization path. The implementation should not add branching, compatibility shims, or tests for a nonexistent non-BYOP provider path.
+- Do not add a feature flag for request readiness or normal-flow placeholder blocking. This is a BYOP Chat payload correctness and history-consistency fix, not a product rollout switch.
+- Debug logging may be added for observability, but there should not be a runtime switch that allows normal request flow to keep sending placeholder tool results.
+- The initial implementation should use logs for readiness diagnostics and should not add a new telemetry event.
+- Readiness telemetry may be considered later if maintainers need aggregate blocked-rate metrics, but it should be designed separately with its own schema and privacy review.
+- Prefer a deep module for readiness classification over adding more special cases inside the request serializer.
+- Continue to support compacted tool results intentionally produced by local compaction; those are distinct from placeholder repair for missing tool results.
+
+## Testing Decisions
+
+- Tests should assert externally visible request-message sequences, not internal helper implementation details.
+- Add unit tests for the request-readiness module covering complete tool groups, pending tool groups, cancelled tool groups, corrupted history, and compacted tool results.
+- Add unit tests for each initial readiness category so category distinctions remain stable even when user-visible error mapping is shared.
+- Add unit tests for normalized projection construction, including metadata needed by readiness and diagnostics.
+- Add unit tests that the initial normalized projection covers the BYOP Chat readiness message kinds without requiring exhaustive abstraction of every raw `api::Message` variant.
+- Add unit tests that visible unknown or readiness-irrelevant message kinds act as ordering boundaries for pending tool-call groups, while fully filtered message kinds do not affect readiness.
+- Add unit tests that normalized projection construction omits raw message content, tool output, tool arguments, and user prompt text while retaining safe metadata needed for classification.
+- Add unit tests that projection preserves result source, including persisted history versus current `RequestParams.input`, and uses that source to diagnose duplicate projections.
+- Add unit tests for normalized projection ID semantics: assistant tool-call items use the assistant message ID for both `message_id` and `assistant_tool_call_message_id`, while tool-result items keep their own `message_id` and reference the assistant message separately when known.
+- Add unit tests for strict assistant back-reference inference on tool-result items: unique same-task ordered matches are allowed, ambiguous or invalid-order matches are not used for repair authorization.
+- Add unit tests for ordering boundaries: tool results must follow their assistant tool-call group and precede any later user or assistant message in the same task.
+- Add tests showing that `AcceptedHistoryRepair` is sendable but remains distinct from ordinary `Ready` in diagnostics and outbound placeholder generation.
+- Add tests showing that readiness returns `NeedsCancellationCommit` without mutating state, and controller preflight commits the cancellation result before rerunning readiness.
+- Add controller tests showing that cancellation-result persistence failure blocks BYOP dispatch and does not continue with in-memory-only cancellation state.
+- Add controller tests showing that finished-result drain persistence failure blocks BYOP dispatch when those results are required for readiness.
+- Add controller/request-construction coverage that successful tool-result persistence causes `RequestParams` to be rebuilt from updated conversation state before readiness is rerun.
+- Add coverage that controller preflight does not patch old `RequestParams.input` in place and therefore avoids projecting both current-input and newly persisted history results.
+- Add controller-level coverage that readiness reruns are bounded, require progress per iteration, and block with diagnostics when the same actionable state repeats without progress.
+- Add controller-level coverage that the initial readiness loop stops at `max_iterations = 3` and logs only non-sensitive loop metadata.
+- Add controller-level coverage that readiness-loop non-convergence maps to a generalized user-visible blocked-request error while diagnostics preserve `ReadinessLoopDidNotConverge`.
+- Add controller/request-construction coverage that persisted tool results are not rolled back when later BYOP serialization or dispatch fails.
+- Keep readiness unit tests close to `crate::ai::byop_readiness` so the behavior can be validated without constructing full UI or provider state.
+- Add controller-level coverage for preflight behavior before BYOP dispatch, including synchronous cancellation result persistence and auto-resume not-ready handling.
+- Add controller-level coverage that pending tool results do not open a BYOP provider request, do not block the UI thread, and resume request construction only after relevant results are committed.
+- Add controller-level coverage that missing results are classified as pending or drainable only when the live action model has a matching running action or finished action result.
+- Add controller-level coverage that running and finished action matching requires the current conversation plus task ID and tool call or action ID, so another task's result cannot satisfy the current missing result.
+- Add controller-level coverage that a missing tool result with no running action, no drainable finished result, and no repair record is classified as corrupted or unexplained history instead of waiting indefinitely.
+- Add serializer-level coverage that projected missing results are never classified as pending because serializer validation has no live action-model state.
+- Add coverage that pending-result not-ready states wait without rendering an error, while corrupted or unexplained missing-result states produce a user-visible blocked-request error.
+- Add coverage that corrupted or unexplained readiness errors map to `RenderableAIError::Other` without introducing a dedicated UI error variant.
+- Add UI/error-mapping coverage that blocked-request copy says the BYOP request was not sent and identifies a missing recorded tool result, without implying the provider rejected the request.
+- Add coverage that corrupted or unexplained history uses `will_attempt_resume=false`, does not schedule retry or auto-resume, and does not open a BYOP provider request.
+- Add UI/error-mapping coverage that blocked-request errors do not expose an automatic retry or ordinary retry action in the initial implementation.
+- Add coverage that a later manual continuation still passes through readiness and does not bypass the same blocked history state.
+- Add coverage that repeated manual continuations can surface user feedback again while diagnostics for the same blocked state are rate-limited or coalesced.
+- Add log-focused coverage that repeated blocked-request diagnostics are coalesced by conversation ID, task ID, assistant tool-call message ID, tool call ID, readiness category, and trigger layer without using sensitive content.
+- Add log-focused coverage that coalesced diagnostics report a suppressed count in a non-sensitive summary when the coalescing window ends or the readiness category changes.
+- Add log-focused coverage that the initial coalescing window is scoped to one request attempt, and a later manual continuation starts a new coalescing window.
+- Add log-focused coverage that readiness diagnostics include a non-persistent request-attempt identifier that correlates preflight and serializer logs without entering repair matching or persistence.
+- Add log-focused coverage that the request-attempt identifier is present in diagnostic records but excluded from the duplicate-diagnostic coalescing key.
+- Add log-focused coverage for readiness diagnostic levels: `AcceptedHistoryRepair` at `info`, `PendingToolResults` at `debug` or lower-noise behavior, and corrupted or unexplained categories at `error`.
+- Add log-focused coverage that `AcceptedHistoryRepair` emits one summarized `info` diagnostic per request with record count and non-sensitive identifiers, rather than using blocked-request coalescing or logging each record separately.
+- Add log-focused coverage that accepted-repair summaries include repair-source counts and omit placeholder payload content and other sensitive content.
+- Add log-focused coverage that `NeedsCancellationCommit` starts at `debug`, remains low-noise after successful commit and ready rerun, and escalates to `error` only for persistence failure, repeated no-progress state, or loop non-convergence.
+- Add log-focused coverage that `StaleRepairRecordIgnored` logs at `debug` when non-blocking, while the resulting unauthorized visible gap logs through its blocking `error` category.
+- Add serializer-level coverage that projected normal-flow gaps are rejected before sanitizer repair, while accepted history-repair gaps can still be repaired.
+- Add coverage or code structure assertions where practical that the renamed sanitizer is only called for accepted history repair and not for normal-flow missing results.
+- Add serializer-level coverage that readiness is evaluated against the final outbound message projection after compaction and filtering, so hidden historical gaps do not block while visible assistant tool calls still require a result or repair record.
+- Add coverage that controller preflight activity checks do not replace serializer validation over the final post-compaction/filtering projection.
+- Add serializer-level coverage that compaction or filtering hides tool-call messages and their corresponding tool results together, and blocks if an orphan tool result remains visible.
+- Add serializer-level coverage that compaction or filtering does not create new repair dependence by hiding a tool result while keeping its assistant tool-call message visible.
+- Add serializer-level coverage that repair records for hidden assistant tool-call messages remain unused, are not consumed, and do not count as stale for the current projection.
+- Add serializer-level coverage that current `RequestParams.input` action results are treated as real terminal results in the final outbound projection and are not mistaken for missing persisted history.
+- Add controller/request-construction coverage that current input action results remain supported for valid existing paths but are not used as a fallback after controller preflight fails to persist a required drained or cancellation result.
+- Add serializer-level coverage that current input action results without persisted message IDs receive diagnostic-only synthetic projection IDs and do not participate in durable repair-record matching.
+- Add serializer-level coverage that once a current input result is persisted, subsequent projections use the real `ToolCallResult` message ID and `PersistedHistory` source instead of the old synthetic ID.
+- Add serializer-level coverage that the same tool call result appearing in both history and current input is blocked as a duplicate outbound projection rather than silently deduplicated.
+- Add serializer-level coverage for multi-tool-call assistant messages where some calls have real results and some are repaired, plus a blocking case where one visible call lacks both a real result and a repair record.
+- Add serializer-level coverage that sendable multi-tool-call groups emit outbound tool responses in assistant `tool_calls` order, mixing real results and structured repair placeholders only where individually authorized.
+- Add readiness coverage that duplicate persisted tool results for one visible tool call block serialization as corrupted or unexplained history.
+- Add controller coverage that known late-cancellation duplicates are deduplicated before serializer validation and do not produce duplicate outbound tool responses.
+- Add serializer-level coverage that out-of-order real tool results are blocked rather than reordered.
+- Add controller-level coverage for any known safe normal-flow ordering repair before serializer validation, if such repair is implemented.
+- Add controller-level coverage that the initial auto-repair scope is limited to finished-result draining and known late-cancellation duplicate deduplication, while arbitrary reordering, unknown duplicate deletion, and late-result movement across a user turn remain blocked.
+- Add coverage that missing results without an explicit repair source are rejected as normal-flow defects.
+- Add coverage that corrupted persisted history blocks serialization by default and does not produce placeholder tool results.
+- Add coverage that each accepted repair source is categorized in diagnostics.
+- Add coverage that only forked-history and restored-legacy-history repair sources authorize placeholder repair in the initial implementation.
+- Add coverage that corrupted, unknown, or manual-style repair categories are not accepted unless a future explicit repair-and-continue source is introduced.
+- Add coverage that repair records are created at fork and legacy restore/conversion boundaries, not lazily during readiness, serializer validation, or sanitizer repair.
+- Add fork-creation coverage showing that only gaps introduced by the retained forked task/message set receive `ForkedHistory` records.
+- Add fork-creation coverage that retained orphan tool results are not converted into repair records and are blocked as corrupted or unexplained history.
+- Add legacy restore/conversion coverage showing that only known legacy gaps receive `RestoredLegacyHistory` records.
+- Add legacy restore/conversion coverage that a missing result without conversion-time evidence is not treated as `RestoredLegacyHistory` and blocks by default.
+- Add coverage that compacted tool results satisfy readiness without entering placeholder repair.
+- Add coverage that forked-history repair metadata survives conversation serialization and remains available after fork routing tokens are cleared.
+- Add `AgentConversationData` roundtrip and legacy-payload tests for the new BYOP repair metadata field.
+- Add repair-state versioning tests, including legacy missing sidecar deserializing to empty state and invalid sidecar JSON blocking repair authorization instead of silently permitting placeholders.
+- Add coverage that invalid repair sidecar JSON blocks only when the current outbound projection needs repair authorization, while healthy real-result projections continue with a diagnostic.
+- Add `AIConversation` load tests showing invalid repair sidecar data is preserved as an explicit invalid status rather than collapsed into an empty repair state.
+- Add repair sidecar load-category tests for missing sidecar, invalid JSON, and unsupported version, including no raw JSON in diagnostics.
+- Add repair state version tests showing version `1` is accepted, missing version is unsupported, higher versions are unsupported, and unknown versions do not authorize repair.
+- Add coverage that forked-history repair records authorize only the recorded missing tool calls and do not allow unrelated normal-flow gaps.
+- Add coverage that restored-legacy-history repair records authorize only the recorded missing tool calls and do not allow unrelated gaps in restored conversations.
+- Add coverage that repair records do not authorize repair when only `tool_call_id` matches but `task_id` or assistant tool-call message ID differs.
+- Add coverage that restored conversations with unexplained missing tool results are treated as corrupted persisted history by default.
+- Add coverage that placeholder tool results generated for repair do not mutate task messages or persisted conversation history.
+- Add coverage that repair placeholder payloads are structured JSON with an accepted repair-source reason and do not use the legacy bare text `(tool 执行结果未保留)`.
+- Add coverage that repair placeholder payload `status` is always `"unavailable"` regardless of repair source.
+- Add coverage that repair placeholder payload reason strings map from internal repair-source enums to stable snake_case values.
+- Add coverage that repair placeholder `note` is fixed machine-facing English text and does not vary by UI locale.
+- Add coverage that repair placeholder payloads contain only `status`, `reason`, and `note`, and do not include raw tool names.
+- Add coverage that structured repair payload assertions parse JSON and compare fields semantically rather than relying on field order.
+- Add coverage that repair placeholder payloads do not include tool arguments, tool output, or user prompt text.
+- Add coverage that repair records can be reused across multiple outbound requests while the historical gap remains, and become inactive when a real result appears or the referenced tool call disappears.
+- Add coverage that stale repair records are ignored by read-only readiness or serializer validation, and that stale-record cleanup is best-effort controller behavior rather than required for request serialization.
+- Add `AIConversation` restore/persist coverage showing that BYOP repair metadata is loaded from and saved back to the `byop_repair_state_json` sidecar.
+- Extend sanitizer tests to confirm placeholders are inserted only for repair cases, not for ordinary in-flight tool execution.
+- Add a regression test for the observed shape where one request contains `(tool 执行结果未保留)` and the next request contains the real cancellation result.
+- Add a regression test where a user prompt cancels a running asynchronous tool and the immediately serialized BYOP request contains the cancellation result with no placeholder.
+- Add coverage that a late executor cancellation event after synchronous cancellation-result persistence is deduplicated by `tool_call_id` and does not create duplicate persisted tool results or duplicate outbound tool responses.
+- Add controller or request-construction coverage for a user prompt submitted while a tool action is in progress.
+- Add auto-resume coverage for locally intercepted tool results that do not enter the normal action queue.
+- Add request-readiness coverage showing that committed local interception results satisfy tool-call readiness without requiring an `AIAgentActionResult` or protobuf result oneof.
+- Add request-readiness coverage showing that committed `invalid_arguments` carrier results satisfy readiness as structured error results even though the target tool did not execute normally.
+- Add request-readiness coverage showing that unreadable local interception payloads do not satisfy readiness, block as corrupted or unexplained history, and do not log the raw payload.
+- Add request-readiness coverage showing that normal-flow unresolved tool calls block serialization and do not produce placeholder tool results.
+- Add coverage that readiness and normal-flow placeholder blocking are always active in the BYOP Chat serialization path and are not gated by a feature flag.
+- Keep existing tool-call ordering tests as prior art: normal adjacent tool messages, missing tool responses, orphan tool responses, out-of-order tool responses, late tool responses after a user query, placeholder replacement by late real results, and multiple independent tool-call groups.
+- Validate generated BYOP request bodies with a strict Chat Completions ordering checker: no orphan tool responses, no duplicate tool result IDs, and no user/assistant message before pending tool responses are resolved.
+- The strict Chat Completions ordering checker may be a test helper for externally visible request bodies, but production code must still run readiness and serializer validation before BYOP dispatch.
+- Include log-focused assertions where practical: unexpected placeholder insertion should produce a categorized diagnostic.
+- Include log-focused assertions where practical that readiness diagnostics include non-sensitive identifiers and omit tool arguments, tool output, and user prompt text.
+- Include log-focused assertions that local interception results use stable redacted diagnostic tool kinds and do not log raw model-provided tool names, tool arguments, or carrier payloads.
+- Do not add telemetry assertions for the initial implementation; readiness observability should be log-based unless a separate telemetry design is approved.
+
+## Out of Scope
+
+- Fixing network, SSE, proxy, or upstream model stream interruptions.
+- Reducing noisy partial tool-argument parse warnings.
+- Changing provider selection, endpoint configuration, model IDs, or BYOP authentication.
+- Redesigning conversation compaction or request size management.
+- Removing placeholder repair behavior for explicitly recorded forked-history or restored-legacy-history gaps.
+- Publishing this PRD to GitHub issues; the local environment does not currently expose `gh` or a GitHub token.
+
+## Further Notes
+
+The observed request set did not show an upstream request rejection problem. All inspected BYOP requests were accepted and had valid tool-call pairing. The issue is conversation fidelity: a protocol-safe placeholder can still be semantically wrong when produced during normal execution.
+
+The current evidence came from local request records and `openwarp.log`: one request contained `(tool 执行结果未保留)` for a tool call, while the next request contained a real cancellation result for that same call. That suggests OpenWarp can send a follow-up request before the real asynchronous result is persisted.
+
+Regression fixtures derived from this observation should be synthetic, minimal, and redacted. Do not copy real logs, prompts, tool arguments, or user content into tests.

--- a/specs/byop-placeholder-tool-results/TECH.md
+++ b/specs/byop-placeholder-tool-results/TECH.md
@@ -1,0 +1,382 @@
+# BYOP Tool Result Readiness Technical Plan
+
+## Status
+
+Drafted from the accepted decisions in `PRODUCT.md`, `CONTEXT.md`, and `ADR.md`.
+
+During the grilling phase, implementation decisions may remain duplicated between `PRODUCT.md` and this file to avoid losing accepted context. After decisions stabilize, do a cleanup pass that keeps `PRODUCT.md` focused on behavior and moves implementation matrices into this technical plan.
+
+Before converting this plan into implementation tasks or issues, run a consistency pass across `CONTEXT.md`, `PRODUCT.md`, this file, and `ADR.md`.
+
+## Goals
+
+- Prevent normal BYOP Chat requests from sending placeholder tool results.
+- Keep explicit forked-history and restored-legacy-history repair available.
+- Validate OpenAI-compatible tool-call ordering before BYOP dispatch.
+- Keep readiness logic testable without constructing full UI state.
+
+## Main Code Areas
+
+- `app/src/ai/byop_readiness/`: new module for pure readiness classification, repair state, diagnostics, and tests.
+- `app/src/ai/blocklist/controller.rs`: controller preflight after `RequestParams` construction and before BYOP dispatch.
+- `app/src/ai/blocklist/action_model.rs`: live action state, finished-result draining, cancellation-result commit and dedupe.
+- `app/src/ai/agent/api.rs`: `RequestParams` should carry a read-only BYOP repair-state snapshot.
+- `app/src/ai/agent/conversation.rs`: `AIConversation` should own deserialized BYOP repair sidecar state and persist it with conversation data.
+- `crates/persistence/src/model.rs`: `AgentConversationData` gets an optional serialized repair sidecar field.
+- `app/src/ai/agent_providers/chat_stream.rs`: serializer validation and renamed accepted-history repair sanitizer.
+- Fork/restore creation paths, including `app/src/ai/blocklist/history_model.rs`, `app/src/terminal/view/load_ai_conversation.rs`, and legacy conversion code, should create repair records only at explicit history transformation points.
+
+## Data Model
+
+Add a BYOP repair sidecar that mirrors the existing compaction sidecar pattern:
+
+```rust
+pub struct RepairState {
+    pub version: u32,
+    pub records: Vec<RepairRecord>,
+}
+
+pub struct RepairRecord {
+    pub source: RepairSource,
+    pub task_id: String,
+    pub assistant_tool_call_message_id: String,
+    pub tool_call_id: String,
+    pub fork_point_message_id: Option<String>,
+    pub exchange_id: Option<String>,
+}
+
+pub enum RepairSource {
+    ForkedHistory,
+    RestoredLegacyHistory,
+}
+
+pub enum RepairStateStatus {
+    Valid(RepairState),
+    Invalid { error_category: RepairStateLoadError },
+}
+
+pub enum RepairStateLoadError {
+    InvalidJson,
+    UnsupportedVersion,
+}
+```
+
+Persistence shape:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub byop_repair_state_json: Option<String>,
+```
+
+The sidecar should live as app-layer BYOP state. `crates/persistence` should only store the optional JSON field and should not own BYOP-specific repair semantics.
+
+`RepairState` starts at version `1`. Missing `byop_repair_state_json` from legacy conversation data should load as a valid empty state, not an error. A present sidecar with no version field or with a version greater than `1` should load as `UnsupportedVersion` until an explicit migration or reader is implemented. Invalid JSON and unsupported versions must be preserved as explicit invalid statuses rather than collapsed into empty state. Invalid status must be logged without raw JSON and must not authorize repair. It blocks only when the current outbound projection needs repair-record authorization for a visible missing result. If all visible tool calls have real terminal results, the request can continue with a high-severity diagnostic.
+
+## Normalized Projection
+
+Readiness should classify an internal normalized projection rather than provider `ChatMessage` values or raw `api::Message` shapes.
+
+The initial projection should cover only the BYOP Chat readiness message kinds needed for tool-call validation:
+
+- user boundary messages
+- assistant tool-call messages
+- tool result messages
+- assistant/system or other boundary messages needed for ordering
+
+Unknown or readiness-irrelevant message kinds should preserve ordering boundaries where needed but should not require a full abstraction of every raw `api::Message` variant in the initial implementation. Boundary behavior is based on final outbound visibility: if the message becomes a visible non-tool-response Chat message, it blocks any pending tool-call group before it; if it is fully filtered out before projection, it does not affect readiness.
+
+The projection should preserve the metadata needed for readiness, diagnostics, and repair matching:
+
+- task ID
+- message ID for the current projected item's source message
+- role or projected message kind
+- assistant tool-call message ID, which is the same as `message_id` for assistant tool-call items and a back-reference for tool-result items when known
+- tool call ID
+- redacted tool kind
+- result source, such as persisted history or current `RequestParams.input`
+- whether the result is real, compacted, structured error, local interception, or accepted repair
+
+Persisted history results and current input results both satisfy readiness, but the projection must keep the source distinction so duplicate projections can be diagnosed instead of silently deduplicated.
+
+Current `RequestParams.input` action results may not yet have persisted message IDs. Projection construction should assign a diagnostic-only ID such as `current_input:{index}:{tool_call_id}` and mark the source as `CurrentInput`. The ID only needs to be stable within one request construction and serializer-validation pass. It is not stable across requests or app restarts. These IDs are not persisted and must not be used for durable repair-record matching, which still depends on task ID, assistant tool-call message ID, and tool call ID.
+
+Once that action result is persisted as a real `ToolCallResult` message, later projections should use the persisted message ID and `PersistedHistory` source. Request construction should not project both the old current input result and the newly persisted history result for the same tool call.
+
+Current input results remain valid for existing request-construction paths where the result is legitimately part of the current request. They must not be used as a fallback after controller preflight attempted and failed to persist a required drained or cancellation result.
+
+When a tool-result item lacks an assistant back-reference, projection construction may infer `assistant_tool_call_message_id` only from a unique same-task pending assistant tool call with the same `tool_call_id` and valid ordering. Valid ordering means the result appears after the assistant tool-call item and before any later user or assistant message. All visible tool calls in an assistant tool-call group must be satisfied before the next user or assistant message appears. Ambiguous, cross-boundary, or invalid-order matches should remain unknown and be classified later as orphan, out-of-order, or corrupted. Repair authorization must not use ambiguous inferred links.
+
+The projection should not carry full message content, tool output, tool arguments, user prompt text, or raw local interception payloads. If content-related diagnostics are necessary, use safe derived fields such as byte length, token estimate, or a non-reversible hash.
+
+Provider `ChatMessage` construction should happen after readiness and accepted-history repair decisions. This keeps provider serialization as the final formatting step instead of the place where missing-result policy is decided.
+
+## Readiness Categories
+
+The initial classifier should preserve these categories for logs and tests:
+
+- `Ready`
+- `AcceptedHistoryRepair`
+- `PendingToolResults`
+- `NeedsCancellationCommit`
+- `DuplicateToolResults`
+- `OrphanToolResult`
+- `OutOfOrderToolResult`
+- `MissingResultWithoutRepairSource`
+- `StaleRepairRecordIgnored`
+
+`AcceptedHistoryRepair` is sendable but must remain distinct from ordinary `Ready`. Corrupted or unexplained categories map to `RenderableAIError::Other` with `will_attempt_resume=false` and `waiting_for_network=false`.
+
+## Classification Rules
+
+- A visible assistant tool call must have exactly one real terminal result or an exactly matching repair record.
+- Repair records match only when task ID, assistant tool-call message ID, and tool call ID all match.
+- Missing results in serializer validation are never considered pending, because serializer validation has no live action-model state.
+- Controller preflight may classify missing results as pending or drainable only when the live action model has a matching running action or finished action result in the current conversation and task.
+- Duplicate, orphan, and out-of-order real tool results block serialization.
+- Serializer validation must not reorder persisted history or deduplicate ambiguous results.
+- Current `RequestParams.input` action results count as real terminal results in the final outbound projection.
+- If the same tool result appears in both history and current input, the outbound projection is duplicate and must block.
+
+## Controller Preflight Flow
+
+1. Build `RequestParams`.
+2. Drain and commit finished action results where available, persisting them before dispatch when the current request depends on them.
+3. Build a controller readiness view from current task history, current request input, repair state, and live action summaries.
+4. If readiness returns `NeedsCancellationCommit`, synchronously commit cancellation results idempotently by tool call ID, persist the updated conversation/request state, discard the old `RequestParams`, rebuild from the updated conversation state, and rerun readiness.
+5. If readiness returns `PendingToolResults`, do not open a BYOP request; leave the conversation in the existing waiting or auto-resume path.
+6. If readiness returns corrupted or unexplained history, surface a blocked-request `RenderableAIError::Other` and do not schedule retry or auto-resume.
+7. Continue to serializer only for `Ready` or `AcceptedHistoryRepair`.
+
+Controller auto-repair is initially limited to finished-result draining and known late-cancellation duplicate dedupe. It should not reorder arbitrary persisted history, delete unknown duplicates, or move late results across a later user turn.
+
+Readiness reruns should use a bounded loop with initial `max_iterations = 3`. Each iteration must record progress, such as a persisted drained result, committed cancellation result, or known duplicate dedupe. If the same actionable readiness state repeats without progress, block dispatch and log an internal readiness-loop diagnostic such as `ReadinessLoopDidNotConverge`. Loop diagnostics should include iteration count and final readiness category, not raw content. The user-visible error should remain the generalized blocked-request copy used for corrupted or unexplained history.
+
+Blocked-request user copy should make clear that OpenWarp did not send the BYOP request because a previous tool call is missing its recorded result. It should not read like a provider/model rejection.
+
+The initial blocked-request UI should not offer automatic retry or an ordinary retry action. Manual continuation remains possible, but it must pass through readiness again and should not bypass the blocked history state. If the same state remains blocked, user feedback may be shown again for the new attempt. Diagnostics should be rate-limited or coalesced by conversation ID, task ID, assistant tool-call message ID, tool call ID, readiness category, and trigger layer to avoid high-severity log spam. The initial coalescing window is one request attempt rather than a time-based window; a later manual continuation starts a new window and may log a new first full non-sensitive diagnostic. Coalescing should log the first occurrence with full non-sensitive metadata, increment a suppressed count for repeated matching diagnostics, and emit a non-sensitive summary containing `suppressed_count` when the coalescing window ends or the readiness category changes. Future repair-and-continue should be a separate explicit action with its own repair source and diagnostics.
+
+Each request attempt should have a non-persistent diagnostic identifier, such as `readiness_attempt_id` or an existing response/request stream ID. Use it to correlate controller preflight and serializer validation diagnostics. Do not persist it or use it for repair matching. Because the coalescing window is already one request attempt, the attempt identifier should be logged but should not be part of the duplicate-diagnostic coalescing key.
+
+If cancellation-result persistence fails, BYOP dispatch should be blocked. Finished-result drain persistence failures should also block when those results are required for readiness. The failed result should not be reintroduced through current `RequestParams.input` to bypass persistence. After successful persistence, request construction should rebuild `RequestParams` from updated conversation state rather than patch old input in place, so the serializer does not see both current-input and persisted-history copies of the same result. The initial implementation should not proceed with only in-memory tool-result state, because retry or restart could recreate the missing-result gap.
+
+If tool-result persistence succeeds but later BYOP serialization or dispatch fails, do not roll back the persisted result. The result is a real conversation fact and should remain available for the next request attempt.
+
+## Serializer Validation Flow
+
+1. Build the final outbound message projection after compaction/filtering and after merging persisted task messages with current `RequestParams.input`, or build it from inputs that already encode final post-compaction/filtering visibility.
+2. Run serializer validation over the projected messages before accepted-history repair.
+3. For `Ready`, serialize normally.
+4. For `AcceptedHistoryRepair`, pass the exact accepted records to the renamed repair sanitizer.
+5. For any normal-flow gap, duplicate, orphan, or ordering defect, block before sanitizer repair.
+
+Compaction and filtering must preserve tool-call group integrity. If an assistant tool-call item is hidden, its corresponding tool-result items must be hidden too. A visible tool result whose assistant tool-call item was hidden is an orphan and should block serializer validation. If an assistant tool-call item remains visible, each visible tool call should have a real or compacted tool result unless a pre-existing forked-history or restored-legacy repair record already authorizes the gap. Compaction/filtering must not create new repair dependence by hiding a result while keeping its tool call visible. A repair record for a hidden assistant tool-call item is unused for the current projection and should not be consumed or considered stale.
+
+Controller preflight may use an un-compacted task/activity view to decide pending, drainable, and cancellation actions. That does not replace serializer validation over the final post-compaction/filtering projection.
+
+Rename the broad sanitizer entry point to narrow its meaning, for example:
+
+```rust
+repair_tool_call_pairs_for_accepted_history_gaps(...)
+```
+
+This repair function should only generate outbound structured JSON placeholders for accepted repair records. It must not persist placeholder messages.
+
+## Placeholder Payload
+
+Accepted repair placeholders should use structured JSON:
+
+```json
+{
+  "status": "unavailable",
+  "reason": "forked_history_repair",
+  "note": "tool result was unavailable in repaired conversation history"
+}
+```
+
+The `status` field should always be `"unavailable"`. Use a source-derived reason such as `forked_history_repair` or `restored_legacy_history_repair`. Do not include tool arguments, tool output, user prompt text, or raw local interception payloads.
+
+Map internal enum values to outbound reason strings explicitly:
+
+- `RepairSource::ForkedHistory` -> `forked_history_repair`
+- `RepairSource::RestoredLegacyHistory` -> `restored_legacy_history_repair`
+
+The `note` should be fixed English machine-facing text and should not be localized or vary by UI locale.
+
+The payload should contain only `status`, `reason`, and `note`. Do not include raw tool names; diagnostics can carry redacted tool kinds separately. Tests should parse the JSON payload and compare field sets and values semantically rather than relying on object field order.
+
+For multi-tool-call assistant messages, emit outbound tool responses in the assistant `tool_calls` order. Use real results where present and structured repair placeholders only at individually authorized positions.
+
+## Repair Record Creation
+
+Repair records are created only at explicit history transformation points:
+
+- Fork creation: after building the retained forked task/message set, record only assistant tool calls whose matching results were intentionally omitted by the fork operation.
+- Legacy restore/conversion: record only known legacy gaps proven by conversion-time input or documented old-format behavior.
+
+Do not create repair records lazily in readiness, serializer validation, or sanitizer repair. Do not create records for orphan tool results.
+
+## Local Interception Results
+
+Committed local interception results satisfy readiness when their structured `server_message_data` can be interpreted.
+
+Use stable diagnostic tool kinds:
+
+- `local_interception:todowrite`
+- `local_interception:webfetch`
+- `local_interception:websearch`
+- `local_interception:invalid_arguments`
+
+`invalid_arguments` is a structured error result and satisfies readiness. Unreadable local interception payloads block as corrupted or unexplained history and must not log raw payload content.
+
+## Diagnostics
+
+Readiness and serializer diagnostics should include:
+
+- readiness category
+- conversation ID
+- task ID
+- assistant tool-call message ID
+- tool call ID
+- redacted tool kind
+- trigger layer
+
+Do not log tool arguments, tool output, raw user prompt text, raw carrier payloads, or raw local interception payloads.
+
+Initial observability should be log-only. Do not add a new telemetry event as part of this implementation. If aggregate readiness-blocked metrics are needed later, design telemetry separately with its own schema and privacy review.
+
+Initial log levels:
+
+- `info`: `AcceptedHistoryRepair`
+- `debug` or lower-noise behavior: `PendingToolResults`
+- `debug`: initial `NeedsCancellationCommit` when controller preflight can commit the cancellation result and rerun readiness
+- `debug`: non-blocking `StaleRepairRecordIgnored`
+- `error`: corrupted or unexplained categories, including `DuplicateToolResults`, `OrphanToolResult`, `OutOfOrderToolResult`, `MissingResultWithoutRepairSource`, invalid repair sidecar, and `ReadinessLoopDidNotConverge`
+- `error`: cancellation-result persistence failure, repeated `NeedsCancellationCommit` without progress, or readiness-loop non-convergence
+
+`AcceptedHistoryRepair` is sendable and should not use blocked-request coalescing. If multiple repair records are used in one request, emit one summarized `info` diagnostic with record count, repair-source counts, and non-sensitive identifiers. Do not log placeholder payload content, tool arguments, tool output, user prompt text, or raw payloads.
+
+## Test Plan
+
+Unit tests near `app/src/ai/byop_readiness/`:
+
+- every readiness category
+- normalized projection construction and metadata retention
+- minimal BYOP Chat readiness message-kind coverage without exhaustive raw `api::Message` abstraction
+- visible unknown or readiness-irrelevant messages act as ordering boundaries, while filtered messages do not affect readiness
+- projection construction omits raw content while preserving classification metadata
+- result-source distinctions between persisted history and current `RequestParams.input`
+- projection ID semantics for assistant tool-call items and tool-result items
+- synthetic diagnostic IDs for current input results without persisted message IDs
+- strict assistant back-reference inference for tool-result items
+- ordering boundaries around assistant tool-call groups
+- complete, pending, cancelled, duplicate, orphan, out-of-order, corrupted, compacted, and accepted-repair groups
+- repair record exact matching by task ID, assistant tool-call message ID, and tool call ID
+- structured error and unreadable local interception payload behavior
+
+Controller tests:
+
+- user continuation with in-flight tool commits cancellation result before serialization
+- cancellation-result persistence failure blocks BYOP dispatch
+- finished-result drain persistence failure blocks BYOP dispatch when required for readiness
+- successful tool-result persistence rebuilds `RequestParams` before readiness is rerun
+- old `RequestParams.input` is not patched in place after persistence
+- bounded readiness reruns require progress and block on repeated actionable states without progress
+- readiness rerun loop stops at initial `max_iterations = 3`
+- readiness-loop non-convergence uses generalized user copy and `ReadinessLoopDidNotConverge` diagnostics
+- persisted tool results remain committed when later BYOP serialization or dispatch fails
+- late cancellation duplicate dedupes by tool call ID
+- pending/drainable classification requires live action state in the current conversation and task
+- corrupted/unexplained history does not retry, auto-resume, or open BYOP request
+- blocked-request copy distinguishes local no-send behavior from provider rejection
+- blocked-request UI does not expose automatic retry or ordinary retry in the initial implementation
+- manual continuation still goes through readiness and cannot bypass the same blocked history state
+- repeated manual continuation can show user feedback while coalescing duplicate diagnostics
+- duplicate blocked-request diagnostics use a non-sensitive coalescing key
+- coalesced diagnostics report suppressed counts in non-sensitive summaries
+- diagnostic coalescing is scoped to a single request attempt, with manual continuation starting a new window
+- readiness diagnostics include a non-persistent request-attempt identifier
+- request-attempt identifier is excluded from the coalescing key
+- readiness diagnostic log levels match category severity
+- accepted history repair emits one summarized `info` diagnostic per request
+- accepted history repair summaries include repair-source counts and omit sensitive content
+- `NeedsCancellationCommit` remains low-noise on successful commit and escalates only on persistence failure or no-progress loop behavior
+- non-blocking `StaleRepairRecordIgnored` logs at `debug`, while unauthorized visible gaps log through blocking `error` categories
+
+Serializer/request-body tests:
+
+- current `RequestParams.input` action results satisfy readiness
+- current input action results are not used as a fallback after required persistence fails
+- current input action results without persisted message IDs receive diagnostic-only synthetic projection IDs
+- persisted current input results switch to real message IDs and `PersistedHistory` source in later projections
+- duplicate history plus current input blocks
+- final projection after compaction/filtering is the validation target
+- controller preflight activity checks do not replace serializer validation over final projection
+- compaction/filtering hides assistant tool-call items and corresponding tool-result items together
+- compaction/filtering does not create new missing-result repair dependence
+- hidden assistant tool-call repair records remain unused and are not consumed or cleaned up
+- accepted repair placeholders use structured JSON and are not persisted
+- accepted repair placeholder status is always `unavailable`
+- accepted repair placeholder reasons use stable snake_case mappings from internal repair sources
+- accepted repair placeholder note is fixed English machine-facing text
+- accepted repair placeholder payload contains only `status`, `reason`, and `note`
+- accepted repair placeholder tests compare parsed JSON semantics rather than field order
+- multi-tool-call groups preserve assistant `tool_calls` order
+- strict Chat Completions ordering helper verifies no orphan tools, duplicates, or user/assistant messages before required tool responses
+
+Persistence and transformation tests:
+
+- `AgentConversationData` roundtrip and legacy payload without `byop_repair_state_json`
+- repair-state versioning and invalid-sidecar handling
+- invalid repair sidecar blocks only repair-dependent projections
+- invalid repair sidecar loads as explicit invalid status, not empty state
+- load categories for missing sidecar, invalid JSON, and unsupported version
+- strict version handling: v1 accepted, missing version and higher versions unsupported
+- `AIConversation` loads and saves repair state sidecar
+- fork creation records only retained tool calls with intentionally missing results
+- retained orphan tool results block and do not produce repair records
+- legacy restore records only conversion-proven legacy gaps
+
+## Implementation Phases
+
+1. Build `app/src/ai/byop_readiness/` with minimal BYOP Chat normalized projection construction, pure readiness classification, diagnostics types, and focused unit tests. Do not wire controller preflight or mutate action/conversation state in this phase.
+2. Add BYOP repair sidecar persistence after Phase 1 defines `RepairState` and `RepairStateStatus`. Then wire `AgentConversationData` roundtrip tests and `AIConversation` load/save integration. Avoid adding a bare JSON field before the load semantics, version handling, and invalid-state behavior exist.
+3. Add serializer validation over the final outbound projection, then rename or extract the accepted-history repair sanitizer so placeholders are produced only for accepted repair records. This may be implemented as substeps, first blocking normal-flow gaps and then generating accepted repair placeholders, but the phase should not be considered complete or merged as finished until both behaviors are present.
+4. Add controller preflight with bounded readiness reruns, finished-result draining, synchronous cancellation-result persistence, duplicate dedupe for known late cancellation, and request rebuild after successful persistence. Wire this after Phase 3 serializer validation is in place, so the serializer already acts as the final safety net if a controller path is missed.
+5. Add fork and legacy restore/conversion Repair Record creation at explicit history transformation boundaries. Do this after serializer accepted-repair consumption exists, so newly persisted records have a validated consumption path and tests can prove placeholders remain outbound-only.
+6. Add regression, request-body, and log-focused coverage for the observed placeholder-then-cancellation shape, strict Chat Completions ordering, diagnostics, and blocked-request behavior. The observed-shape fixture should be synthetic, minimal, and redacted: reproduce the structure where one request would have sent a placeholder before the next request sees the real cancellation result, without embedding real logs, prompts, tool arguments, or user content.
+
+## Implementation Checklist
+
+Execute write changes in phase order. Parallelize only read-only investigation or test-fixture design unless write ownership is clearly disjoint. Avoid simultaneous edits to the serializer, controller preflight, and request-construction paths because their ordering dependencies are central to this design.
+
+- [ ] Create `app/src/ai/byop_readiness/` with normalized projection types, safe metadata fields, and pure readiness result categories.
+- [ ] Add focused unit tests for projection construction, content omission, result-source distinctions, assistant back-reference inference, and every readiness category.
+- [ ] Define `RepairState`, `RepairRecord`, `RepairSource`, `RepairStateStatus`, and strict version/load handling.
+- [ ] Add `byop_repair_state_json` persistence, `AgentConversationData` roundtrip tests, and `AIConversation` load/save integration.
+- [ ] Pass a read-only repair state snapshot through `RequestParams`.
+- [ ] Validate final post-compaction/filtering outbound projection before provider `ChatMessage` construction.
+- [ ] Rename or extract the sanitizer so accepted history repair is the only placeholder-producing path.
+- [ ] Emit structured outbound repair placeholders with only `status`, `reason`, and `note`.
+- [ ] Add controller preflight with bounded reruns, progress checks, finished-result draining, cancellation-result commits, persistence failure blocking, and `RequestParams` rebuilds.
+- [ ] Add fork and legacy restore/conversion repair-record creation at explicit transformation boundaries only.
+- [ ] Add request-body regression tests for normal-flow blocking, accepted repair, current input results, duplicate projections, compaction/filtering boundaries, and strict Chat Completions ordering.
+- [ ] Add log-focused tests for diagnostic levels, coalescing, request-attempt IDs, source counts, redaction, and blocked-request copy.
+- [ ] Run the project-required validation, at minimum `cargo check`, before considering implementation complete.
+
+## Phase Stop Points
+
+- Phase 1 stop point: `byop_readiness` projection/classifier compiles and focused unit tests pass.
+- Phase 2 stop point: repair sidecar load/save behavior is covered by `AgentConversationData` roundtrip tests and `AIConversation` restore/persist tests.
+- Phase 3 stop point: serializer/request-body tests prove normal-flow gaps block and accepted repair placeholders are outbound-only structured JSON.
+- Phase 4 stop point: controller tests prove bounded preflight, drain/cancellation persistence, request rebuild, pending handling, and no retry/auto-resume for corrupted history.
+- Phase 5 stop point: fork and legacy restore/conversion tests prove repair records are created only at explicit transformation boundaries and only for authorized gaps.
+- Phase 6 stop point: regression, strict ordering, and log-focused tests pass, followed by project-required validation, at minimum `cargo check`.
+
+## Non-Goals
+
+- No feature flag for readiness or normal-flow placeholder blocking.
+- No new telemetry event in the initial implementation.
+- No SQL migration or new persistence table/column.
+- No non-BYOP provider branching.
+- No automatic repair for corrupted, unknown, or manual gaps in the initial implementation.
+- No serializer mutation of conversation state.


### PR DESCRIPTION
新增 BYOP Request Readiness 分类器和 repair sidecar，按 specs/byop-placeholder-tool-results/ISSUES.md 的切片记录设计、实现和验收状态。

在 serializer 和 controller preflight 中阻断缺失、重复、孤立或乱序的 tool result；普通流程先持久化真实 finished/cancellation result，只有显式 Repair Record 才允许 outbound-only placeholder。

将 blocked readiness 映射为不可自动重试的本地错误，并补充 fork repair、严格排序、日志脱敏和持久化回归覆盖。

Validation: cargo check -p warp --lib

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * BYOP placeholder tool results with request-level readiness validation
  * Conversation repair state tracking for forked and restored history
  * Tool call result preflight validation and consistency checks

* **Bug Fixes**
  * Improved error handling for blocked BYOP requests

* **Tests**
  * Readiness classification and repair scenario test coverage

* **Documentation**
  * Architecture specifications for BYOP placeholder tool results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->