### PR TITLE
feat(ssh): 支持通过 SSH 打开/编辑/保存远程文件

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,14 @@ git-fetch-with-cli = true
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]
+
+# 静态 musl 构建(CLI / remote-server tarball)。
+# `[build].rustflags` 里的 `-Wl,-headerpad_max_install_names` 是 macOS
+# 专用 linker flag,会让 musl-gcc 报错;target-specific rustflags 会整体
+# 覆盖 `[build].rustflags`,所以这里只保留通用的 symbol-mangling 设置,
+# 并显式开启 crt-static 产出完全静态、不依赖宿主 libc 的二进制。
+# linker 默认走 `cc`(在 CI 上由 musl-tools 提供 `musl-gcc`);
+# 需要时可用 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER 覆盖
+# (见 script/deploy_remote_server)。
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "symbol-mangling-version=v0", "-C", "target-feature=+crt-static"]

--- a/.github/workflows/openwarp_release.yml
+++ b/.github/workflows/openwarp_release.yml
@@ -283,28 +283,31 @@ jobs:
       # 以及 Alpine 等 musl 发行版)上运行。GUI AppImage/deb 仍走上面的
       # glibc 链接构建,不受影响。
       #
-      # `musl-tools` 只提供 C 编译器 `musl-gcc`,而依赖树里的 `freetype-sys`
-      # 等 *-sys crate 需要 musl 的 C++ 编译器。`musl-gcc` 本身只是个调用宿主
-      # gcc + musl specs 的 shell wrapper,这里照同样方式补一个 `musl-g++`
-      # 包装宿主 g++,并把两者按 cc-rs 期望的 `x86_64-linux-musl-{gcc,g++}`
-      # 三元组命名暴露到 PATH。
-      - name: Install musl toolchain for static CLI build
+      # 用 `cargo zigbuild` 做 musl 交叉编译:zig 自带完整的 C/C++ musl
+      # 工具链(`zig cc` / `zig c++`),不依赖宿主的 `musl-gcc` 或手写的
+      # `musl-g++` wrapper —— 历史上为 freetype-sys / harfbuzz-sys 等 *-sys
+      # 依赖准备的「宿主 g++ + musl specs」hack 因此整条移除。
+      # 本地 dev 自动构建路径(`ssh_transport.rs`)也优先用 zigbuild,两边
+      # 工具链统一。
+      - name: Install zig + cargo-zigbuild for static musl CLI build
         run: |
           set -euo pipefail
-          sudo apt-get install -y musl-tools
           rustup target add x86_64-unknown-linux-musl
-          # 生成 musl-g++ wrapper(musl-tools 没有提供)。
-          sudo tee /usr/bin/musl-g++ >/dev/null <<'EOF'
-          #!/bin/sh
-          exec "${REALGXX:-g++}" "$@" -specs "/usr/lib/musl/lib/musl-gcc.specs"
-          EOF
-          sudo chmod +x /usr/bin/musl-g++
-          # cc-rs 默认按 `<triple>-gcc` / `<triple>-g++` 找交叉编译器。
-          sudo ln -sf /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
-          sudo ln -sf /usr/bin/musl-g++ /usr/local/bin/x86_64-linux-musl-g++
+          # zig:用官方预编译 tarball,固定版本以保证构建可复现。
+          # 0.13.0 与 cargo-zigbuild >= 0.19 兼容。
+          ZIG_VERSION="0.13.0"
+          ZIG_DIR="$HOME/.local/zig-${ZIG_VERSION}"
+          if [ ! -x "${ZIG_DIR}/zig" ]; then
+            mkdir -p "${ZIG_DIR}"
+            curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
+              | tar -xJ -C "${ZIG_DIR}" --strip-components=1
+          fi
+          echo "${ZIG_DIR}" >> "$GITHUB_PATH"
+          # cargo-zigbuild:走 cargo install,首次安装在缓存里之后会复用。
+          cargo install --locked cargo-zigbuild --version ^0.19
         shell: bash
 
-      - name: Build CLI (static musl)
+      - name: Build CLI (static musl via zigbuild)
         id: bundle_cli
         run: |
           script/bundle --channel "$CHANNEL" --arch x86_64 --artifact cli --packages none \
@@ -313,11 +316,13 @@ jobs:
         env:
           GIT_RELEASE_TAG: ${{ needs.prepare_metadata.outputs.release_tag }}
           APPIMAGE_EXTRACT_AND_RUN: 1
+          # 让 script/linux/bundle 把 `cargo build` 切到 `cargo zigbuild`。
+          USE_ZIGBUILD: "true"
           # libc(musl)被 +crt-static 静态链接进二进制 —— 这是让产物摆脱
-          # 宿主 glibc 下限的关键。`libdbus-sys`(经 keyring → dbus-secret-service
-          # 链入)的 build script 用 pkg-config 探测 `dbus-1`;交叉编译时它默认
-          # 拒绝使用宿主 .pc 文件,这里放行(上面的 "Install extra dependencies"
-          # 步骤已装 libdbus-1-dev 提供 .pc 与头文件)。
+          # 宿主 glibc 下限的关键。`libdbus-sys` 现在通过 keyring 的
+          # `vendored` feature 从源码内嵌编译(见 Cargo.toml),不再用 pkg-config
+          # 探测宿主 `dbus-1`;`PKG_CONFIG_ALLOW_CROSS=1` 保留作兜底,
+          # 万一某个新引入的 -sys crate 还在用 pkg-config 也不会卡。
           PKG_CONFIG_ALLOW_CROSS: 1
 
       - name: Package CLI tarball

--- a/.github/workflows/openwarp_release.yml
+++ b/.github/workflows/openwarp_release.yml
@@ -278,14 +278,47 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Build CLI
+      # CLI/remote-server tarball 用静态 musl 链接,产物不依赖宿主 glibc,
+      # 可在任意 Linux x86_64 主机(含 CentOS 7 / Amazon Linux 2 等旧 glibc
+      # 以及 Alpine 等 musl 发行版)上运行。GUI AppImage/deb 仍走上面的
+      # glibc 链接构建,不受影响。
+      #
+      # `musl-tools` 只提供 C 编译器 `musl-gcc`,而依赖树里的 `freetype-sys`
+      # 等 *-sys crate 需要 musl 的 C++ 编译器。`musl-gcc` 本身只是个调用宿主
+      # gcc + musl specs 的 shell wrapper,这里照同样方式补一个 `musl-g++`
+      # 包装宿主 g++,并把两者按 cc-rs 期望的 `x86_64-linux-musl-{gcc,g++}`
+      # 三元组命名暴露到 PATH。
+      - name: Install musl toolchain for static CLI build
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          # 生成 musl-g++ wrapper(musl-tools 没有提供)。
+          sudo tee /usr/bin/musl-g++ >/dev/null <<'EOF'
+          #!/bin/sh
+          exec "${REALGXX:-g++}" "$@" -specs "/usr/lib/musl/lib/musl-gcc.specs"
+          EOF
+          sudo chmod +x /usr/bin/musl-g++
+          # cc-rs 默认按 `<triple>-gcc` / `<triple>-g++` 找交叉编译器。
+          sudo ln -sf /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
+          sudo ln -sf /usr/bin/musl-g++ /usr/local/bin/x86_64-linux-musl-g++
+        shell: bash
+
+      - name: Build CLI (static musl)
         id: bundle_cli
         run: |
-          script/bundle --channel "$CHANNEL" --arch x86_64 --artifact cli --packages none
+          script/bundle --channel "$CHANNEL" --arch x86_64 --artifact cli --packages none \
+            --target x86_64-unknown-linux-musl
         shell: bash
         env:
           GIT_RELEASE_TAG: ${{ needs.prepare_metadata.outputs.release_tag }}
           APPIMAGE_EXTRACT_AND_RUN: 1
+          # libc(musl)被 +crt-static 静态链接进二进制 —— 这是让产物摆脱
+          # 宿主 glibc 下限的关键。`libdbus-sys`(经 keyring → dbus-secret-service
+          # 链入)的 build script 用 pkg-config 探测 `dbus-1`;交叉编译时它默认
+          # 拒绝使用宿主 .pc 文件,这里放行(上面的 "Install extra dependencies"
+          # 步骤已装 libdbus-1-dev 提供 .pc 与头文件)。
+          PKG_CONFIG_ALLOW_CROSS: 1
 
       - name: Package CLI tarball
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,14 @@ keyring = { version = "3.6", features = [
     "linux-native",
     "linux-native-sync-persistent",
     "crypto-rust",
+    # vendored:让 dbus-secret-service → dbus → libdbus-sys 从 C 源码编译 dbus,
+    # 不再依赖系统 `libdbus-1-dev` + pkg-config。这样:
+    #   1. 把 warp 交叉编译到 x86_64-unknown-linux-musl(dev 自动上传 remote-server、
+    #      release CI 的 musl CLI 产物)时,libdbus-sys 不会因 pkg-config 不支持
+    #      cross 而失败;
+    #   2. 普通 Linux 构建也不再需要预装 dbus 开发包。
+    # 代价是每次 clean build 多编译一个小 C 库(可缓存),换来构建自洽。
+    "vendored",
 ] }
 lasso = { version = "0.7.3", features = ["multi-threaded"] }
 lazy_static = "1.4.0"

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -1183,6 +1183,7 @@ fn format_agent_text<W: Write>(text: &AIAgentText, w: &mut W) -> io::Result<()> 
                     Some(CodeSource::AIAction { .. })
                     | Some(CodeSource::New { .. })
                     | Some(CodeSource::FileTree { .. })
+                    | Some(CodeSource::RemoteFileTree { .. })
                     | Some(CodeSource::Finder { .. })
                     | None => {}
                 }

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -2909,7 +2909,7 @@ pub(crate) fn resolve_absolute_file_path(
 ) -> Option<PathBuf> {
     use warp_util::path::CleanPathResult;
 
-    use crate::util::file::{absolute_path_if_valid, ShellPathType};
+    use crate::util::file::{absolute_path_if_valid, LinkValidationContext, ShellPathType};
 
     let clean_path = CleanPathResult::with_line_and_column_number(&path.to_string_lossy());
 
@@ -2918,6 +2918,7 @@ pub(crate) fn resolve_absolute_file_path(
         &clean_path,
         ShellPathType::PlatformNative(home_dir.clone()),
         shell_launch_data,
+        &LinkValidationContext::Local,
     ) {
         return Some(resolved);
     }
@@ -2930,6 +2931,7 @@ pub(crate) fn resolve_absolute_file_path(
             &clean_joined_path,
             ShellPathType::PlatformNative(home_dir),
             shell_launch_data,
+            &LinkValidationContext::Local,
         )
     })
 }

--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -162,10 +162,16 @@ impl LeafContents {
             // SSH server editor:数据(host/user/...)持久化在 ssh_servers 表里,
             // pane 本身只是 view,关掉再打开没差别。
             LeafContents::SshServer { .. } => false,
+            // 远端文件代码 pane:远端 buffer 依赖活跃 SSH 连接,`RemoteFileTree`
+            // source 不可恢复(`is_restorable() == false`)。若写入持久化会留下
+            // 一条 restore 阶段被跳过的孤儿 `Code` 行,导致整个 tab 丢失 ——
+            // 因此带远端 source 的代码 pane 整体不持久化。
+            LeafContents::Code(CodePaneSnapShot::Local { source, .. }) => {
+                source.as_ref().map(|s| s.is_restorable()).unwrap_or(true)
+            }
             LeafContents::Terminal(_)
             | LeafContents::Notebook(_)
             | LeafContents::AIDocument(_)
-            | LeafContents::Code(_)
             | LeafContents::EnvVarCollection(_)
             | LeafContents::Workflow(_)
             | LeafContents::Settings(_)

--- a/app/src/code/buffer_location.rs
+++ b/app/src/code/buffer_location.rs
@@ -107,10 +107,11 @@ impl SyncClock {
     }
 
     /// Reconstruct a `SyncClock` from wire values (proto deserialization).
+    /// 用 `from_wire_u64` 饱和而不是 `as usize`,避免 32-bit 平台上隐式截断。
     pub fn from_wire(server_version: u64, client_version: u64) -> Self {
         Self {
-            server_version: ContentVersion::from_raw(server_version as usize),
-            client_version: ContentVersion::from_raw(client_version as usize),
+            server_version: ContentVersion::from_wire_u64(server_version),
+            client_version: ContentVersion::from_wire_u64(client_version),
         }
     }
 

--- a/app/src/code/buffer_location.rs
+++ b/app/src/code/buffer_location.rs
@@ -1,0 +1,134 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use warp_core::HostId;
+use warp_util::content_version::ContentVersion;
+use warp_util::standardized_path::StandardizedPath;
+
+/// Identifies a file on a remote host.
+///
+/// Pairs a [`HostId`] (to deduplicate across multiple SSH sessions to the
+/// same host) with the server-side [`StandardizedPath`].
+///
+/// 实现 `Serialize`/`Deserialize` 仅为让其能作为 `CodeSource` 的字段编译通过
+/// (`CodeSource` 整体派生 serde);远端文件 pane 实际不持久化。
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RemotePath {
+    pub host_id: HostId,
+    pub path: StandardizedPath,
+}
+
+impl RemotePath {
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    pub fn new(host_id: HostId, path: StandardizedPath) -> Self {
+        Self { host_id, path }
+    }
+
+    /// 远端文件名(取路径最后一段),用作 tab / pane header 标题。
+    pub fn file_name(&self) -> &str {
+        self.path
+            .as_str()
+            .rsplit('/')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.path.as_str())
+    }
+}
+
+/// Uniquely identifies where a buffer's content lives.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum BufferLocation {
+    /// File on the local filesystem.
+    Local(PathBuf),
+    /// File on a remote host, identified by host + path.
+    Remote(RemotePath),
+}
+
+impl BufferLocation {
+    /// 本地路径(仅 `Local` 变体有);远端文件返回 `None`。
+    pub fn local_path(&self) -> Option<&std::path::Path> {
+        match self {
+            BufferLocation::Local(path) => Some(path.as_path()),
+            BufferLocation::Remote(_) => None,
+        }
+    }
+
+    /// 用于 tab / header 显示的文件名。
+    pub fn display_name(&self) -> String {
+        match self {
+            BufferLocation::Local(path) => path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.display().to_string()),
+            BufferLocation::Remote(remote) => remote.file_name().to_string(),
+        }
+    }
+
+    /// 用于语言识别(后缀)的路径。远端文件用其远端路径构造一个
+    /// `PathBuf`(只取后缀,不做文件系统访问)。
+    pub fn language_path(&self) -> PathBuf {
+        match self {
+            BufferLocation::Local(path) => path.clone(),
+            BufferLocation::Remote(remote) => PathBuf::from(remote.path.as_str()),
+        }
+    }
+}
+
+/// Tracks sync state between client and server for a single remote buffer.
+///
+/// Uses a version vector with two components:
+/// - `server_version`: bumped by the server when the file changes on disk.
+/// - `client_version`: bumped by the client when the user edits the buffer.
+///
+/// Conflict detection:
+/// - Server pushes `{S_new, C_expected}`. Client checks `C_expected == local client_version`.
+///   Match → accept. Mismatch → conflict.
+/// - Client sends `{S_expected, C_new}`. Server checks `S_expected == local server_version`.
+///   Match → accept. Mismatch → reject (server pushes its current state).
+///
+/// Both fields use `ContentVersion` internally. At the wire boundary (proto
+/// encode/decode), convert via `ContentVersion::as_u64()` and
+/// `ContentVersion::from_raw()`.
+#[derive(Clone, Debug)]
+pub struct SyncClock {
+    /// Last version acknowledged from the server (file-watcher side).
+    pub server_version: ContentVersion,
+    /// Last version acknowledged from the client (user-edit side).
+    pub client_version: ContentVersion,
+}
+
+impl SyncClock {
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+    pub fn new() -> Self {
+        Self {
+            server_version: ContentVersion::from_raw(0),
+            client_version: ContentVersion::from_raw(0),
+        }
+    }
+
+    /// Reconstruct a `SyncClock` from wire values (proto deserialization).
+    pub fn from_wire(server_version: u64, client_version: u64) -> Self {
+        Self {
+            server_version: ContentVersion::from_raw(server_version as usize),
+            client_version: ContentVersion::from_raw(client_version as usize),
+        }
+    }
+
+    /// Bump the server version after a file-watcher change.
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+    pub fn bump_server(&mut self) -> ContentVersion {
+        self.server_version = ContentVersion::new();
+        self.server_version
+    }
+
+    /// Check whether a server push's expected client version matches our local state.
+    pub fn server_push_matches(&self, expected_client_version: ContentVersion) -> bool {
+        self.client_version == expected_client_version
+    }
+
+    /// Check whether a client edit's expected server version matches our local state.
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+    pub fn client_edit_matches(&self, expected_server_version: ContentVersion) -> bool {
+        self.server_version == expected_server_version
+    }
+}

--- a/app/src/code/editor_management.rs
+++ b/app/src/code/editor_management.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use crate::ai::skills::SkillOpenOrigin;
@@ -16,6 +16,7 @@ use crate::{
     workspace::PaneViewLocator,
 };
 
+use super::buffer_location::BufferLocation;
 use super::view::CodeView;
 
 pub struct CodeEditorSummary<'a> {
@@ -120,6 +121,12 @@ pub enum CodeSource {
     ProjectRules { path: PathBuf },
     /// Opened from file tree.
     FileTree { path: PathBuf },
+    /// 从远端文件树点击打开的远端文件(openWarp 独有)。通过 buffer-sync 协议
+    /// 与 SSH daemon 同步内容,本地没有对应路径,因此 tab 身份用 [`RemotePath`]
+    /// 标识。pane 不持久化 —— 远端 buffer 依赖活跃 SSH 连接。
+    RemoteFileTree {
+        remote_path: super::buffer_location::RemotePath,
+    },
     /// Opened from macOS Finder via "Open With".
     Finder { path: PathBuf },
     /// Opened from a skill.
@@ -140,19 +147,40 @@ impl CodeSource {
             | Self::AIAction { .. }
             | Self::ProjectRules { .. }
             | Self::FileTree { .. }
+            | Self::RemoteFileTree { .. }
             | Self::Finder { .. }
             | Self::Skill { .. } => None,
         }
     }
 
+    /// 本地文件路径。**不包含远端文件** —— 远端文件没有本地路径,用
+    /// [`Self::location`] 取统一身份。
     pub fn path(&self) -> Option<PathBuf> {
         match self {
-            Self::New { .. } | Self::AIAction { .. } => None,
+            Self::New { .. } | Self::AIAction { .. } | Self::RemoteFileTree { .. } => None,
             Self::Link { path, .. }
             | Self::ProjectRules { path }
             | Self::FileTree { path }
             | Self::Finder { path }
             | Self::Skill { path, .. } => Some(path.clone()),
+        }
+    }
+
+    /// 该 source 对应文件的统一身份(本地路径或远端 `RemotePath`)。
+    ///
+    /// 本地文件与远端文件统一走 `CodeView` 的多文件分组逻辑,tab 去重 / 聚焦
+    /// 都用 [`BufferLocation`] 作为 key。
+    pub fn location(&self) -> Option<BufferLocation> {
+        match self {
+            Self::New { .. } | Self::AIAction { .. } => None,
+            Self::RemoteFileTree { remote_path } => {
+                Some(BufferLocation::Remote(remote_path.clone()))
+            }
+            Self::Link { path, .. }
+            | Self::ProjectRules { path }
+            | Self::FileTree { path }
+            | Self::Finder { path }
+            | Self::Skill { path, .. } => Some(BufferLocation::Local(path.clone())),
         }
     }
 
@@ -187,6 +215,7 @@ impl CodeSource {
             Self::AIAction { .. } => "ai_action",
             Self::ProjectRules { .. } => "project_rules",
             Self::FileTree { .. } => "file_tree",
+            Self::RemoteFileTree { .. } => "remote_file_tree",
             Self::Finder { .. } => "finder",
             Self::Skill { .. } => "skill",
         }
@@ -195,9 +224,9 @@ impl CodeSource {
     /// Returns `true` if this source should be restored across app restarts.
     ///
     /// `AIAction` is ephemeral (tied to a live conversation) and should not
-    /// be restored.
+    /// be restored. `RemoteFileTree` 依赖活跃 SSH 连接,同样不恢复。
     pub fn is_restorable(&self) -> bool {
-        !matches!(self, Self::AIAction { .. })
+        !matches!(self, Self::AIAction { .. } | Self::RemoteFileTree { .. })
     }
 }
 
@@ -249,17 +278,18 @@ impl CodeManager {
     pub fn deregister_pane(&mut self, source: &CodeSource) {
         self.source_to_pane_data.remove(&source.omit_line_col());
     }
-    /// Returns the locator for a code pane that already has `path` open in the given pane group.
-    pub fn get_locator_for_path_in_tab(
+    /// Returns the locator for a code pane that already has `location` open in
+    /// the given pane group. `location` 统一覆盖本地与远端文件。
+    pub fn get_locator_for_location_in_tab(
         &self,
         pane_group_id: EntityId,
-        path: &Path,
+        location: &BufferLocation,
     ) -> Option<PaneViewLocator> {
         self.source_to_pane_data
             .iter()
             .find(|(source, data)| {
                 data.locator.pane_group_id == pane_group_id
-                    && source.path().is_some_and(|p| p.as_path() == path)
+                    && source.location().as_ref() == Some(location)
             })
             .map(|(_, data)| data.locator)
     }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -67,7 +67,6 @@ use crate::{
 use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::{color::internal_colors, Fill};
 use warp_core::HostId;
-use warpui::ui_components::components::UiComponent;
 
 mod editing;
 mod render;
@@ -1931,7 +1930,6 @@ impl FileTreeView {
         let is_selected = self.selected_item.as_ref() == Some(id);
         let is_expanded = self.is_item_expanded(&id.root, item);
         let render_state = item.to_render_state(is_expanded, appearance);
-        let is_remote_file = root_dir.is_remote() && matches!(item, FileTreeItem::File { .. });
 
         let item_display_name = render_state.display_name.clone();
         let item_position_id = format!("file_tree_item:{item_display_name}");
@@ -1950,34 +1948,15 @@ impl FileTreeView {
         let id_for_context = id.clone();
         let id_for_drop = id.clone();
         let id_for_drag = id.clone();
-        let ui_builder = appearance.ui_builder();
         let hoverable = Hoverable::new(render_state.mouse_state.clone(), move |mouse_state| {
             let item_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
-            let element = Self::render_item_with_hover(
+            // 远端文件已支持通过 buffer-sync 协议打开,不再显示「无法打开」提示。
+            Self::render_item_with_hover(
                 render_state,
                 appearance,
                 item_highlight_state,
                 editor_view,
-            );
-
-            if is_remote_file && mouse_state.is_hovered() {
-                let tooltip = ui_builder
-                    .tool_tip(crate::t!("code-open-file-unavailable-remote-tooltip"))
-                    .build()
-                    .finish();
-                let offset = OffsetPositioning::offset_from_parent(
-                    Vector2F::new(0., 4.),
-                    ParentOffsetBounds::WindowByPosition,
-                    ParentAnchor::BottomLeft,
-                    ChildAnchor::TopLeft,
-                );
-                Stack::new()
-                    .with_child(element)
-                    .with_positioned_overlay_child(tooltip, offset)
-                    .finish()
-            } else {
-                element
-            }
+            )
         })
         .on_click(
             move |event_ctx: &mut EventContext, _app_ctx: &AppContext, _position| {
@@ -2000,12 +1979,8 @@ impl FileTreeView {
                 });
             },
         )
-        // Remote files can't be opened in the editor, so use the default cursor.
-        .with_cursor(if is_remote_file {
-            Cursor::Arrow
-        } else {
-            Cursor::PointingHand
-        })
+        // 本地和远端文件都可点击打开,统一用手型光标。
+        .with_cursor(Cursor::PointingHand)
         .finish();
 
         let draggable = Draggable::new(draggable_state, hoverable)
@@ -2226,10 +2201,19 @@ impl FileTreeView {
 
         match item {
             FileTreeItem::File { metadata, .. } => {
-                // Remote file trees don't support opening files in the editor.
                 if !is_remote {
                     let path = metadata.path.to_local_path_lossy();
                     self.open_file(&path, None, ctx);
+                } else {
+                    // 远端文件:走 buffer-sync 协议打开。
+                    #[cfg(feature = "local_tty")]
+                    if let Some(host_id) = root_dir.remote_host_id.clone() {
+                        let remote_path = crate::code::buffer_location::RemotePath::new(
+                            host_id,
+                            (*metadata.path).clone(),
+                        );
+                        ctx.emit(FileTreeEvent::OpenRemoteFile { remote_path });
+                    }
                 }
             }
             FileTreeItem::DirectoryHeader { directory, .. } => {
@@ -2866,6 +2850,11 @@ pub enum FileTreeEvent {
     CDToDirectory { path: PathBuf },
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     OpenDirectoryInNewTab { path: PathBuf },
+    /// 在远端文件树里点击一个文件时发出,请求以远端 buffer 方式打开它。
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    OpenRemoteFile {
+        remote_path: crate::code::buffer_location::RemotePath,
+    },
 }
 
 impl Entity for FileTreeView {

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -1079,12 +1079,19 @@ impl GlobalBufferModel {
                                 }
                             })
                             .collect();
-                        client.send_buffer_edit(
+                        // 投递失败说明连接已死,daemon 收不到这次编辑而本地
+                        // buffer 已推进 —— 标记为冲突,触发 UI 重新同步。
+                        if let Err(e) = client.send_buffer_edit(
                             path_for_edit.clone(),
                             expected_sv,
                             new_cv.as_u64(),
                             edits,
-                        );
+                        ) {
+                            log::error!(
+                                "Failed to send remote buffer edit for {path_for_edit}: {e}"
+                            );
+                            ctx.emit(GlobalBufferModelEvent::RemoteBufferConflict { file_id });
+                        }
                     }
                 });
             }

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -153,6 +153,9 @@ pub enum GlobalBufferModelEvent {
     /// A server-local buffer was updated from a file-watcher event.
     /// Carries the incremental diff edits for the ServerModel to push
     /// to connected clients as `BufferUpdatedPush`.
+    ///
+    /// Note: this event is NOT emitted from `apply_client_edit`. See that
+    /// method's doc comment for the V0 single-client limitation.
     ServerLocalBufferUpdated {
         file_id: FileId,
         /// Incremental edits with 1-indexed character offsets (matching `CharOffset`).
@@ -229,11 +232,17 @@ impl GlobalBufferModel {
                 edits,
             } = event
             {
+                // wire offset 是 1-indexed char offset(对齐 CharOffset)。
+                // 用饱和转换避免 32-bit 平台 `as usize` 截断高位;native 64-bit 上等价。
                 let char_edits: Vec<_> = edits
                     .iter()
                     .map(|e| CharOffsetEdit {
-                        start: CharOffset::from(e.start_offset as usize),
-                        end: CharOffset::from(e.end_offset as usize),
+                        start: CharOffset::from(
+                            usize::try_from(e.start_offset).unwrap_or(usize::MAX),
+                        ),
+                        end: CharOffset::from(
+                            usize::try_from(e.end_offset).unwrap_or(usize::MAX),
+                        ),
                         text: e.text.clone(),
                     })
                     .collect();
@@ -1194,10 +1203,10 @@ impl GlobalBufferModel {
             return;
         };
 
-        let expected_cv = ContentVersion::from_raw(expected_client_version as usize);
+        let expected_cv = ContentVersion::from_wire_u64(expected_client_version);
         if sync_clock.server_push_matches(expected_cv) {
             // Accept the update — apply edits incrementally.
-            sync_clock.server_version = ContentVersion::from_raw(new_server_version as usize);
+            sync_clock.server_version = ContentVersion::from_wire_u64(new_server_version);
 
             let Some(buffer) = state.buffer.upgrade(ctx) else {
                 return;
@@ -1248,7 +1257,21 @@ impl GlobalBufferModel {
     /// If `expected_server_version` matches the buffer's current server version,
     /// the edits are applied to the in-memory buffer (no disk write) and the
     /// client version is updated. Returns `true` if accepted, `false` if rejected
-    /// (stale edit — silently discarded).
+    /// (stale edit — silently discarded, per `BufferEdit` proto spec).
+    ///
+    /// V0 limitation (single-client per buffer):
+    /// this intentionally does NOT emit `ServerLocalBufferUpdated`. That event
+    /// would broadcast the edit to every other connection that has the buffer
+    /// open, but `SyncClock.client_version` is daemon-wide rather than
+    /// per-connection, so there is no safe `expected_client_version` to put
+    /// in a `BufferUpdatedPush` targeted at peer connection C (its local
+    /// `client_version` is independent of A's). Until `SyncClock` becomes
+    /// per-connection, only one client should hold a writable view of a
+    /// given remote buffer at a time.
+    ///
+    /// TODO(ssh-remote, multi-client): make `SyncClock.client_version` a
+    /// `HashMap<ConnectionId, ContentVersion>` and forward A's edits to
+    /// peers with the per-peer expected `client_version`.
     #[cfg(feature = "local_fs")]
     pub fn apply_client_edit(
         &mut self,
@@ -1285,13 +1308,20 @@ impl GlobalBufferModel {
         let new_version = ContentVersion::new();
         buffer.update(ctx, |buffer, ctx| {
             let max_offset = buffer.max_charoffset();
+            // wire offset 饱和转换 + clamp 到 buffer 末尾,双重防御。
             let char_edits: Vec<(std::ops::Range<CharOffset>, String)> = edits
                 .iter()
                 .map(|edit| {
-                    let start =
-                        CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
-                    let end =
-                        CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
+                    let start = CharOffset::from(
+                        usize::try_from(edit.start_offset)
+                            .unwrap_or(usize::MAX)
+                            .min(max_offset.as_usize()),
+                    );
+                    let end = CharOffset::from(
+                        usize::try_from(edit.end_offset)
+                            .unwrap_or(usize::MAX)
+                            .min(max_offset.as_usize()),
+                    );
                     (start..end, edit.text.clone())
                 })
                 .collect();

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -1001,6 +1001,9 @@ impl GlobalBufferModel {
         }
 
         let file_id = FileId::new();
+        // TODO(ssh-remote): buffer 在初始内容(OpenBufferResponse)到达前即可编辑,
+        // 加载窗口内的用户编辑会被 replace_all() 覆盖丢失。需在 Buffer/编辑器层
+        // 增加 read-only 支持后,在 sync_clock=None 期间锁定该 buffer。
         let buffer = ctx.add_model(|_| Buffer::default());
 
         // Store state with sync_clock = None (set to Some on OpenBufferResponse).
@@ -1090,6 +1093,8 @@ impl GlobalBufferModel {
             let manager = remote_server::manager::RemoteServerManager::handle(ctx);
             let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
                 log::warn!("No remote server client for host {host_id:?}");
+                // 清理失败的 file_id,使后续重试能重新发送 OpenBuffer。
+                self.cleanup_file_id(file_id, ctx);
                 ctx.emit(GlobalBufferModelEvent::FailedToLoad {
                     file_id,
                     error: Rc::new(FileLoadError::DoesNotExist),
@@ -1127,6 +1132,8 @@ impl GlobalBufferModel {
                     }
                     Err(error) => {
                         log::warn!("Failed to open remote buffer: {error}");
+                        // 清理失败的 file_id,使后续重试能重新发送 OpenBuffer。
+                        me.cleanup_file_id(file_id, ctx);
                         ctx.emit(GlobalBufferModelEvent::FailedToLoad {
                             file_id,
                             error: Rc::new(FileLoadError::DoesNotExist),
@@ -1302,7 +1309,8 @@ impl GlobalBufferModel {
             return Err(FileSaveError::RemoteError("Buffer deallocated".to_string()));
         };
         let content = buffer.as_ref(ctx).text().into_string();
-        let version = ContentVersion::new();
+        // 使用 buffer 当前版本,避免与 daemon 的版本同步错位。
+        let version = buffer.as_ref(ctx).version();
         FileModel::handle(ctx).update(ctx, |file_model, ctx| {
             file_model.save(file_id, content, version, ctx)
         })
@@ -1324,8 +1332,19 @@ impl GlobalBufferModel {
         };
 
         if let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source {
+            // 拒绝过期的冲突解决:若服务端版本在客户端看到冲突后又变化,
+            // 强行覆盖会丢掉更新的服务端编辑。
+            if sync_clock.server_version != acknowledged_server_version {
+                return Err(FileSaveError::RemoteError(
+                    "Stale conflict resolution".to_string(),
+                ));
+            }
             sync_clock.server_version = acknowledged_server_version;
             sync_clock.client_version = current_client_version;
+        } else {
+            return Err(FileSaveError::RemoteError(
+                "Buffer is not server-local".to_string(),
+            ));
         }
 
         let Some(buffer) = state.buffer.upgrade(ctx) else {
@@ -1340,9 +1359,10 @@ impl GlobalBufferModel {
 
         // Save to disk. Note: the buffer content has already been replaced
         // in memory above. If the save fails, memory and disk will diverge.
+        // 使用 buffer 当前版本,且在保存成功(FileSaved 回调)前不更新
+        // base_content_version,避免与 daemon 版本同步错位。
         let content = client_content.to_string();
-        let save_version = ContentVersion::new();
-        state.set_base_content_version(save_version);
+        let save_version = buffer.as_ref(ctx).version();
         FileModel::handle(ctx).update(ctx, |file_model, ctx| {
             file_model.save(file_id, content, save_version, ctx)
         })
@@ -1404,6 +1424,13 @@ impl GlobalBufferModel {
         let manager = remote_server::manager::RemoteServerManager::handle(ctx);
         let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
             log::warn!("save_remote_buffer: host {host_id:?} 无 remote server client");
+            // 通知编辑器保存失败,避免停留在虚假的“已保存”状态。
+            ctx.emit(GlobalBufferModelEvent::FailedToSave {
+                file_id,
+                error: Rc::new(FileSaveError::RemoteError(format!(
+                    "Remote host {host_id:?} is not connected"
+                ))),
+            });
             return;
         };
 
@@ -1422,12 +1449,22 @@ impl GlobalBufferModel {
                             ctx.emit(GlobalBufferModelEvent::FileSaved { file_id });
                         }
                         Some(SaveResult::Error(err)) => {
-                            log::warn!("远端保存失败: {}", err.message);
+                            // 把远端保存失败上抛给编辑器,显示失败提示。
+                            ctx.emit(GlobalBufferModelEvent::FailedToSave {
+                                file_id,
+                                error: Rc::new(FileSaveError::RemoteError(err.message)),
+                            });
                         }
                     }
                 }
                 Err(error) => {
-                    log::warn!("save_remote_buffer: SaveBuffer 请求失败: {error}");
+                    // 传输/协议错误同样上抛给编辑器。
+                    ctx.emit(GlobalBufferModelEvent::FailedToSave {
+                        file_id,
+                        error: Rc::new(FileSaveError::RemoteError(format!(
+                            "SaveBuffer request failed: {error}"
+                        ))),
+                    });
                 }
             },
         );

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -6,12 +6,15 @@ use std::rc::Rc;
 use bimap::BiMap;
 
 use futures_util::stream::AbortHandle;
+use string_offset::{ByteOffset, CharOffset};
 use warp_core::features::FeatureFlag;
-use warp_editor::content::buffer::Buffer;
+use warp_editor::content::buffer::{Buffer, ToBufferCharOffset};
 use warp_editor::content::diff::{text_diff, TextDiff};
 use warp_util::content_version::ContentVersion;
 use warp_util::file::{FileId, FileLoadError, FileSaveError};
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle};
+
+use super::buffer_location::{BufferLocation, SyncClock};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
@@ -39,11 +42,86 @@ struct PendingDiffParse {
     abort_handle: AbortHandle,
 }
 
+/// Describes the backing store for a buffer's content.
+enum BufferSource {
+    /// Backed by the local filesystem (existing behavior).
+    Local {
+        base_content_version: Option<ContentVersion>,
+    },
+    /// Backed by a remote filesystem over the remote server protocol.
+    Remote {
+        remote_path: super::buffer_location::RemotePath,
+        /// `None` while waiting for the `OpenBufferResponse`; `Some` once loaded.
+        sync_clock: Option<SyncClock>,
+    },
+    /// Local file managed by the remote-server daemon.
+    /// Owns the SyncClock for version tracking. Connection tracking
+    /// is handled by ServerModel, not here — the buffer is a file-level
+    /// concept shared across connections.
+    ServerLocal {
+        sync_clock: SyncClock,
+        base_content_version: Option<ContentVersion>,
+    },
+}
+
 struct InternalBufferState {
     buffer: WeakModelHandle<Buffer>,
-    base_content_version: Option<ContentVersion>,
     /// Tracks any active background diff parsing for auto-reload.
     pending_diff_parse: Option<PendingDiffParse>,
+    source: BufferSource,
+}
+
+impl InternalBufferState {
+    /// Returns the base content version for local/server-local buffers,
+    /// `None` for remote.
+    ///
+    /// Remote buffers return `None` because they don't use the file-watcher
+    /// auto-reload path. Version tracking for remote buffers is handled by
+    /// `SyncClock` instead.
+    fn base_content_version(&self) -> Option<ContentVersion> {
+        match &self.source {
+            BufferSource::Local {
+                base_content_version,
+            }
+            | BufferSource::ServerLocal {
+                base_content_version,
+                ..
+            } => *base_content_version,
+            BufferSource::Remote { .. } => None,
+        }
+    }
+
+    /// Sets the base content version. Applicable to Local and ServerLocal buffers.
+    fn set_base_content_version(&mut self, version: ContentVersion) {
+        match &mut self.source {
+            BufferSource::Local {
+                base_content_version,
+            }
+            | BufferSource::ServerLocal {
+                base_content_version,
+                ..
+            } => {
+                *base_content_version = Some(version);
+            }
+            BufferSource::Remote { .. } => {}
+        }
+    }
+
+    /// Whether this buffer has been loaded (has content).
+    fn is_loaded(&self) -> bool {
+        match &self.source {
+            BufferSource::Local {
+                base_content_version,
+            }
+            | BufferSource::ServerLocal {
+                base_content_version,
+                ..
+            } => base_content_version.is_some(),
+            // Remote buffers are loaded once the OpenBufferResponse arrives
+            // and populates the sync clock.
+            BufferSource::Remote { sync_clock, .. } => sync_clock.is_some(),
+        }
+    }
 }
 
 pub enum GlobalBufferModelEvent {
@@ -67,6 +145,21 @@ pub enum GlobalBufferModelEvent {
         file_id: FileId,
         error: Rc<FileSaveError>,
     },
+    /// A remote buffer update conflicted with local edits.
+    /// The UI should present a resolution dialog.
+    RemoteBufferConflict {
+        file_id: FileId,
+    },
+    /// A server-local buffer was updated from a file-watcher event.
+    /// Carries the incremental diff edits for the ServerModel to push
+    /// to connected clients as `BufferUpdatedPush`.
+    ServerLocalBufferUpdated {
+        file_id: FileId,
+        /// Incremental edits with 1-indexed character offsets (matching `CharOffset`).
+        edits: Vec<CharOffsetEdit>,
+        new_server_version: ContentVersion,
+        expected_client_version: ContentVersion,
+    },
 }
 
 impl GlobalBufferModelEvent {
@@ -76,9 +169,23 @@ impl GlobalBufferModelEvent {
             | GlobalBufferModelEvent::FailedToLoad { file_id, .. }
             | GlobalBufferModelEvent::BufferUpdatedFromFileEvent { file_id, .. }
             | GlobalBufferModelEvent::FileSaved { file_id, .. }
-            | GlobalBufferModelEvent::FailedToSave { file_id, .. } => *file_id,
+            | GlobalBufferModelEvent::FailedToSave { file_id, .. }
+            | GlobalBufferModelEvent::RemoteBufferConflict { file_id, .. }
+            | GlobalBufferModelEvent::ServerLocalBufferUpdated { file_id, .. } => *file_id,
         }
     }
+}
+
+/// A text edit using 1-indexed character offsets (matching `CharOffset`).
+///
+/// Used to carry incremental edits in `ServerLocalBufferUpdated` events
+/// and `handle_buffer_updated_push` without coupling `GlobalBufferModel`
+/// to proto types. Offsets use the same 1-indexed coordinate system as
+/// the buffer's `CharOffset`, so no conversion is needed at the boundary.
+pub struct CharOffsetEdit {
+    pub start: CharOffset,
+    pub end: CharOffset,
+    pub text: String,
 }
 
 /// Global singleton model for managing shared buffers across editors.
@@ -86,7 +193,7 @@ impl GlobalBufferModelEvent {
 /// This allows multiple editors to share the same buffer when editing the same file,
 /// enabling consistent content synchronization and more efficient memory usage.
 pub struct GlobalBufferModel {
-    path_to_id: BiMap<PathBuf, FileId>,
+    location_to_id: BiMap<BufferLocation, FileId>,
     buffers: HashMap<FileId, InternalBufferState>,
 }
 
@@ -96,9 +203,50 @@ impl GlobalBufferModel {
         _ctx.subscribe_to_model(&FileModel::handle(_ctx), Self::handle_file_model_events);
 
         Self {
-            path_to_id: BiMap::new(),
+            location_to_id: BiMap::new(),
             buffers: HashMap::new(),
         }
+    }
+
+    /// 客户端 app 专用:订阅 `RemoteServerManager` 的 buffer push 事件,把远端
+    /// daemon 推来的 `BufferUpdated` 应用到本地 Remote buffer。
+    ///
+    /// 必须由客户端 app 在注册 `GlobalBufferModel` 时显式调用 —— **不能**放进
+    /// `new()`:remote-server daemon 同样会注册 `GlobalBufferModel`(用于
+    /// ServerLocal buffer 的服务端同步),但 daemon 不注册 `RemoteServerManager`,
+    /// 若在 `new()` 里 `RemoteServerManager::handle()` 会 panic「never registered」
+    /// 导致 daemon 一启动就崩。
+    #[cfg(feature = "local_tty")]
+    pub fn subscribe_to_remote_server_manager(ctx: &mut ModelContext<Self>) {
+        use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+        let mgr = RemoteServerManager::handle(ctx);
+        ctx.subscribe_to_model(&mgr, |me, event, ctx| {
+            if let RemoteServerManagerEvent::BufferUpdated {
+                host_id,
+                path,
+                new_server_version,
+                expected_client_version,
+                edits,
+            } = event
+            {
+                let char_edits: Vec<_> = edits
+                    .iter()
+                    .map(|e| CharOffsetEdit {
+                        start: CharOffset::from(e.start_offset as usize),
+                        end: CharOffset::from(e.end_offset as usize),
+                        text: e.text.clone(),
+                    })
+                    .collect();
+                me.handle_buffer_updated_push(
+                    host_id,
+                    path,
+                    *new_server_version,
+                    *expected_client_version,
+                    &char_edits,
+                    ctx,
+                );
+            }
+        });
     }
 
     /// Scan through all buffers and deallocate any that are no longer in use.
@@ -120,7 +268,7 @@ impl GlobalBufferModel {
         }
 
         for id in &ids_to_remove {
-            self.path_to_id.remove_by_right(id);
+            self.location_to_id.remove_by_right(id);
         }
 
         for id in ids_to_remove {
@@ -140,12 +288,12 @@ impl GlobalBufferModel {
     pub fn buffer_loaded(&self, file_id: FileId) -> bool {
         self.buffers
             .get(&file_id)
-            .map(|state| state.base_content_version.is_some())
+            .map(|state| state.is_loaded())
             .unwrap_or(false)
     }
 
     fn cleanup_file_id(&mut self, file_id: FileId, _ctx: &mut ModelContext<Self>) {
-        self.path_to_id.remove_by_right(&file_id);
+        self.location_to_id.remove_by_right(&file_id);
 
         self.buffers.remove(&file_id);
 
@@ -168,7 +316,7 @@ impl GlobalBufferModel {
         let state = self.buffers.get(&file_id)?;
 
         // If the buffer hasn't been loaded yet, don't return a model handle.
-        if state.base_content_version.is_none() {
+        if !state.is_loaded() {
             log::info!("Cannot return handle for unloaded buffers");
             return None;
         }
@@ -212,7 +360,7 @@ impl GlobalBufferModel {
                 buffer.set_version(new_version);
             });
 
-            state.base_content_version = Some(new_version);
+            state.set_base_content_version(new_version);
 
             ctx.emit(GlobalBufferModelEvent::BufferLoaded {
                 file_id,
@@ -236,7 +384,7 @@ impl GlobalBufferModel {
                 buffer.set_version(new_version);
             });
 
-            state.base_content_version = Some(new_version);
+            state.set_base_content_version(new_version);
 
             ctx.emit(GlobalBufferModelEvent::BufferUpdatedFromFileEvent {
                 file_id,
@@ -300,7 +448,11 @@ impl GlobalBufferModel {
             return;
         };
 
-        // Verify the buffer still matches the expected base version
+        // Verify the buffer still matches the expected base version.
+        // This also correctly handles the case where a client edit arrives
+        // during the background diff parse: apply_client_edit modifies the
+        // buffer version, so this check will fail and we discard the stale
+        // diff rather than incorrectly bumping the server version.
         if !buffer.as_ref(ctx).version_match(&base_version) {
             log::info!("Buffer version changed during diff parsing, aborting apply");
             ctx.emit(GlobalBufferModelEvent::BufferUpdatedFromFileEvent {
@@ -310,6 +462,34 @@ impl GlobalBufferModel {
             });
             return;
         }
+
+        let is_server_local = matches!(state.source, BufferSource::ServerLocal { .. });
+
+        // For ServerLocal buffers, convert byte-range edits to 1-indexed
+        // char-offset edits BEFORE applying the diff, because the byte
+        // ranges in diff.edits reference the old (pre-edit) buffer content.
+        // Uses the buffer's native byte→char offset conversion.
+        let char_offset_edits: Option<Vec<CharOffsetEdit>> = if is_server_local {
+            let buffer_ref = buffer.as_ref(ctx);
+            Some(
+                diff.edits
+                    .iter()
+                    .map(|(range, text)| {
+                        // +1: 0-indexed text byte offset → 1-indexed buffer byte offset
+                        let start =
+                            ByteOffset::from(range.start + 1).to_buffer_char_offset(buffer_ref);
+                        let end = ByteOffset::from(range.end + 1).to_buffer_char_offset(buffer_ref);
+                        CharOffsetEdit {
+                            start,
+                            end,
+                            text: text.clone(),
+                        }
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
 
         // Apply the diff edits
         buffer.update(ctx, |buffer, ctx| {
@@ -322,13 +502,25 @@ impl GlobalBufferModel {
             buffer.insert_at_char_offset_ranges(char_edits, new_version, ctx);
         });
 
-        state.base_content_version = Some(new_version);
+        state.set_base_content_version(new_version);
 
-        ctx.emit(GlobalBufferModelEvent::BufferUpdatedFromFileEvent {
-            file_id,
-            success: true,
-            content_version: new_version,
-        });
+        if let Some(char_offset_edits) = char_offset_edits {
+            if let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source {
+                let new_sv = sync_clock.bump_server();
+                ctx.emit(GlobalBufferModelEvent::ServerLocalBufferUpdated {
+                    file_id,
+                    edits: char_offset_edits,
+                    new_server_version: new_sv,
+                    expected_client_version: sync_clock.client_version,
+                });
+            }
+        } else {
+            ctx.emit(GlobalBufferModelEvent::BufferUpdatedFromFileEvent {
+                file_id,
+                success: true,
+                content_version: new_version,
+            });
+        }
     }
 
     #[cfg(feature = "local_fs")]
@@ -372,7 +564,7 @@ impl GlobalBufferModel {
                         let internal_base_version = self
                             .buffers
                             .get(id)
-                            .and_then(|state| state.base_content_version);
+                            .and_then(|state| state.base_content_version());
                         let has_no_user_edits = internal_base_version
                             .is_some_and(|v| buffer.as_ref(ctx).version_match(&v));
 
@@ -426,7 +618,7 @@ impl GlobalBufferModel {
                 // Make sure base content version is updated after a save is performed.
                 // This avoids us flagging the incoming update from file watcher as conflict changes.
                 if let Some(state) = self.buffers.get_mut(id) {
-                    state.base_content_version = Some(*version);
+                    state.set_base_content_version(*version);
                 }
                 ctx.emit(GlobalBufferModelEvent::FileSaved { file_id: *id });
             }
@@ -481,31 +673,36 @@ impl GlobalBufferModel {
         })
     }
 
-    /// Remove a tracked buffer, cleaning up FileModel and LSP state.
+    /// Remove a tracked buffer, cleaning up FileModel state.
     /// Used when a new file is deleted before ever being saved to a permanent location.
     pub fn remove(&mut self, file_id: FileId, ctx: &mut ModelContext<Self>) {
         self.cleanup_file_id(file_id, ctx);
     }
 
-    /// Look up the file path for a tracked buffer.
+    /// Look up the file path for a tracked local buffer.
     pub fn file_path(&self, file_id: FileId) -> Option<&Path> {
-        self.path_to_id
-            .get_by_right(&file_id)
-            .map(|path| path.as_path())
+        match self.location_to_id.get_by_right(&file_id) {
+            Some(BufferLocation::Local(path)) => Some(path.as_path()),
+            _ => None,
+        }
     }
 
     /// Get the base content version (last known on-disk version) for a tracked buffer.
     pub fn base_version(&self, file_id: FileId) -> Option<ContentVersion> {
         self.buffers
             .get(&file_id)
-            .and_then(|state| state.base_content_version)
+            .and_then(|state| state.base_content_version())
     }
 
     /// Discard any in progress changes and reload the buffer with the canonical version from the file system.
     #[cfg(feature = "local_fs")]
-    pub fn discard_unsaved_changes(&mut self, path: &PathBuf, ctx: &mut ModelContext<Self>) {
-        if let Some(id) = self.path_to_id.get_by_left(path).cloned() {
-            let path_clone = path.clone();
+    pub fn discard_unsaved_changes(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
+        if let Some(id) = self
+            .location_to_id
+            .get_by_left(&BufferLocation::Local(path.to_path_buf()))
+            .cloned()
+        {
+            let path_clone = path.to_path_buf();
             ctx.spawn(
                 async move { FileModel::read_content_for_file(&path_clone).await },
                 move |me, content, ctx| match content {
@@ -556,7 +753,7 @@ impl GlobalBufferModel {
         let old_state = self.buffers.remove(&old_file_id)?;
         let buffer = old_state.buffer.upgrade(ctx)?;
 
-        self.path_to_id.remove_by_right(&old_file_id);
+        self.location_to_id.remove_by_right(&old_file_id);
 
         // Cancel + unsubscribe old FileId from FileModel.
         let file_model = FileModel::handle(ctx);
@@ -565,7 +762,7 @@ impl GlobalBufferModel {
             file_model.unsubscribe(old_file_id, ctx);
         });
 
-        Some(self.register_buffer_for_path(new_path, buffer, old_state.base_content_version, ctx))
+        Some(self.register_buffer_for_path(new_path, buffer, old_state.base_content_version(), ctx))
     }
 
     /// Adopt an existing buffer under a new path without reading from disk.
@@ -593,7 +790,11 @@ impl GlobalBufferModel {
     ) -> BufferState {
         // If a buffer is already registered for this path, clean up the old entry
         // to avoid orphaning the previous FileId in `self.buffers`.
-        if let Some(old_file_id) = self.path_to_id.get_by_left(&path).copied() {
+        if let Some(old_file_id) = self
+            .location_to_id
+            .get_by_left(&BufferLocation::Local(path.clone()))
+            .copied()
+        {
             self.cleanup_file_id(old_file_id, ctx);
         }
 
@@ -604,39 +805,64 @@ impl GlobalBufferModel {
             id
         });
 
-        self.path_to_id.insert(path.clone(), file_id);
+        self.location_to_id
+            .insert(BufferLocation::Local(path.clone()), file_id);
         self.buffers.insert(
             file_id,
             InternalBufferState {
                 buffer: buffer.downgrade(),
-                base_content_version,
                 pending_diff_parse: None,
+                source: BufferSource::Local {
+                    base_content_version,
+                },
             },
         );
 
         BufferState::new(file_id, buffer)
     }
 
-    /// Open a buffer for the given file path.
+    /// Open a buffer at the given location.
+    ///
+    /// Dispatches to the appropriate private opener based on the location variant.
+    /// If a buffer already exists for this location and is loaded, returns the
+    /// existing `BufferState`.
+    pub fn open(&mut self, location: BufferLocation, ctx: &mut ModelContext<Self>) -> BufferState {
+        match location {
+            #[cfg(feature = "local_fs")]
+            BufferLocation::Local(path) => self.open_local(path, false, ctx),
+            #[cfg(not(feature = "local_fs"))]
+            BufferLocation::Local(_) => {
+                unimplemented!("Local buffers require the local_fs feature")
+            }
+            BufferLocation::Remote(remote_path) => self.open_remote_buffer(remote_path, ctx),
+        }
+    }
+
+    /// Open a local buffer for the given file path.
     ///
     /// If a buffer already exists for this path and is loaded, returns the existing BufferState.
     /// If no buffer exists, creates a new Buffer and BufferState using FileModel.
     /// File system updates are automatically subscribed to for all buffers.
     ///
-    /// # Arguments
-    /// * `path` - The file path to open
-    /// * `ctx` - The model context for creating new buffers if needed
-    ///
-    /// # Returns
-    /// Returns the BufferState for the requested file path.
+    /// When `is_server_local` is true, the buffer is created with a `ServerLocal`
+    /// source (with a `SyncClock`) instead of a plain `Local` source.
     #[cfg(feature = "local_fs")]
-    pub fn open(&mut self, path: PathBuf, ctx: &mut ModelContext<Self>) -> BufferState {
-        if let Some(id) = self.path_to_id.get_by_left(&path).cloned() {
+    fn open_local(
+        &mut self,
+        path: PathBuf,
+        is_server_local: bool,
+        ctx: &mut ModelContext<Self>,
+    ) -> BufferState {
+        if let Some(id) = self
+            .location_to_id
+            .get_by_left(&BufferLocation::Local(path.clone()))
+            .cloned()
+        {
             debug_assert!(self.buffers.contains_key(&id));
             if let Some(state) = self.buffers.get(&id) {
                 if let Some(handle) = state.buffer.upgrade(ctx) {
                     // Only emit buffer loaded if the base content version is set.
-                    if state.base_content_version.is_some() {
+                    if state.is_loaded() {
                         ctx.emit(GlobalBufferModelEvent::BufferLoaded {
                             file_id: id,
                             content_version: handle.as_ref(ctx).version(),
@@ -647,11 +873,16 @@ impl GlobalBufferModel {
             }
         }
 
-        self.create_new_buffer(&path, ctx)
+        self.create_new_buffer(&path, is_server_local, ctx)
     }
 
     #[cfg(feature = "local_fs")]
-    fn create_new_buffer(&mut self, path: &Path, ctx: &mut ModelContext<Self>) -> BufferState {
+    fn create_new_buffer(
+        &mut self,
+        path: &Path,
+        is_server_local: bool,
+        ctx: &mut ModelContext<Self>,
+    ) -> BufferState {
         // Open file through FileModel to get FileId
         // Always subscribe to updates for GlobalBufferModel created buffers
         let file_id =
@@ -666,13 +897,24 @@ impl GlobalBufferModel {
             }))
         });
 
-        self.path_to_id.insert(path.to_path_buf(), file_id);
+        self.location_to_id
+            .insert(BufferLocation::Local(path.to_path_buf()), file_id);
+        let source = if is_server_local {
+            BufferSource::ServerLocal {
+                sync_clock: SyncClock::new(),
+                base_content_version: None,
+            }
+        } else {
+            BufferSource::Local {
+                base_content_version: None,
+            }
+        };
         self.buffers.insert(
             file_id,
             InternalBufferState {
                 buffer: buffer.downgrade(),
-                base_content_version: None,
                 pending_diff_parse: None,
+                source,
             },
         );
 
@@ -703,7 +945,9 @@ impl GlobalBufferModel {
             return Some(Vec::new());
         }
 
-        let file_id = self.path_to_id.get_by_left(path)?;
+        let file_id = self
+            .location_to_id
+            .get_by_left(&BufferLocation::Local(path.to_path_buf()))?;
         let buffer = self.buffer_handle_for_id(*file_id, ctx)?;
 
         let buffer_ref = buffer.as_ref(ctx);
@@ -723,6 +967,470 @@ impl GlobalBufferModel {
         }
 
         Some(lines)
+    }
+
+    // ── Remote buffer operations (client side) ────────────────────────
+
+    /// Open a remote buffer identified by a `RemotePath`.
+    ///
+    /// Sends `OpenBuffer` to the remote server, creates a local `Buffer` model,
+    /// and sets up bidirectional sync via `BufferEvent` → `BufferEdit`.
+    ///
+    /// Returns a `BufferState` immediately (buffer content is populated asynchronously).
+    #[cfg_attr(not(feature = "local_tty"), allow(unused_variables, unused_mut))]
+    fn open_remote_buffer(
+        &mut self,
+        remote_path: super::buffer_location::RemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> BufferState {
+        let location = BufferLocation::Remote(remote_path.clone());
+
+        // Return existing buffer if already open.
+        if let Some(id) = self.location_to_id.get_by_left(&location).cloned() {
+            if let Some(state) = self.buffers.get(&id) {
+                if let Some(handle) = state.buffer.upgrade(ctx) {
+                    if state.is_loaded() {
+                        ctx.emit(GlobalBufferModelEvent::BufferLoaded {
+                            file_id: id,
+                            content_version: handle.as_ref(ctx).version(),
+                        });
+                    }
+                    return BufferState::new(id, handle.clone());
+                }
+            }
+        }
+
+        let file_id = FileId::new();
+        let buffer = ctx.add_model(|_| Buffer::default());
+
+        // Store state with sync_clock = None (set to Some on OpenBufferResponse).
+        self.location_to_id.insert(location, file_id);
+        self.buffers.insert(
+            file_id,
+            InternalBufferState {
+                buffer: buffer.downgrade(),
+                pending_diff_parse: None,
+                source: BufferSource::Remote {
+                    remote_path: remote_path.clone(),
+                    sync_clock: None,
+                },
+            },
+        );
+
+        #[cfg(feature = "local_tty")]
+        {
+            use warp_editor::content::buffer::BufferEvent;
+
+            // Extract fields before moving remote_path into the buffer source.
+            let path_str = remote_path.path.as_str().to_string();
+            let host_id = remote_path.host_id.clone();
+
+            // Subscribe to buffer content changes so edits are sent back to the daemon.
+            let client_for_sub = {
+                let manager = remote_server::manager::RemoteServerManager::handle(ctx);
+                manager.as_ref(ctx).client_for_host(&host_id).cloned()
+            };
+            if let Some(client) = client_for_sub {
+                let path_for_edit = path_str.clone();
+                ctx.subscribe_to_model(&buffer, move |me, event, ctx| {
+                    if let BufferEvent::ContentChanged { delta, origin, .. } = event {
+                        // Skip server-originated changes to prevent echo loop.
+                        // Server pushes applied via insert_at_char_offset_ranges
+                        // emit ContentChanged with SystemEdit origin.
+                        if !origin.from_user() {
+                            return;
+                        }
+
+                        // Look up the sync clock to get the expected server version
+                        // and bump the client version.
+                        let Some(state) = me.buffers.get_mut(&file_id) else {
+                            return;
+                        };
+                        let BufferSource::Remote { sync_clock, .. } = &mut state.source else {
+                            return;
+                        };
+                        let Some(sync_clock) = sync_clock.as_mut() else {
+                            return;
+                        };
+                        let expected_sv = sync_clock.server_version.as_u64();
+                        let new_cv = ContentVersion::new();
+                        sync_clock.client_version = new_cv;
+
+                        // Build incremental edits from the ContentChanged delta.
+                        let Some(buffer) = state.buffer.upgrade(ctx) else {
+                            return;
+                        };
+                        let edits: Vec<remote_server::proto::TextEdit> = delta
+                            .precise_deltas
+                            .iter()
+                            .map(|d| {
+                                // Wire offsets are 1-indexed (matching CharOffset).
+                                let text = buffer
+                                    .as_ref(ctx)
+                                    .text_in_range(d.resolved_range.clone())
+                                    .into_string();
+                                remote_server::proto::TextEdit {
+                                    start_offset: d.replaced_range.start.as_usize() as u64,
+                                    end_offset: d.replaced_range.end.as_usize() as u64,
+                                    text,
+                                }
+                            })
+                            .collect();
+                        client.send_buffer_edit(
+                            path_for_edit.clone(),
+                            expected_sv,
+                            new_cv.as_u64(),
+                            edits,
+                        );
+                    }
+                });
+            }
+
+            // Look up the client on the main thread, then send OpenBuffer asynchronously.
+            let manager = remote_server::manager::RemoteServerManager::handle(ctx);
+            let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
+                log::warn!("No remote server client for host {host_id:?}");
+                ctx.emit(GlobalBufferModelEvent::FailedToLoad {
+                    file_id,
+                    error: Rc::new(FileLoadError::DoesNotExist),
+                });
+                return BufferState::new(file_id, buffer);
+            };
+
+            ctx.spawn(
+                async move {
+                    client
+                        .open_buffer(path_str)
+                        .await
+                        .map_err(|e| format!("{e}"))
+                },
+                move |me, result, ctx| match result {
+                    Ok(response) => {
+                        let Some(state) = me.buffers.get_mut(&file_id) else {
+                            return;
+                        };
+                        if let BufferSource::Remote { sync_clock, .. } = &mut state.source {
+                            *sync_clock = Some(SyncClock::from_wire(response.server_version, 0));
+                        }
+                        let Some(buffer) = state.buffer.upgrade(ctx) else {
+                            return;
+                        };
+                        let version = ContentVersion::new();
+                        buffer.update(ctx, |buffer, ctx| {
+                            buffer.replace_all(&response.content, ctx);
+                            buffer.set_version(version);
+                        });
+                        ctx.emit(GlobalBufferModelEvent::BufferLoaded {
+                            file_id,
+                            content_version: version,
+                        });
+                    }
+                    Err(error) => {
+                        log::warn!("Failed to open remote buffer: {error}");
+                        ctx.emit(GlobalBufferModelEvent::FailedToLoad {
+                            file_id,
+                            error: Rc::new(FileLoadError::DoesNotExist),
+                        });
+                    }
+                },
+            );
+        }
+
+        BufferState::new(file_id, buffer)
+    }
+
+    /// Handle an incoming `BufferUpdatedPush` from the remote server.
+    ///
+    /// Accepts incremental edits (1-indexed char offsets matching `CharOffset`)
+    /// and applies them to the local buffer via `insert_at_char_offset_ranges`.
+    /// If the expected client version doesn't match, a conflict event is emitted.
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    pub fn handle_buffer_updated_push(
+        &mut self,
+        host_id: &warp_core::HostId,
+        path: &str,
+        new_server_version: u64,
+        expected_client_version: u64,
+        edits: &[CharOffsetEdit],
+        ctx: &mut ModelContext<Self>,
+    ) {
+        // Find the buffer by scanning for a Remote source with matching host+path.
+        let file_id = self.buffers.iter().find_map(|(id, state)| {
+            if let BufferSource::Remote { remote_path, .. } = &state.source {
+                if remote_path.host_id == *host_id && remote_path.path.as_str() == path {
+                    return Some(*id);
+                }
+            }
+            None
+        });
+
+        let Some(file_id) = file_id else {
+            log::warn!("BufferUpdatedPush for unknown remote buffer: {path}");
+            return;
+        };
+
+        let Some(state) = self.buffers.get_mut(&file_id) else {
+            return;
+        };
+
+        let BufferSource::Remote { sync_clock, .. } = &mut state.source else {
+            return;
+        };
+        let Some(sync_clock) = sync_clock.as_mut() else {
+            return;
+        };
+
+        let expected_cv = ContentVersion::from_raw(expected_client_version as usize);
+        if sync_clock.server_push_matches(expected_cv) {
+            // Accept the update — apply edits incrementally.
+            sync_clock.server_version = ContentVersion::from_raw(new_server_version as usize);
+
+            let Some(buffer) = state.buffer.upgrade(ctx) else {
+                return;
+            };
+
+            let new_version = ContentVersion::new();
+            buffer.update(ctx, |buffer, ctx| {
+                let max_offset = buffer.max_charoffset();
+                let char_edits: Vec<(std::ops::Range<CharOffset>, String)> = edits
+                    .iter()
+                    .map(|edit| {
+                        let start = std::cmp::min(edit.start, max_offset);
+                        let end = std::cmp::min(edit.end, max_offset);
+                        (start..end, edit.text.clone())
+                    })
+                    .collect();
+
+                buffer.insert_at_char_offset_ranges(char_edits, new_version, ctx);
+            });
+        } else {
+            // Conflict — local edits diverged from server.
+            log::info!(
+                "Remote buffer conflict for {path}: expected C={expected_client_version}, \
+                 local C={:?}",
+                sync_clock.client_version
+            );
+            ctx.emit(GlobalBufferModelEvent::RemoteBufferConflict { file_id });
+        }
+    }
+
+    // ── Server-local buffer operations (daemon side) ────────────────
+
+    /// Open a server-local buffer for the given file path on the daemon.
+    ///
+    /// Delegates to `open_local` with `is_server_local = true` so the buffer
+    /// is created directly with a `ServerLocal` source and `SyncClock`.
+    #[cfg(feature = "local_fs")]
+    pub fn open_server_local(
+        &mut self,
+        path: PathBuf,
+        ctx: &mut ModelContext<Self>,
+    ) -> BufferState {
+        self.open_local(path, true, ctx)
+    }
+
+    /// Apply a client edit to a server-local buffer.
+    ///
+    /// If `expected_server_version` matches the buffer's current server version,
+    /// the edits are applied to the in-memory buffer (no disk write) and the
+    /// client version is updated. Returns `true` if accepted, `false` if rejected
+    /// (stale edit — silently discarded).
+    #[cfg(feature = "local_fs")]
+    pub fn apply_client_edit(
+        &mut self,
+        file_id: FileId,
+        edits: &[remote_server::proto::TextEdit],
+        expected_server_version: ContentVersion,
+        new_client_version: ContentVersion,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let Some(state) = self.buffers.get_mut(&file_id) else {
+            return false;
+        };
+
+        let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source else {
+            return false;
+        };
+
+        if !sync_clock.client_edit_matches(expected_server_version) {
+            log::info!(
+                "Rejected client edit: expected S={:?}, actual S={:?}",
+                expected_server_version,
+                sync_clock.server_version
+            );
+            return false;
+        }
+
+        sync_clock.client_version = new_client_version;
+
+        let Some(buffer) = state.buffer.upgrade(ctx) else {
+            return false;
+        };
+
+        // Wire offsets are 1-indexed (matching CharOffset), so no conversion needed.
+        let new_version = ContentVersion::new();
+        buffer.update(ctx, |buffer, ctx| {
+            let max_offset = buffer.max_charoffset();
+            let char_edits: Vec<(std::ops::Range<CharOffset>, String)> = edits
+                .iter()
+                .map(|edit| {
+                    let start =
+                        CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
+                    let end =
+                        CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
+                    (start..end, edit.text.clone())
+                })
+                .collect();
+
+            buffer.insert_at_char_offset_ranges(char_edits, new_version, ctx);
+        });
+
+        true
+    }
+
+    /// Save a server-local buffer to disk.
+    #[cfg(feature = "local_fs")]
+    pub fn save_server_local(
+        &mut self,
+        file_id: FileId,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(), FileSaveError> {
+        let Some(state) = self.buffers.get(&file_id) else {
+            return Err(FileSaveError::RemoteError("Buffer not found".to_string()));
+        };
+        let Some(buffer) = state.buffer.upgrade(ctx) else {
+            return Err(FileSaveError::RemoteError("Buffer deallocated".to_string()));
+        };
+        let content = buffer.as_ref(ctx).text().into_string();
+        let version = ContentVersion::new();
+        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
+            file_model.save(file_id, content, version, ctx)
+        })
+    }
+
+    /// Resolve a conflict by accepting the client's content.
+    /// Replaces the buffer content, updates the sync clock, and saves to disk.
+    #[cfg(feature = "local_fs")]
+    pub fn resolve_conflict(
+        &mut self,
+        file_id: FileId,
+        acknowledged_server_version: ContentVersion,
+        current_client_version: ContentVersion,
+        client_content: &str,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(), FileSaveError> {
+        let Some(state) = self.buffers.get_mut(&file_id) else {
+            return Err(FileSaveError::RemoteError("Buffer not found".to_string()));
+        };
+
+        if let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source {
+            sync_clock.server_version = acknowledged_server_version;
+            sync_clock.client_version = current_client_version;
+        }
+
+        let Some(buffer) = state.buffer.upgrade(ctx) else {
+            return Err(FileSaveError::RemoteError("Buffer deallocated".to_string()));
+        };
+
+        let new_version = ContentVersion::new();
+        buffer.update(ctx, |buffer, ctx| {
+            buffer.replace_all(client_content, ctx);
+            buffer.set_version(new_version);
+        });
+
+        // Save to disk. Note: the buffer content has already been replaced
+        // in memory above. If the save fails, memory and disk will diverge.
+        let content = client_content.to_string();
+        let save_version = ContentVersion::new();
+        state.set_base_content_version(save_version);
+        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
+            file_model.save(file_id, content, save_version, ctx)
+        })
+    }
+
+    // ── Public accessors ──────────────────────────────────────────────
+
+    /// Returns the buffer text content for a given `FileId`.
+    pub fn content_for_file(&self, file_id: FileId, ctx: &warpui::AppContext) -> Option<String> {
+        let state = self.buffers.get(&file_id)?;
+        let buffer = state.buffer.upgrade(ctx)?;
+        Some(buffer.as_ref(ctx).text().into_string())
+    }
+
+    /// Returns a reference to the `SyncClock` for a server-local buffer.
+    pub fn sync_clock_for_server_local(&self, file_id: FileId) -> Option<&SyncClock> {
+        let state = self.buffers.get(&file_id)?;
+        match &state.source {
+            BufferSource::ServerLocal { sync_clock, .. } => Some(sync_clock),
+            BufferSource::Local { .. } | BufferSource::Remote { .. } => None,
+        }
+    }
+
+    /// Returns whether a buffer is a `ServerLocal` source.
+    #[cfg(test)]
+    pub fn is_server_local(&self, file_id: FileId) -> bool {
+        self.buffers
+            .get(&file_id)
+            .is_some_and(|state| matches!(state.source, BufferSource::ServerLocal { .. }))
+    }
+
+    /// 该 buffer 是否是客户端 `Remote` buffer(远端 SSH 文件)。
+    ///
+    /// 编辑器保存时用它判断:远端文件不能走本地 `FileModel`(无本地路径,
+    /// 会得到 `NoFilePath`),必须走 buffer-sync 的 `SaveBuffer` 协议。
+    #[cfg(feature = "local_tty")]
+    pub fn is_remote(&self, file_id: FileId) -> bool {
+        self.buffers
+            .get(&file_id)
+            .is_some_and(|state| matches!(state.source, BufferSource::Remote { .. }))
+    }
+
+    /// 客户端:把远端 buffer 的当前内容持久化到 daemon 端磁盘。
+    ///
+    /// daemon 的内存 buffer 已经通过 `BufferEdit`(见 `open_remote_buffer` 里对
+    /// `ContentChanged` 的订阅)实时同步过用户编辑,这里只需发一个 `SaveBuffer`
+    /// 触发 daemon 落盘。请求成功后 emit `FileSaved`,让编辑器/标签更新已保存状态。
+    #[cfg(feature = "local_tty")]
+    pub fn save_remote_buffer(&self, file_id: FileId, ctx: &mut ModelContext<Self>) {
+        let Some(BufferLocation::Remote(remote_path)) =
+            self.location_to_id.get_by_right(&file_id).cloned()
+        else {
+            log::warn!("save_remote_buffer: file_id {file_id:?} 不是 Remote buffer");
+            return;
+        };
+        let host_id = remote_path.host_id.clone();
+        let path_str = remote_path.path.as_str().to_string();
+
+        let manager = remote_server::manager::RemoteServerManager::handle(ctx);
+        let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
+            log::warn!("save_remote_buffer: host {host_id:?} 无 remote server client");
+            return;
+        };
+
+        ctx.spawn(
+            async move {
+                client
+                    .save_buffer(path_str)
+                    .await
+                    .map_err(|e| format!("{e}"))
+            },
+            move |_me, result, ctx| match result {
+                Ok(response) => {
+                    use remote_server::proto::save_buffer_response::Result as SaveResult;
+                    match response.result {
+                        Some(SaveResult::Success(_)) | None => {
+                            ctx.emit(GlobalBufferModelEvent::FileSaved { file_id });
+                        }
+                        Some(SaveResult::Error(err)) => {
+                            log::warn!("远端保存失败: {}", err.message);
+                        }
+                    }
+                }
+                Err(error) => {
+                    log::warn!("save_remote_buffer: SaveBuffer 请求失败: {error}");
+                }
+            },
+        );
     }
 }
 

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -136,6 +136,13 @@ pub enum LocalCodeEditorEvent {
 enum LoadedFileMetadata {
     /// Normal file with both FileId and path (for files that are actually opened)
     LocalFile { id: FileId, path: PathBuf },
+    /// 远端 buffer:文件位于 SSH 主机上,通过 buffer-sync 协议同步,
+    /// 本地没有对应路径。
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    RemoteFile {
+        id: FileId,
+        remote_path: crate::code::buffer_location::RemotePath,
+    },
 }
 
 pub use super::diff_viewer::DisplayMode;
@@ -276,6 +283,21 @@ impl LocalCodeEditorView {
     fn perform_save(&mut self, file_id: FileId, ctx: &mut ViewContext<Self>) {
         self.base_content_version = Some(self.editor.as_ref(ctx).version(ctx));
 
+        // 远端 SSH 文件:走 buffer-sync 的 `SaveBuffer` 协议落盘。不能用下面的本地
+        // `FileModel` 路径 —— Remote buffer 没有本地路径,会得到 `NoFilePath`。
+        // 用户的编辑已通过 `BufferEdit` 实时同步到 daemon,这里只触发 daemon 落盘。
+        #[cfg(feature = "local_tty")]
+        {
+            let is_remote = GlobalBufferModel::handle(ctx)
+                .as_ref(ctx)
+                .is_remote(file_id);
+            if is_remote {
+                GlobalBufferModel::handle(ctx)
+                    .update(ctx, |model, ctx| model.save_remote_buffer(file_id, ctx));
+                return;
+            }
+        }
+
         let result = match self.diff() {
             Some(DiffType::Update {
                 rename: Some(new_path),
@@ -360,8 +382,12 @@ impl LocalCodeEditorView {
     where
         T: FnOnce(BufferState, &mut ViewContext<Self>) -> ViewHandle<CodeEditorView>,
     {
-        let buffer_state = GlobalBufferModel::handle(ctx)
-            .update(ctx, |model, ctx| model.open(path.to_path_buf(), ctx));
+        let buffer_state = GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
+            model.open(
+                crate::code::buffer_location::BufferLocation::Local(path.to_path_buf()),
+                ctx,
+            )
+        });
         let file_id = buffer_state.file_id;
         let editor = editor_constructor(buffer_state, ctx);
 
@@ -379,6 +405,52 @@ impl LocalCodeEditorView {
         local_editor.metadata = Some(LoadedFileMetadata::LocalFile {
             id: file_id,
             path: path.to_path_buf(),
+        });
+
+        Self::subscribe_to_global_buffer_events(file_id, ctx);
+
+        local_editor
+    }
+
+    /// 构造一个绑定到远端 buffer 的编辑器视图。
+    ///
+    /// 通过 [`GlobalBufferModel::open`] 以 [`BufferLocation::Remote`] 打开远端文件,
+    /// 内容由 buffer-sync 协议异步填充。语言识别复用远端路径的后缀。
+    #[cfg(feature = "local_tty")]
+    pub fn new_with_remote_buffer<T>(
+        remote_path: crate::code::buffer_location::RemotePath,
+        editor_constructor: T,
+        enable_diff_nav_by_default: bool,
+        display_mode: Option<DisplayMode>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self
+    where
+        T: FnOnce(BufferState, &mut ViewContext<Self>) -> ViewHandle<CodeEditorView>,
+    {
+        // 远端路径用于语言识别(后缀)。
+        let language_path = std::path::PathBuf::from(remote_path.path.as_str());
+        let buffer_state = GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
+            model.open(
+                crate::code::buffer_location::BufferLocation::Remote(remote_path.clone()),
+                ctx,
+            )
+        });
+        let file_id = buffer_state.file_id;
+        let editor = editor_constructor(buffer_state, ctx);
+
+        editor.update(ctx, |editor, ctx| {
+            editor.set_language_with_path(&language_path, ctx);
+            editor.model.update(ctx, |model, ctx| {
+                model.rebuild_layout_with_syntax_highlighting(ctx)
+            });
+        });
+
+        let mut local_editor =
+            Self::new(editor, None, enable_diff_nav_by_default, display_mode, ctx);
+
+        local_editor.metadata = Some(LoadedFileMetadata::RemoteFile {
+            id: file_id,
+            remote_path,
         });
 
         Self::subscribe_to_global_buffer_events(file_id, ctx);
@@ -516,6 +588,10 @@ impl LocalCodeEditorView {
                         error: error.clone(),
                     });
                 }
+                // 远端 buffer 同步事件由 GlobalBufferModel / ServerModel 内部消费,
+                // 本地编辑器视图不关心。
+                GlobalBufferModelEvent::RemoteBufferConflict { .. }
+                | GlobalBufferModelEvent::ServerLocalBufferUpdated { .. } => {}
             }
         });
     }
@@ -645,14 +721,17 @@ impl LocalCodeEditorView {
 
     pub fn file_id(&self) -> Option<FileId> {
         self.metadata.as_ref().map(|metadata| match metadata {
-            LoadedFileMetadata::LocalFile { id, .. } => *id,
+            LoadedFileMetadata::LocalFile { id, .. }
+            | LoadedFileMetadata::RemoteFile { id, .. } => *id,
         })
     }
 
     pub fn file_path(&self) -> Option<&Path> {
-        self.metadata.as_ref().map(|metadata| match metadata {
-            LoadedFileMetadata::LocalFile { path, .. } => path.as_path(),
-        })
+        match self.metadata.as_ref()? {
+            LoadedFileMetadata::LocalFile { path, .. } => Some(path.as_path()),
+            // 远端文件没有本地路径。
+            LoadedFileMetadata::RemoteFile { .. } => None,
+        }
     }
 
     /// Update this editor's file identity after a `GlobalBufferModel::rename`.

--- a/app/src/code/mod.rs
+++ b/app/src/code/mod.rs
@@ -6,6 +6,7 @@ use warp_util::file::FileSaveError;
 use warpui::elements::DropTargetData;
 use warpui::AppContext;
 
+pub mod buffer_location;
 pub mod diff_viewer;
 pub mod editor;
 pub mod editor_management;

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -451,6 +451,14 @@ impl CodeView {
                     editor.with_selection_as_context(Box::new(get_context_target_terminal_view));
             }
 
+            // 远端 buffer 创建时内容为空,初始内容经 buffer-sync 协议异步到达。
+            // 加载窗口内若可编辑,用户输入会被 OpenBufferResponse 的 replace_all()
+            // 覆盖丢失 —— 先锁为 Selectable(可滚动/选择但不可编辑),待
+            // `FileLoaded` 到达后再恢复 Editable。
+            editor.editor().update(ctx, |code_editor, ctx| {
+                code_editor.set_interaction_state(InteractionState::Selectable, ctx);
+            });
+
             // 与本地 shared-buffer 编辑器一致:补上 footer / 保存冲突 UI。
             editor.add_footer(ctx);
             editor
@@ -547,6 +555,17 @@ impl CodeView {
         }
         ctx.subscribe_to_view(&code_editor, |me, emitter, event, ctx| match event {
             LocalCodeEditorEvent::FileLoaded => {
+                // 远端 buffer 初始内容到达后,解除加载期施加的编辑锁。
+                // 本地文件创建时即可编辑,从不被锁,这里也就是 no-op。
+                if let Some(tab) = me.tab_group.iter().find(|tab| tab.editor_view == emitter) {
+                    if matches!(tab.location, Some(BufferLocation::Remote(_))) {
+                        emitter.update(ctx, |local_editor, ctx| {
+                            local_editor.editor().update(ctx, |code_editor, ctx| {
+                                code_editor.set_interaction_state(InteractionState::Editable, ctx);
+                            });
+                        });
+                    }
+                }
                 me.pane_configuration.update(ctx, |pane_config, ctx| {
                     pane_config.refresh_pane_header_overflow_menu_items(ctx);
                 });

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -450,6 +450,9 @@ impl CodeView {
                 editor =
                     editor.with_selection_as_context(Box::new(get_context_target_terminal_view));
             }
+
+            // 与本地 shared-buffer 编辑器一致:补上 footer / 保存冲突 UI。
+            editor.add_footer(ctx);
             editor
         })
     }
@@ -845,13 +848,15 @@ impl CodeView {
 
     /// Set the title of the pane, which is the file path.
     fn set_title(&self, _unsaved_changes: bool, ctx: &mut ViewContext<Self>) {
-        let file = self.local_path(ctx);
-        let is_new = self
-            .tab_at(self.active_tab_index)
-            .is_some_and(|t| t.editor_view.as_ref(ctx).is_new_file());
+        let active_tab = self.tab_at(self.active_tab_index);
+        let is_new = active_tab.is_some_and(|t| t.editor_view.as_ref(ctx).is_new_file());
 
-        let title = if let Some(file) = file {
+        // 标题优先用本地路径(完整路径),远端文件无本地路径时回退到
+        // `location` 派生的显示名,避免远端 tab 显示成 "Untitled"。
+        let title = if let Some(file) = self.local_path(ctx) {
             file.display().to_string()
+        } else if let Some(name) = active_tab.map(|t| t.display_name()) {
+            name
         } else {
             "Untitled".to_string()
         };
@@ -1155,11 +1160,8 @@ impl CodeView {
         ctx: &mut ViewContext<Self>,
     ) {
         if let Some(tab) = self.tab_at(index) {
-            let file_name = tab
-                .path
-                .as_ref()
-                .and_then(|p| p.file_name())
-                .map(|name| name.to_string_lossy().to_string());
+            // 用 `location` 派生文件名:远端文件没有本地 `path`,否则会丢失文件名。
+            let file_name = tab.location().map(|loc| loc.display_name());
             let summary = UnsavedStateSummary::for_editor_tab(
                 file_name,
                 vec![CodeEditorStatus::new(Self::has_unsaved_changes(tab, ctx))],
@@ -2063,8 +2065,9 @@ impl CodeView {
 
                     to_extend.push(new_data);
                     // If the newly added tab is the active tab in the source CodeView, update the active tab index to point to it.
+                    // `existing_locations_to_idx` 漏算了无 location 的 tab,需用 tab_group 长度。
                     if i == source_code_view.active_tab_index() {
-                        active_tab_index = existing_locations_to_idx.len() + to_extend.len() - 1;
+                        active_tab_index = self.tab_group.len() + to_extend.len() - 1;
                     }
                 }
             }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -542,7 +542,7 @@ impl CodeView {
                 editor.set_interaction_state(InteractionState::Selectable, ctx);
             });
         }
-        ctx.subscribe_to_view(&code_editor, |me, _, event, ctx| match event {
+        ctx.subscribe_to_view(&code_editor, |me, emitter, event, ctx| match event {
             LocalCodeEditorEvent::FileLoaded => {
                 me.pane_configuration.update(ctx, |pane_config, ctx| {
                     pane_config.refresh_pane_header_overflow_menu_items(ctx);
@@ -561,6 +561,18 @@ impl CodeView {
                 }
                 log::warn!("Failed to load file. {err:?}");
                 CodeView::display_load_failure(ctx.window_id(), ctx);
+                // 加载失败后,关闭这个出错的文件 tab —— 避免留下一个无法加载的空 pane/tab。
+                // 通过事件发出者(LocalCodeEditorView 句柄)定位是哪个 tab 失败,
+                // 复用用户手动关闭 tab 的路径 `remove_tab_data_index`:
+                // 若失败的是 tab 组里的多个之一,只移除该 tab;若是唯一的 tab,
+                // `update_tab_bar_state` 会在 tab 组清空后发出 `PaneEvent::Close` 关闭整个 pane。
+                if let Some(failed_index) = me
+                    .tab_group
+                    .iter()
+                    .position(|tab| tab.editor_view == emitter)
+                {
+                    me.remove_tab_data_index(failed_index, ctx);
+                }
             }
             LocalCodeEditorEvent::SelectionAddedAsContext {
                 relative_file_path,

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -70,6 +70,7 @@ use crate::pane_group::{
 };
 
 use super::{
+    buffer_location::BufferLocation,
     diff_viewer::DiffViewer,
     editor::view::{CodeEditorEvent, CodeEditorView},
     editor_management::{CodeManager, CodeSource},
@@ -199,7 +200,12 @@ struct TabDataMouseStateHandles {
 
 #[derive(Clone)]
 pub struct TabData {
+    /// 本地文件路径。**仅本地文件**有值 —— 远端文件没有本地路径。
+    /// 仅用于显示 / repo 检测 / rename 等本地专属逻辑。
     path: Option<PathBuf>,
+    /// tab 的统一身份(本地路径或远端 `RemotePath`),用于 tab 去重 / 聚焦。
+    /// 新建文件(无 backing)为 `None`。
+    location: Option<BufferLocation>,
     editor_view: ViewHandle<LocalCodeEditorView>,
     mouse_state_handles: TabDataMouseStateHandles,
     preview: bool,
@@ -215,6 +221,19 @@ pub enum PendingSaveIntent {
 impl TabData {
     pub fn path(&self) -> Option<PathBuf> {
         self.path.clone()
+    }
+
+    /// tab 的统一身份(本地路径或远端 `RemotePath`)。
+    pub fn location(&self) -> Option<&BufferLocation> {
+        self.location.as_ref()
+    }
+
+    /// tab / header 显示用的文件名。
+    fn display_name(&self) -> String {
+        self.location
+            .as_ref()
+            .map(|loc| loc.display_name())
+            .unwrap_or_else(|| "Untitled".to_string())
     }
 }
 
@@ -251,9 +270,9 @@ impl CodeView {
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let path = source.path();
+        let location = source.location();
         let mut view = Self::new_internal(source, ctx);
-        view.open_or_focus_existing(path, line_col, ctx);
+        view.open_or_focus_existing(location, line_col, ctx);
         #[cfg(feature = "local_fs")]
         {
             view.update_markdown_mode_segmented_control(ctx);
@@ -309,7 +328,9 @@ impl CodeView {
     ) -> Self {
         let mut view = Self::new_internal(source, ctx);
         for tab_snapshot in tabs {
-            let tab_data = view.build_tab_data(tab_snapshot.path.clone(), false, ctx);
+            // 持久化恢复只可能是本地文件 —— 远端 pane 不持久化。
+            let location = tab_snapshot.path.clone().map(BufferLocation::Local);
+            let tab_data = view.build_tab_data(location, false, ctx);
             view.tab_group.push(tab_data);
         }
         let clamped_index = if view.tab_group.is_empty() {
@@ -324,17 +345,17 @@ impl CodeView {
     /// Create a new "preview" code view for when a user is exploring the file tree.
     /// There is only one preview active at a time
     pub fn new_preview(source: CodeSource, ctx: &mut ViewContext<Self>) -> Self {
-        let path = source.path();
+        let location = source.location();
         let mut view = Self::new_internal(source, ctx);
 
-        if let Some(path) = path {
-            view.open_in_preview_or_promote(path, ctx);
+        if let Some(location) = location {
+            view.open_in_preview_or_promote(location, ctx);
             #[cfg(feature = "local_fs")]
             {
                 view.update_markdown_mode_segmented_control(ctx);
             }
         } else {
-            log::warn!("Preview CodeView constructed with no path");
+            log::warn!("Preview CodeView constructed with no location");
         }
         view
     }
@@ -391,6 +412,48 @@ impl CodeView {
         })
     }
 
+    /// 构造一个绑定到远端 buffer 的编辑器视图。结构与
+    /// [`Self::construct_shared_buffer_editor_from_path`] 一致,但 buffer 经
+    /// `GlobalBufferModel` 的 `BufferLocation::Remote` 路径打开,内容由
+    /// buffer-sync 协议异步填充。
+    #[cfg(feature = "local_tty")]
+    fn construct_shared_buffer_editor_from_remote(
+        &mut self,
+        remote_path: &super::buffer_location::RemotePath,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<LocalCodeEditorView> {
+        let remote_path = remote_path.clone();
+        ctx.add_typed_action_view(|ctx| {
+            let mut editor = LocalCodeEditorView::new_with_remote_buffer(
+                remote_path,
+                |buffer_state, ctx| {
+                    ctx.add_typed_action_view(|ctx| {
+                        CodeEditorView::new(
+                            None,
+                            Some(buffer_state.buffer),
+                            CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight),
+                            ctx,
+                        )
+                        .with_horizontal_scrollbar_appearance(
+                            warpui::elements::new_scrollable::ScrollableAppearance::new(
+                                warpui::elements::ScrollbarWidth::Auto,
+                                true,
+                            ),
+                        )
+                    })
+                },
+                false,
+                None,
+                ctx,
+            );
+            if FeatureFlag::HoaCodeReview.is_enabled() {
+                editor =
+                    editor.with_selection_as_context(Box::new(get_context_target_terminal_view));
+            }
+            editor
+        })
+    }
+
     /// Construct an editor for a new (unsaved) file with no file backing.
     fn construct_new_file_editor(
         &mut self,
@@ -423,16 +486,32 @@ impl CodeView {
 
     fn build_tab_data(
         &mut self,
-        path: Option<PathBuf>,
+        location: Option<BufferLocation>,
         preview: bool,
         ctx: &mut ViewContext<Self>,
     ) -> TabData {
+        // 本地路径(仅 `Local` 变体有),用于显示 / repo 检测 / rename。
+        let path = location.as_ref().and_then(|loc| match loc {
+            BufferLocation::Local(p) => Some(p.clone()),
+            BufferLocation::Remote(_) => None,
+        });
+
         // Opt out of shared buffer if we are creating a new file.
         // TODO(kevin): Once the file is saved, we should convert that into a shared buffer.
-        let code_editor = if let Some(path) = path.as_ref() {
-            self.construct_shared_buffer_editor_from_path(path, ctx)
-        } else {
-            self.construct_new_file_editor(ctx)
+        let code_editor = match location.as_ref() {
+            Some(BufferLocation::Local(path)) => {
+                self.construct_shared_buffer_editor_from_path(path, ctx)
+            }
+            #[cfg(feature = "local_tty")]
+            Some(BufferLocation::Remote(remote_path)) => {
+                self.construct_shared_buffer_editor_from_remote(remote_path, ctx)
+            }
+            #[cfg(not(feature = "local_tty"))]
+            Some(BufferLocation::Remote(_)) => {
+                log::error!("Remote files require the local_tty feature");
+                self.construct_new_file_editor(ctx)
+            }
+            None => self.construct_new_file_editor(ctx),
         };
 
         let editor = code_editor.as_ref(ctx).editor().clone();
@@ -540,6 +619,7 @@ impl CodeView {
 
         TabData {
             path,
+            location,
             editor_view: code_editor,
             mouse_state_handles: Default::default(),
             preview,
@@ -597,14 +677,18 @@ impl CodeView {
             .find(|(_, tab)| tab.preview)
     }
 
-    /// Open a local file as a "preview" or if it's already being previewed, promote it to "open", making it
-    /// active and editable.
-    pub fn open_in_preview_or_promote(&mut self, path: PathBuf, ctx: &mut ViewContext<Self>) {
+    /// Open a file as a "preview" or if it's already being previewed, promote it to "open", making it
+    /// active and editable. `location` 统一覆盖本地与远端文件。
+    pub fn open_in_preview_or_promote(
+        &mut self,
+        location: BufferLocation,
+        ctx: &mut ViewContext<Self>,
+    ) {
         // If the file already is open, set the active tab to the existing tab and return.
         if let Some(existing_index) = self
             .tab_group
             .iter()
-            .position(|tab| tab.path == Some(path.clone()))
+            .position(|tab| tab.location.as_ref() == Some(&location))
         {
             self.set_active_tab_index(existing_index, ctx);
             self.promote_if_preview(ctx);
@@ -613,7 +697,7 @@ impl CodeView {
 
         // Find the existing preview tab (if any) and replace it with a new GlobalBuffer-backed editor
         if let Some((preview_index, _)) = self.preview_tab() {
-            let new_tab = self.build_tab_data(Some(path.clone()), true, ctx);
+            let new_tab = self.build_tab_data(Some(location.clone()), true, ctx);
             self.tab_group[preview_index] = new_tab;
 
             GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
@@ -625,25 +709,28 @@ impl CodeView {
         }
 
         // Create a new preview tab
-        let new_tab = self.build_tab_data(Some(path.clone()), true, ctx);
+        let new_tab = self.build_tab_data(Some(location.clone()), true, ctx);
 
         self.tab_group.push(new_tab);
         let active_tab_index = self.tab_group.len() - 1;
         self.set_active_tab_index(active_tab_index, ctx);
 
-        ctx.emit(CodeViewEvent::FileOpened {
-            file_path: path,
-            tab_index: self.active_tab_index,
-        });
+        // `FileOpened` 仅对本地文件有意义(repo 检测 / OpenedFilesModel)。
+        if let BufferLocation::Local(file_path) = location {
+            ctx.emit(CodeViewEvent::FileOpened {
+                file_path,
+                tab_index: self.active_tab_index,
+            });
+        }
     }
 
     pub fn open_in_preview_or_promote_and_jump(
         &mut self,
-        path: PathBuf,
+        location: BufferLocation,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.open_in_preview_or_promote(path, ctx);
+        self.open_in_preview_or_promote(location, ctx);
         if let Some(line_col) = line_col {
             self.jump_to_line_col_in_active_tab(line_col, ctx);
         }
@@ -651,12 +738,12 @@ impl CodeView {
 
     pub fn open_or_focus_existing(
         &mut self,
-        path: Option<PathBuf>,
+        location: Option<BufferLocation>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
         // If the tab already exists, focus it (and optionally jump) without re-opening from disk.
-        if let Some(existing_index) = self.focus_existing_tab_if_present(&path, ctx) {
+        if let Some(existing_index) = self.focus_existing_tab_if_present(&location, ctx) {
             self.promote_if_preview(ctx);
             if let Some(line_col) = line_col {
                 self.jump_to_line_col_in_tab(existing_index, line_col, ctx);
@@ -664,18 +751,20 @@ impl CodeView {
             return;
         }
 
-        self.open_new_tab_for_path(path, line_col, ctx);
+        self.open_new_tab_for_location(location, line_col, ctx);
     }
 
     fn focus_existing_tab_if_present(
         &mut self,
-        path: &Option<PathBuf>,
+        location: &Option<BufferLocation>,
         ctx: &mut ViewContext<Self>,
     ) -> Option<usize> {
+        // `None` location(新建文件)永不与已有 tab 去重。
+        let location = location.as_ref()?;
         let existing_index = self
             .tab_group
             .iter()
-            .position(|tab| tab.path.as_ref() == path.as_ref())?;
+            .position(|tab| tab.location.as_ref() == Some(location))?;
         self.set_active_tab_index(existing_index, ctx);
         Some(existing_index)
     }
@@ -704,21 +793,24 @@ impl CodeView {
         });
     }
 
-    fn open_new_tab_for_path(
+    fn open_new_tab_for_location(
         &mut self,
-        path: Option<PathBuf>,
+        location: Option<BufferLocation>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let new_tab = self.build_tab_data(path.clone(), false, ctx);
+        let new_tab = self.build_tab_data(location.clone(), false, ctx);
         self.tab_group.push(new_tab);
         let active_tab_index = self.tab_group.len() - 1;
 
-        if let (Some(file_path), Some(tab)) = (path, self.tab_group.get(active_tab_index)) {
-            ctx.emit(CodeViewEvent::FileOpened {
-                file_path: file_path.clone(),
-                tab_index: active_tab_index,
-            });
+        if let (Some(location), Some(tab)) = (location, self.tab_group.get(active_tab_index)) {
+            // `FileOpened` 仅对本地文件有意义(repo 检测 / OpenedFilesModel)。
+            if let BufferLocation::Local(file_path) = &location {
+                ctx.emit(CodeViewEvent::FileOpened {
+                    file_path: file_path.clone(),
+                    tab_index: active_tab_index,
+                });
+            }
 
             let scroll_position = match line_col {
                 Some(line_col) => ScrollPosition::LineAndColumn(line_col),
@@ -908,6 +1000,7 @@ impl CodeView {
                 .as_ref(ctx)
                 .file_path()
                 .map(|p| p.to_path_buf());
+            tab.location = new_path.clone().map(BufferLocation::Local);
             tab.path = new_path;
         }
     }
@@ -1110,15 +1203,22 @@ impl CodeView {
         index: usize,
         ctx: &mut ViewContext<Self>,
     ) -> Option<CodePane> {
-        self.tab_at(index).and_then(|t| t.path()).map(|path| {
-            let source = CodeSource::Link {
-                path,
-                range_start: None,
-                range_end: None,
-            };
-            self.remove_tab_data_index(index, ctx);
-            CodePane::new(source, None, ctx)
-        })
+        self.tab_at(index)
+            .and_then(|t| t.location().cloned())
+            .map(|location| {
+                let source = match location {
+                    BufferLocation::Local(path) => CodeSource::Link {
+                        path,
+                        range_start: None,
+                        range_end: None,
+                    },
+                    BufferLocation::Remote(remote_path) => {
+                        CodeSource::RemoteFileTree { remote_path }
+                    }
+                };
+                self.remove_tab_data_index(index, ctx);
+                CodePane::new(source, None, ctx)
+            })
     }
 
     fn remove_tab_with_intent(
@@ -1243,6 +1343,7 @@ impl CodeView {
         for tab in self.tab_group.iter_mut() {
             if tab.path.as_ref().is_some_and(|path| path == old_path) {
                 tab.path = Some(new_path.to_path_buf());
+                tab.location = Some(BufferLocation::Local(new_path.to_path_buf()));
                 tab.editor_view.update(ctx, |editor, ctx| {
                     let was_unsaved = editor.has_unsaved_changes(ctx);
 
@@ -1412,11 +1513,7 @@ impl CodeView {
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween);
 
-        let file_name = tab_data
-            .path
-            .as_ref()
-            .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
-            .unwrap_or_else(|| "Untitled".to_string());
+        let file_name = tab_data.display_name();
         let language_icon =
             icon_from_file_path(&file_name, appearance, ItemHighlightState::Default);
         row.add_child(
@@ -1799,9 +1896,7 @@ impl CodeView {
         let title = self
             .tab_group
             .first()
-            .and_then(|tab| tab.path.as_ref())
-            .and_then(|path| path.file_name())
-            .map(|name| name.to_string_lossy().to_string())
+            .map(|tab| tab.display_name())
             .unwrap_or_else(|| "Untitled".to_string());
 
         let appearance = Appearance::as_ref(app);
@@ -1932,19 +2027,18 @@ impl CodeView {
 
     /// Merges tabs from another `CodeView`, avoiding duplicates and updating the active tab index.
     pub fn merge_tabs(&mut self, source_code_view: &CodeView, ctx: &mut ViewContext<Self>) {
-        let existing_paths_to_idx: HashMap<String, usize> = self
+        let existing_locations_to_idx: HashMap<BufferLocation, usize> = self
             .tab_group
             .iter()
             .enumerate()
-            .filter_map(|(idx, tab)| tab.path().map(|p| (p.to_string_lossy().to_string(), idx)))
+            .filter_map(|(idx, tab)| tab.location().cloned().map(|loc| (loc, idx)))
             .collect();
         let mut active_tab_index = self.active_tab_index();
         let mut to_extend: Vec<TabData> = Vec::new();
 
         for (i, tab_data) in source_code_view.tab_group.iter().enumerate() {
-            if let Some(path) = tab_data.path() {
-                if let Some(&index) = existing_paths_to_idx.get(&path.to_string_lossy().to_string())
-                {
+            if let Some(location) = tab_data.location() {
+                if let Some(&index) = existing_locations_to_idx.get(location) {
                     // If the tab already exists in the tab group and is the active tab in the source CodeView,
                     // update the active tab index to point to it.
                     if i == source_code_view.active_tab_index() {
@@ -1958,7 +2052,7 @@ impl CodeView {
                     to_extend.push(new_data);
                     // If the newly added tab is the active tab in the source CodeView, update the active tab index to point to it.
                     if i == source_code_view.active_tab_index() {
-                        active_tab_index = existing_paths_to_idx.len() + to_extend.len() - 1;
+                        active_tab_index = existing_locations_to_idx.len() + to_extend.len() - 1;
                     }
                 }
             }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1512,7 +1512,17 @@ fn initialize_app(
     );
     #[cfg(feature = "local_fs")]
     ctx.add_singleton_model(FileModel::new);
-    ctx.add_singleton_model(GlobalBufferModel::new);
+    ctx.add_singleton_model(|ctx| {
+        let model = GlobalBufferModel::new(ctx);
+        // 客户端 app:订阅 RemoteServerManager 的 buffer push 事件。daemon 不做
+        // 这一步(daemon 不注册 RemoteServerManager),所以这段不能放进
+        // GlobalBufferModel::new。RemoteServerManager 已在前面注册过。
+        #[cfg(feature = "local_tty")]
+        if FeatureFlag::SshRemoteServer.is_enabled() {
+            GlobalBufferModel::subscribe_to_remote_server_manager(ctx);
+        }
+        model
+    });
     #[cfg(windows)]
     ctx.add_singleton_model(util::traffic_lights::windows::RendererState::new);
 
@@ -2247,6 +2257,15 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
     if ChannelState::is_release_bundle() {
         flags.extend(features::RELEASE_FLAGS);
     }
+
+    // SSH remote-server:release bundle 走 RELEASE_FLAGS 启用,但 dev 源码构建
+    // (`cargo run`)不是 release bundle,该 flag 会一直关闭 —— 于是 SSH 会话
+    // 永远退回 legacy 路径,remote-server transport 不激活,dev 模式自动构建并
+    // 上传二进制(见 ssh_transport.rs)也就没有机会触发。这里在 debug 构建里
+    // 显式开启,保证开发时能联调远端文件打开 / buffer-sync。Windows 暂不支持
+    // remote-server 二进制,与 RELEASE_FLAGS 的 cfg 保持一致排除掉。
+    #[cfg(all(debug_assertions, not(windows)))]
+    flags.insert(FeatureFlag::SshRemoteServer);
 
     // Issue #72: HTTP 代理设置页面。不走 channel 判断,所有 channel 含 warp-oss
     // 默认启用,作为企业 VPN / 公司代理场景的基本能力。

--- a/app/src/notebooks/link.rs
+++ b/app/src/notebooks/link.rs
@@ -182,6 +182,7 @@ impl NotebookLinks {
                                     &clean_path,
                                     crate::util::file::ShellPathType::PlatformNative(base_directory.to_path_buf()),
                                     Some(launch_data),
+                                    &crate::util::file::LinkValidationContext::Local,
                                 ) else {
                                     return Either::Right(future::ready(Err(ResolveError::FileNotFound)));
                                 };

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -634,6 +634,13 @@ pub enum Event {
         target: FileTarget,
         line_col: Option<LineAndColumnArg>,
     },
+    /// OpenWarp:在终端里 Ctrl/Cmd+点击远端 SSH 会话输出中的文件路径时发出,
+    /// 由 workspace 走 buffer-sync 协议在编辑器中打开远端文件。
+    #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+    OpenRemoteFileFromTerminal {
+        remote_path: crate::code::buffer_location::RemotePath,
+        line_col: Option<LineAndColumnArg>,
+    },
     /// File was renamed in the file tree
     #[cfg(feature = "local_fs")]
     FileRenamed {

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -66,13 +66,13 @@ impl PaneContent for CodePane {
 
     fn pre_attach(&self, group: &PaneGroup, ctx: &mut ViewContext<PaneGroup>) -> bool {
         let source = self.file_view(ctx).as_ref(ctx).source().clone();
-        let Some(path) = source.path() else {
+        let Some(location) = source.location() else {
             return true;
         };
         let pane_group_id = ctx.view_id();
 
         let existing_locator = CodeManager::handle(ctx).read(ctx, |manager, _ctx| {
-            manager.get_locator_for_path_in_tab(pane_group_id, path.as_path())
+            manager.get_locator_for_location_in_tab(pane_group_id, &location)
         });
 
         // If the file is already open in the same tab, don't restore it, just focus it (and jump).
@@ -83,7 +83,7 @@ impl PaneContent for CodePane {
                     _ => None,
                 };
                 code_pane.file_view(ctx).update(ctx, |code_view, ctx| {
-                    code_view.open_or_focus_existing(Some(path.clone()), line_col, ctx);
+                    code_view.open_or_focus_existing(Some(location.clone()), line_col, ctx);
                 });
             }
 
@@ -93,16 +93,16 @@ impl PaneContent for CodePane {
             return false;
         }
 
-        #[cfg(feature = "local_fs")]
+        #[cfg(any(feature = "local_fs", feature = "local_tty"))]
         self.file_view(ctx).update(ctx, |code_view, ctx| {
-            if let Some(path) = source.path() {
-                let line_col = match &source {
-                    CodeSource::Link { range_start, .. } => *range_start,
-                    _ => None,
-                };
-                code_view.open_or_focus_existing(Some(path), line_col, ctx);
-            }
+            let line_col = match &source {
+                CodeSource::Link { range_start, .. } => *range_start,
+                _ => None,
+            };
+            code_view.open_or_focus_existing(Some(location), line_col, ctx);
         });
+        #[cfg(not(any(feature = "local_fs", feature = "local_tty")))]
+        let _ = location;
 
         true
     }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -753,6 +753,17 @@ fn handle_terminal_view_event(
                     line_col: *line_col,
                 });
             }
+            // OpenWarp:把终端发出的"打开远端文件"事件透传给 pane_group → workspace。
+            #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+            Event::OpenRemoteFileFromTerminal {
+                remote_path,
+                line_col,
+            } => {
+                ctx.emit(pane_group::Event::OpenRemoteFileFromTerminal {
+                    remote_path: remote_path.clone(),
+                    line_col: *line_col,
+                });
+            }
             Event::CopyFileToRemote { command, upload_id } => {
                 let new_pane_id = group.insert_terminal_pane(
                     Direction::Right,

--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -5,6 +5,8 @@ pub use remote_server::*;
 #[cfg(not(target_family = "wasm"))]
 pub mod auth_context;
 #[cfg(not(target_family = "wasm"))]
+pub mod server_buffer_tracker;
+#[cfg(not(target_family = "wasm"))]
 pub mod server_model;
 #[cfg(not(target_family = "wasm"))]
 pub mod ssh_transport;
@@ -70,6 +72,12 @@ pub(super) fn run_daemon_app(
         ctx.add_singleton_model(|_ctx| DetectedRepositories::default());
         ctx.add_singleton_model(RepoMetadataModel::new_with_incremental_updates);
         ctx.add_singleton_model(warp_files::FileModel::new);
+        // GlobalBufferModel 必须在 ServerModel 之前注册:buffer-sync 的服务端
+        // 处理(server_model.rs / server_buffer_tracker.rs)通过
+        // `GlobalBufferModel::handle(ctx)` 访问它,未注册会在 daemon 启动时
+        // panic「Cannot get singleton model ... never registered」。它自身
+        // 在 `new()` 里订阅 FileModel,所以排在 FileModel 之后。
+        ctx.add_singleton_model(crate::code::global_buffer_model::GlobalBufferModel::new);
         ctx.add_singleton_model(server_model_init);
     })?;
     Ok(())

--- a/app/src/remote_server/server_buffer_tracker.rs
+++ b/app/src/remote_server/server_buffer_tracker.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use bimap::BiMap;
 use warp_editor::content::buffer::Buffer;
 use warp_util::file::FileId;
 use warpui::{ModelContext, ModelHandle, SingletonEntity as _};
@@ -23,8 +24,10 @@ pub enum PendingBufferRequestKind {
 /// - Per-buffer connection sets (which connections have each buffer open)
 /// - Pending async requests (OpenBuffer, SaveBuffer, ResolveConflict) awaiting events
 pub struct ServerBufferTracker {
-    /// Maps wire path strings to `FileId` for open server-local buffers.
-    open_buffers: HashMap<String, FileId>,
+    /// 双向映射 wire path ↔ FileId,两侧查找都 O(1)。
+    /// `path_for_file_id` 在每次 `ServerLocalBufferUpdated` 都会被调用,
+    /// 用 BiMap 避免线性扫描。
+    open_buffers: BiMap<String, FileId>,
     /// 持有每个已打开 server-local buffer 的**强引用** `ModelHandle<Buffer>`。
     ///
     /// `GlobalBufferModel` 内部只存 `WeakModelHandle`,客户端靠编辑器 view 持有
@@ -47,7 +50,7 @@ pub struct ServerBufferTracker {
 impl ServerBufferTracker {
     pub fn new() -> Self {
         Self {
-            open_buffers: HashMap::new(),
+            open_buffers: BiMap::new(),
             buffer_handles: HashMap::new(),
             buffer_connections: HashMap::new(),
             pending_requests: HashMap::new(),
@@ -68,20 +71,17 @@ impl ServerBufferTracker {
         self.buffer_handles.insert(file_id, buffer);
     }
 
-    /// Look up a FileId by its wire path.
+    /// Look up a FileId by its wire path. O(1)。
     pub fn file_id_for_path(&self, path: &str) -> Option<FileId> {
-        self.open_buffers.get(path).copied()
+        self.open_buffers.get_by_left(path).copied()
     }
 
-    /// Look up the wire path for a given FileId.
+    /// Look up the wire path for a given FileId. O(1) via BiMap。
+    /// 返回 owned `String` 而非 `&str`,让调用方在持有结果的同时还能借用
+    /// 其它 `&mut self`(典型场景:在事件 handler 里拿到 path 然后回头
+    /// `send_server_message(...)`)。push 频率不高,clone 开销可忽略。
     pub fn path_for_file_id(&self, file_id: FileId) -> Option<String> {
-        self.open_buffers.iter().find_map(|(p, id)| {
-            if *id == file_id {
-                Some(p.clone())
-            } else {
-                None
-            }
-        })
+        self.open_buffers.get_by_right(&file_id).cloned()
     }
 
     // ── Connection tracking ───────────────────────────────────────
@@ -129,7 +129,7 @@ impl ServerBufferTracker {
 
         for &file_id in &orphaned {
             self.buffer_connections.remove(&file_id);
-            self.open_buffers.retain(|_, id| *id != file_id);
+            self.open_buffers.remove_by_right(&file_id);
             self.pending_requests.remove(&file_id);
             // 释放强引用,允许 buffer 被回收。
             self.buffer_handles.remove(&file_id);
@@ -147,7 +147,7 @@ impl ServerBufferTracker {
         conn_id: ConnectionId,
         ctx: &mut ModelContext<ServerModel>,
     ) {
-        let Some(&file_id) = self.open_buffers.get(path) else {
+        let Some(&file_id) = self.open_buffers.get_by_left(path) else {
             return;
         };
 
@@ -160,7 +160,7 @@ impl ServerBufferTracker {
 
         // No connections remain — deallocate.
         self.buffer_connections.remove(&file_id);
-        self.open_buffers.remove(path);
+        self.open_buffers.remove_by_left(path);
         self.pending_requests.remove(&file_id);
         // 释放强引用,允许 buffer 被回收。
         self.buffer_handles.remove(&file_id);

--- a/app/src/remote_server/server_buffer_tracker.rs
+++ b/app/src/remote_server/server_buffer_tracker.rs
@@ -107,6 +107,13 @@ impl ServerBufferTracker {
         conn_id: ConnectionId,
         ctx: &mut ModelContext<ServerModel>,
     ) -> Vec<FileId> {
+        // 丢弃该连接产生的所有 pending 请求,避免断连后留下陈旧条目。
+        for entries in self.pending_requests.values_mut() {
+            entries.retain(|(_, pending_conn_id, _)| *pending_conn_id != conn_id);
+        }
+        self.pending_requests
+            .retain(|_, entries| !entries.is_empty());
+
         let orphaned: Vec<FileId> = self
             .buffer_connections
             .iter_mut()
@@ -123,6 +130,7 @@ impl ServerBufferTracker {
         for &file_id in &orphaned {
             self.buffer_connections.remove(&file_id);
             self.open_buffers.retain(|_, id| *id != file_id);
+            self.pending_requests.remove(&file_id);
             // 释放强引用,允许 buffer 被回收。
             self.buffer_handles.remove(&file_id);
             GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| gbm.remove(file_id, ctx));
@@ -153,6 +161,7 @@ impl ServerBufferTracker {
         // No connections remain — deallocate.
         self.buffer_connections.remove(&file_id);
         self.open_buffers.remove(path);
+        self.pending_requests.remove(&file_id);
         // 释放强引用,允许 buffer 被回收。
         self.buffer_handles.remove(&file_id);
         GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| gbm.remove(file_id, ctx));

--- a/app/src/remote_server/server_buffer_tracker.rs
+++ b/app/src/remote_server/server_buffer_tracker.rs
@@ -1,0 +1,201 @@
+use std::collections::{HashMap, HashSet};
+
+use warp_editor::content::buffer::Buffer;
+use warp_util::file::FileId;
+use warpui::{ModelContext, ModelHandle, SingletonEntity as _};
+
+use super::server_model::{ConnectionId, ServerModel};
+use crate::code::global_buffer_model::GlobalBufferModel;
+use crate::remote_server::protocol::RequestId;
+
+/// Distinguishes the type of pending buffer request so the event
+/// subscription can send the correct response message.
+#[derive(Clone, Copy, Debug)]
+pub enum PendingBufferRequestKind {
+    OpenBuffer,
+    SaveBuffer,
+    ResolveConflict,
+}
+
+/// Bridges the ServerModel's per-connection state with the GlobalBufferModel's
+/// tracked buffers. Manages:
+/// - Wire path → FileId mappings for open server-local buffers
+/// - Per-buffer connection sets (which connections have each buffer open)
+/// - Pending async requests (OpenBuffer, SaveBuffer, ResolveConflict) awaiting events
+pub struct ServerBufferTracker {
+    /// Maps wire path strings to `FileId` for open server-local buffers.
+    open_buffers: HashMap<String, FileId>,
+    /// 持有每个已打开 server-local buffer 的**强引用** `ModelHandle<Buffer>`。
+    ///
+    /// `GlobalBufferModel` 内部只存 `WeakModelHandle`,客户端靠编辑器 view 持有
+    /// 强引用让 buffer 存活;但 daemon 没有 view —— 若不在这里持有强引用,
+    /// `handle_open_buffer` 返回后 buffer 引用计数归零,会被 WarpUI 的
+    /// `flush_effects` 回收,导致随后 `FileModel` 异步加载完成时 weak handle 已
+    /// 失效(日志「Cannot populate buffer with content due to deallocated model
+    /// handle」)。buffer 关闭(无连接)时一并 drop。
+    buffer_handles: HashMap<FileId, ModelHandle<Buffer>>,
+    /// Tracks which connections have each buffer open.
+    /// File-watcher pushes go to all connections in the set.
+    buffer_connections: HashMap<FileId, HashSet<ConnectionId>>,
+    /// Tracks in-flight OpenBuffer / SaveBuffer / ResolveConflict requests so
+    /// `GlobalBufferModelEvent`s can be correlated back to the originating
+    /// request and connection. Uses a `Vec` to support concurrent requests
+    /// for the same buffer from different connections.
+    pending_requests: HashMap<FileId, Vec<(RequestId, ConnectionId, PendingBufferRequestKind)>>,
+}
+
+impl ServerBufferTracker {
+    pub fn new() -> Self {
+        Self {
+            open_buffers: HashMap::new(),
+            buffer_handles: HashMap::new(),
+            buffer_connections: HashMap::new(),
+            pending_requests: HashMap::new(),
+        }
+    }
+
+    // ── Path ↔ FileId mapping ─────────────────────────────────────
+
+    /// Register a wire path → FileId mapping,并持有 buffer 的强引用让它在
+    /// daemon 端存活(见 `buffer_handles` 字段说明)。
+    pub fn track_open_buffer(
+        &mut self,
+        path: String,
+        file_id: FileId,
+        buffer: ModelHandle<Buffer>,
+    ) {
+        self.open_buffers.insert(path, file_id);
+        self.buffer_handles.insert(file_id, buffer);
+    }
+
+    /// Look up a FileId by its wire path.
+    pub fn file_id_for_path(&self, path: &str) -> Option<FileId> {
+        self.open_buffers.get(path).copied()
+    }
+
+    /// Look up the wire path for a given FileId.
+    pub fn path_for_file_id(&self, file_id: FileId) -> Option<String> {
+        self.open_buffers.iter().find_map(|(p, id)| {
+            if *id == file_id {
+                Some(p.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    // ── Connection tracking ───────────────────────────────────────
+
+    /// Add a connection to a buffer's subscriber set.
+    pub fn add_connection(&mut self, file_id: FileId, conn_id: ConnectionId) {
+        self.buffer_connections
+            .entry(file_id)
+            .or_default()
+            .insert(conn_id);
+    }
+
+    /// Returns the set of connections subscribed to a buffer.
+    pub fn connections_for_buffer(&self, file_id: &FileId) -> Option<&HashSet<ConnectionId>> {
+        self.buffer_connections.get(file_id)
+    }
+
+    /// Remove a connection from all buffer subscription sets.
+    /// Returns the list of FileIds that have no remaining connections
+    /// (orphaned buffers that should be deallocated).
+    pub fn remove_connection(
+        &mut self,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<ServerModel>,
+    ) -> Vec<FileId> {
+        let orphaned: Vec<FileId> = self
+            .buffer_connections
+            .iter_mut()
+            .filter_map(|(file_id, conns)| {
+                conns.remove(&conn_id);
+                if conns.is_empty() {
+                    Some(*file_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for &file_id in &orphaned {
+            self.buffer_connections.remove(&file_id);
+            self.open_buffers.retain(|_, id| *id != file_id);
+            // 释放强引用,允许 buffer 被回收。
+            self.buffer_handles.remove(&file_id);
+            GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| gbm.remove(file_id, ctx));
+        }
+
+        orphaned
+    }
+
+    /// Remove a single connection from a buffer's subscriber set.
+    /// If no connections remain, deallocates the buffer entirely.
+    pub fn close_buffer(
+        &mut self,
+        path: &str,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<ServerModel>,
+    ) {
+        let Some(&file_id) = self.open_buffers.get(path) else {
+            return;
+        };
+
+        if let Some(conns) = self.buffer_connections.get_mut(&file_id) {
+            conns.remove(&conn_id);
+            if !conns.is_empty() {
+                return; // Other connections still using this buffer.
+            }
+        }
+
+        // No connections remain — deallocate.
+        self.buffer_connections.remove(&file_id);
+        self.open_buffers.remove(path);
+        // 释放强引用,允许 buffer 被回收。
+        self.buffer_handles.remove(&file_id);
+        GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| gbm.remove(file_id, ctx));
+    }
+
+    // ── Pending request tracking ──────────────────────────────────
+
+    /// Stash a pending async request for later correlation with an event.
+    pub fn insert_pending(
+        &mut self,
+        file_id: FileId,
+        request_id: RequestId,
+        conn_id: ConnectionId,
+        kind: PendingBufferRequestKind,
+    ) {
+        self.pending_requests
+            .entry(file_id)
+            .or_default()
+            .push((request_id, conn_id, kind));
+    }
+
+    /// Retrieve and remove pending requests that match `kind` for the given
+    /// FileId. Other pending requests for the same FileId are left in place.
+    pub fn take_pending_by_kind(
+        &mut self,
+        file_id: &FileId,
+        kind: PendingBufferRequestKind,
+    ) -> Vec<(RequestId, ConnectionId)> {
+        let Some(entries) = self.pending_requests.get_mut(file_id) else {
+            return Vec::new();
+        };
+        let mut matched = Vec::new();
+        entries.retain(|(req, conn, k)| {
+            if std::mem::discriminant(k) == std::mem::discriminant(&kind) {
+                matched.push((req.clone(), conn.to_owned()));
+                false // remove from the vec
+            } else {
+                true // keep
+            }
+        });
+        if entries.is_empty() {
+            self.pending_requests.remove(file_id);
+        }
+        matched
+    }
+}

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -1359,8 +1359,8 @@ impl ServerModel {
             return;
         };
 
-        let expected_sv = ContentVersion::from_raw(msg.expected_server_version as usize);
-        let new_cv = ContentVersion::from_raw(msg.new_client_version as usize);
+        let expected_sv = ContentVersion::from_wire_u64(msg.expected_server_version);
+        let new_cv = ContentVersion::from_wire_u64(msg.new_client_version);
 
         // Per spec: if the edit is rejected (stale server version),
         // the server silently drops it.
@@ -1448,8 +1448,8 @@ impl ServerModel {
             ));
         };
 
-        let ack_sv = ContentVersion::from_raw(msg.acknowledged_server_version as usize);
-        let current_cv = ContentVersion::from_raw(msg.current_client_version as usize);
+        let ack_sv = ContentVersion::from_wire_u64(msg.acknowledged_server_version);
+        let current_cv = ContentVersion::from_wire_u64(msg.current_client_version);
         let result = GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| {
             gbm.resolve_conflict(file_id, ack_sv, current_cv, &msg.client_content, ctx)
         });

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -367,8 +367,14 @@ impl ServerModel {
                     let Some(conns) = me.buffers.connections_for_buffer(file_id) else {
                         return;
                     };
-                    // Find the path for this file_id.
-                    let path = me.buffers.path_for_file_id(*file_id).unwrap_or_default();
+                    // Find the path for this file_id; abort the push if tracker
+                    // state is inconsistent (空 path 会破坏 path↔buffer 契约)。
+                    let Some(path) = me.buffers.path_for_file_id(*file_id) else {
+                        log::error!(
+                            "Missing path mapping for server-local buffer file_id={file_id:?}"
+                        );
+                        return;
+                    };
 
                     let proto_edits: Vec<TextEdit> = edits
                         .iter()
@@ -1297,8 +1303,8 @@ impl ServerModel {
         ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
         log::info!(
-            "Handling OpenBuffer path={} (request_id={request_id})",
-            msg.path
+            "Handling OpenBuffer path={path} (request_id={request_id})",
+            path = msg.path
         );
 
         let path = PathBuf::from(&msg.path);
@@ -1349,7 +1355,7 @@ impl ServerModel {
     #[cfg(feature = "local_fs")]
     fn handle_buffer_edit(&mut self, msg: BufferEdit, ctx: &mut ModelContext<Self>) {
         let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
-            log::warn!("BufferEdit for unknown buffer: {}", msg.path);
+            log::warn!("BufferEdit for unknown buffer: {path}", path = msg.path);
             return;
         };
 
@@ -1373,15 +1379,15 @@ impl ServerModel {
         ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
         log::info!(
-            "Handling SaveBuffer path={} (request_id={request_id})",
-            msg.path
+            "Handling SaveBuffer path={path} (request_id={request_id})",
+            path = msg.path
         );
 
         let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
             return HandlerOutcome::Sync(server_message::Message::SaveBufferResponse(
                 SaveBufferResponse {
                     result: Some(save_buffer_response::Result::Error(FileOperationError {
-                        message: format!("Buffer not open: {}", msg.path),
+                        message: format!("Buffer not open: {path}", path = msg.path),
                     })),
                 },
             ));
@@ -1426,8 +1432,8 @@ impl ServerModel {
         ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
         log::info!(
-            "Handling ResolveConflict path={} (request_id={request_id})",
-            msg.path
+            "Handling ResolveConflict path={path} (request_id={request_id})",
+            path = msg.path
         );
 
         let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
@@ -1435,7 +1441,7 @@ impl ServerModel {
                 ResolveConflictResponse {
                     result: Some(resolve_conflict_response::Result::Error(
                         FileOperationError {
-                            message: format!("Buffer not open: {}", msg.path),
+                            message: format!("Buffer not open: {path}", path = msg.path),
                         },
                     )),
                 },
@@ -1517,7 +1523,10 @@ impl ServerModel {
         conn_id: ConnectionId,
         ctx: &mut ModelContext<Self>,
     ) {
-        log::info!("Handling CloseBuffer path={} conn={conn_id}", msg.path);
+        log::info!(
+            "Handling CloseBuffer path={path} conn={conn_id}",
+            path = msg.path
+        );
         self.buffers.close_buffer(&msg.path, conn_id, ctx);
     }
 }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -30,8 +30,9 @@ use super::proto::{
 // `local_fs` 下可用,因此整套服务端 buffer 处理都按 `local_fs` 门控。
 #[cfg(feature = "local_fs")]
 use super::proto::{
-    resolve_conflict_response, save_buffer_response, BufferEdit, BufferUpdatedPush, CloseBuffer,
-    OpenBuffer, OpenBufferResponse, ResolveConflict, ResolveConflictResponse,
+    list_directory_response, resolve_conflict_response, save_buffer_response, BufferEdit,
+    BufferUpdatedPush, CloseBuffer, DirEntry, ListDirectory, ListDirectoryResponse,
+    ListDirectorySuccess, OpenBuffer, OpenBufferResponse, ResolveConflict, ResolveConflictResponse,
     ResolveConflictSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, TextEdit,
 };
 #[cfg(feature = "local_fs")]
@@ -627,13 +628,17 @@ impl ServerModel {
             Some(client_message::Message::ResolveConflict(msg)) => {
                 self.handle_resolve_conflict(msg, &request_id, conn_id, ctx)
             }
+            // OpenWarp:远端终端文件链接的目录列举(校验路径形态用)。
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::ListDirectory(msg)) => self.handle_list_directory(msg),
             #[cfg(not(feature = "local_fs"))]
             Some(
                 client_message::Message::OpenBuffer(_)
                 | client_message::Message::BufferEdit(_)
                 | client_message::Message::CloseBuffer(_)
                 | client_message::Message::SaveBuffer(_)
-                | client_message::Message::ResolveConflict(_),
+                | client_message::Message::ResolveConflict(_)
+                | client_message::Message::ListDirectory(_),
             ) => HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
                 code: ErrorCode::InvalidRequest.into(),
                 message: "Buffer syncing requires the local_fs feature".to_string(),
@@ -1463,6 +1468,43 @@ impl ServerModel {
                 },
             )),
         }
+    }
+
+    /// OpenWarp:处理 `ListDirectory` —— 同步列举一个目录下的直接子项。
+    ///
+    /// 给远端终端文件链接检测做精确校验用:客户端缓存某个 cwd 下的
+    /// 真实目录项,链接检测器据此从 `ls -l` 整行里切出正确的文件名。
+    /// `std::fs::read_dir` 在 daemon 端是廉价的同步调用,故直接返回
+    /// `HandlerOutcome::Sync`,不走异步 spawn。
+    #[cfg(feature = "local_fs")]
+    fn handle_list_directory(&self, msg: ListDirectory) -> HandlerOutcome {
+        log::info!("Handling ListDirectory path={}", msg.path);
+
+        let result = match std::fs::read_dir(&msg.path) {
+            Ok(read_dir) => {
+                let mut entries = Vec::new();
+                for entry in read_dir.flatten() {
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    // 优先用 `file_type()`(不跟随符号链接、无需额外 stat);
+                    // 失败时回退到 `metadata()`(会跟随符号链接)。
+                    let is_dir = match entry.file_type() {
+                        Ok(ft) => ft.is_dir(),
+                        Err(_) => entry.metadata().map(|m| m.is_dir()).unwrap_or(false),
+                    };
+                    entries.push(DirEntry { name, is_dir });
+                }
+                list_directory_response::Result::Success(ListDirectorySuccess { entries })
+            }
+            Err(err) => list_directory_response::Result::Error(FileOperationError {
+                message: format!("Failed to list directory {}: {err}", msg.path),
+            }),
+        };
+
+        HandlerOutcome::Sync(server_message::Message::ListDirectoryResponse(
+            ListDirectoryResponse {
+                result: Some(result),
+            },
+        ))
     }
 
     /// Handles `CloseBuffer` notification (fire-and-forget).

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -26,6 +26,19 @@ use super::proto::{
     WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 
+// Buffer-sync 相关:依赖 GlobalBufferModel,后者的 server-local 操作只在
+// `local_fs` 下可用,因此整套服务端 buffer 处理都按 `local_fs` 门控。
+#[cfg(feature = "local_fs")]
+use super::proto::{
+    resolve_conflict_response, save_buffer_response, BufferEdit, BufferUpdatedPush, CloseBuffer,
+    OpenBuffer, OpenBufferResponse, ResolveConflict, ResolveConflictResponse,
+    ResolveConflictSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, TextEdit,
+};
+#[cfg(feature = "local_fs")]
+use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
+#[cfg(feature = "local_fs")]
+use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
+
 /// How long the daemon waits with no connections before exiting.
 pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 * 60);
 
@@ -164,6 +177,10 @@ pub struct ServerModel {
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
     pending_file_ops: PendingFileOps,
+    /// Tracks open server-local buffers, their connections, and pending
+    /// buffer requests (OpenBuffer, SaveBuffer, ResolveConflict).
+    #[cfg(feature = "local_fs")]
+    buffers: ServerBufferTracker,
     /// Daemon-wide bearer credential for the identity-scoped daemon.
     ///
     /// The token is written by Initialize when the client supplies a
@@ -195,6 +212,8 @@ impl ServerModel {
             host_id,
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
+            #[cfg(feature = "local_fs")]
+            buffers: ServerBufferTracker::new(),
             auth_token: None,
         };
         // Subscribe to FileModel and RepoMetadataModel events
@@ -298,6 +317,170 @@ impl ServerModel {
                 } => {}
             });
         }
+        // Subscribe to GlobalBufferModel events for server-local buffers.
+        #[cfg(feature = "local_fs")]
+        {
+            let gbm = GlobalBufferModel::handle(ctx);
+            ctx.subscribe_to_model(&gbm, |me, event, ctx| match event {
+                GlobalBufferModelEvent::BufferLoaded { file_id, .. } => {
+                    // Complete all pending OpenBuffer requests for this file.
+                    let pending = me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::OpenBuffer);
+                    if !pending.is_empty() {
+                        let gbm = GlobalBufferModel::handle(ctx);
+                        let content = gbm.as_ref(ctx).content_for_file(*file_id, ctx);
+                        let server_version = gbm
+                            .as_ref(ctx)
+                            .sync_clock_for_server_local(*file_id)
+                            .map(|c| c.server_version.as_u64());
+
+                        for (request_id, conn_id) in pending {
+                            let message = match (&content, server_version) {
+                                (Some(content), Some(sv)) => {
+                                    server_message::Message::OpenBufferResponse(
+                                        OpenBufferResponse {
+                                            content: content.clone(),
+                                            server_version: sv,
+                                        },
+                                    )
+                                }
+                                _ => server_message::Message::Error(ErrorResponse {
+                                    code: ErrorCode::Internal.into(),
+                                    message: format!(
+                                        "Buffer loaded but content or sync clock unavailable for file {file_id:?}"
+                                    ),
+                                }),
+                            };
+                            me.send_server_message(Some(conn_id), Some(&request_id), message);
+                        }
+                    }
+                }
+                GlobalBufferModelEvent::ServerLocalBufferUpdated {
+                    file_id,
+                    edits,
+                    new_server_version,
+                    expected_client_version,
+                } => {
+                    // Push incremental edits to all connections that have this buffer open.
+                    let Some(conns) = me.buffers.connections_for_buffer(file_id) else {
+                        return;
+                    };
+                    // Find the path for this file_id.
+                    let path = me.buffers.path_for_file_id(*file_id).unwrap_or_default();
+
+                    let proto_edits: Vec<TextEdit> = edits
+                        .iter()
+                        .map(|edit| TextEdit {
+                            start_offset: edit.start.as_usize() as u64,
+                            end_offset: edit.end.as_usize() as u64,
+                            text: edit.text.clone(),
+                        })
+                        .collect();
+
+                    let conns: Vec<_> = conns.iter().copied().collect();
+                    for conn_id in conns {
+                        me.send_server_message(
+                            Some(conn_id),
+                            None,
+                            server_message::Message::BufferUpdated(BufferUpdatedPush {
+                                path: path.clone(),
+                                new_server_version: new_server_version.as_u64(),
+                                expected_client_version: expected_client_version.as_u64(),
+                                edits: proto_edits.clone(),
+                            }),
+                        );
+                    }
+                }
+                GlobalBufferModelEvent::FileSaved { file_id } => {
+                    for (request_id, conn_id) in me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::SaveBuffer)
+                    {
+                        me.send_server_message(
+                            Some(conn_id),
+                            Some(&request_id),
+                            server_message::Message::SaveBufferResponse(SaveBufferResponse {
+                                result: Some(save_buffer_response::Result::Success(
+                                    SaveBufferSuccess {},
+                                )),
+                            }),
+                        );
+                    }
+                    for (request_id, conn_id) in me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::ResolveConflict)
+                    {
+                        me.send_server_message(
+                            Some(conn_id),
+                            Some(&request_id),
+                            server_message::Message::ResolveConflictResponse(
+                                ResolveConflictResponse {
+                                    result: Some(resolve_conflict_response::Result::Success(
+                                        ResolveConflictSuccess {},
+                                    )),
+                                },
+                            ),
+                        );
+                    }
+                }
+                GlobalBufferModelEvent::FailedToSave { file_id, error } => {
+                    for (request_id, conn_id) in me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::SaveBuffer)
+                    {
+                        me.send_server_message(
+                            Some(conn_id),
+                            Some(&request_id),
+                            server_message::Message::SaveBufferResponse(SaveBufferResponse {
+                                result: Some(save_buffer_response::Result::Error(
+                                    FileOperationError {
+                                        message: format!("{error}"),
+                                    },
+                                )),
+                            }),
+                        );
+                    }
+                    for (request_id, conn_id) in me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::ResolveConflict)
+                    {
+                        me.send_server_message(
+                            Some(conn_id),
+                            Some(&request_id),
+                            server_message::Message::ResolveConflictResponse(
+                                ResolveConflictResponse {
+                                    result: Some(resolve_conflict_response::Result::Error(
+                                        FileOperationError {
+                                            message: format!("{error}"),
+                                        },
+                                    )),
+                                },
+                            ),
+                        );
+                    }
+                }
+                GlobalBufferModelEvent::FailedToLoad { file_id, error } => {
+                    for (request_id, conn_id) in me
+                        .buffers
+                        .take_pending_by_kind(file_id, PendingBufferRequestKind::OpenBuffer)
+                    {
+                        me.send_server_message(
+                            Some(conn_id),
+                            Some(&request_id),
+                            server_message::Message::Error(ErrorResponse {
+                                code: ErrorCode::Internal.into(),
+                                message: format!("Failed to load buffer: {error}"),
+                            }),
+                        );
+                    }
+                }
+                GlobalBufferModelEvent::BufferUpdatedFromFileEvent { .. }
+                | GlobalBufferModelEvent::RemoteBufferConflict { .. } => {
+                    // Not relevant for server-local buffers.
+                }
+            });
+        }
         // Start the grace timer immediately so the daemon exits if no proxy
         // connects within GRACE_PERIOD. In practice the spawning proxy connects
         // within milliseconds, so the risk of premature shutdown is negligible;
@@ -339,6 +522,10 @@ impl ServerModel {
         if self.connection_senders.remove(&conn_id).is_none() {
             return;
         }
+        // Drop this connection from all open server-local buffers; orphaned
+        // buffers (no remaining connections) are deallocated by the tracker.
+        #[cfg(feature = "local_fs")]
+        self.buffers.remove_connection(conn_id, ctx);
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
         if remaining == 0 {
@@ -418,6 +605,39 @@ impl ServerModel {
             Some(client_message::Message::ReadFileContext(msg)) => {
                 self.handle_read_file_context(msg, &request_id, conn_id, ctx)
             }
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::OpenBuffer(msg)) => {
+                self.handle_open_buffer(msg, &request_id, conn_id, ctx)
+            }
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::BufferEdit(msg)) => {
+                self.handle_buffer_edit(msg, ctx);
+                return; // fire-and-forget notification
+            }
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::CloseBuffer(msg)) => {
+                self.handle_close_buffer(msg, conn_id, ctx);
+                return; // fire-and-forget notification
+            }
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::SaveBuffer(msg)) => {
+                self.handle_save_buffer(msg, &request_id, conn_id, ctx)
+            }
+            #[cfg(feature = "local_fs")]
+            Some(client_message::Message::ResolveConflict(msg)) => {
+                self.handle_resolve_conflict(msg, &request_id, conn_id, ctx)
+            }
+            #[cfg(not(feature = "local_fs"))]
+            Some(
+                client_message::Message::OpenBuffer(_)
+                | client_message::Message::BufferEdit(_)
+                | client_message::Message::CloseBuffer(_)
+                | client_message::Message::SaveBuffer(_)
+                | client_message::Message::ResolveConflict(_),
+            ) => HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: "Buffer syncing requires the local_fs feature".to_string(),
+            })),
             None => {
                 log::warn!(
                     "Received ClientMessage with no message variant (request_id={request_id})"
@@ -1059,6 +1279,204 @@ impl ServerModel {
         );
 
         HandlerOutcome::Async(Some(handle))
+    }
+
+    /// Handles `OpenBuffer` by opening the file via `GlobalBufferModel`.
+    /// The response is sent asynchronously when `BufferLoaded` fires.
+    #[cfg(feature = "local_fs")]
+    fn handle_open_buffer(
+        &mut self,
+        msg: OpenBuffer,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling OpenBuffer path={} (request_id={request_id})",
+            msg.path
+        );
+
+        let path = PathBuf::from(&msg.path);
+        let gbm = GlobalBufferModel::handle(ctx);
+        let buffer_state = gbm.update(ctx, |gbm, ctx| gbm.open_server_local(path, ctx));
+        let file_id = buffer_state.file_id;
+
+        // Track path → FileId mapping and connection。track_open_buffer 同时持有
+        // buffer 的强引用 —— daemon 没有编辑器 view,不持有的话 buffer 会在
+        // FileModel 异步加载完成前被回收(见 ServerBufferTracker::buffer_handles)。
+        self.buffers
+            .track_open_buffer(msg.path.clone(), file_id, buffer_state.buffer);
+        self.buffers.add_connection(file_id, conn_id);
+
+        // If already loaded, respond immediately.
+        if gbm.as_ref(ctx).buffer_loaded(file_id) {
+            let content = gbm
+                .as_ref(ctx)
+                .content_for_file(file_id, ctx)
+                .unwrap_or_default();
+            let server_version = gbm
+                .as_ref(ctx)
+                .sync_clock_for_server_local(file_id)
+                .map(|c| c.server_version.as_u64())
+                .unwrap_or(1);
+            return HandlerOutcome::Sync(server_message::Message::OpenBufferResponse(
+                OpenBufferResponse {
+                    content,
+                    server_version,
+                },
+            ));
+        }
+
+        // Not yet loaded — stash request info so the GlobalBufferModelEvent
+        // subscription can send the response when content arrives.
+        self.buffers.insert_pending(
+            file_id,
+            request_id.clone(),
+            conn_id,
+            PendingBufferRequestKind::OpenBuffer,
+        );
+        HandlerOutcome::Async(None)
+    }
+
+    /// Handles `BufferEdit` notification (fire-and-forget).
+    /// Delegates to `GlobalBufferModel::apply_client_edit`. On rejection
+    /// (stale server version), the edit is silently dropped.
+    #[cfg(feature = "local_fs")]
+    fn handle_buffer_edit(&mut self, msg: BufferEdit, ctx: &mut ModelContext<Self>) {
+        let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
+            log::warn!("BufferEdit for unknown buffer: {}", msg.path);
+            return;
+        };
+
+        let expected_sv = ContentVersion::from_raw(msg.expected_server_version as usize);
+        let new_cv = ContentVersion::from_raw(msg.new_client_version as usize);
+
+        // Per spec: if the edit is rejected (stale server version),
+        // the server silently drops it.
+        GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| {
+            gbm.apply_client_edit(file_id, &msg.edits, expected_sv, new_cv, ctx);
+        });
+    }
+
+    /// Handles `SaveBuffer` by persisting the buffer to disk.
+    #[cfg(feature = "local_fs")]
+    fn handle_save_buffer(
+        &mut self,
+        msg: SaveBuffer,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling SaveBuffer path={} (request_id={request_id})",
+            msg.path
+        );
+
+        let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
+            return HandlerOutcome::Sync(server_message::Message::SaveBufferResponse(
+                SaveBufferResponse {
+                    result: Some(save_buffer_response::Result::Error(FileOperationError {
+                        message: format!("Buffer not open: {}", msg.path),
+                    })),
+                },
+            ));
+        };
+
+        let result = GlobalBufferModel::handle(ctx)
+            .update(ctx, |gbm, ctx| gbm.save_server_local(file_id, ctx));
+
+        match result {
+            Ok(()) => {
+                // Response will come via the FileSaved event subscription.
+                // Track the file_id → (request_id, conn_id) so the event
+                // handler can correlate.
+                self.buffers.insert_pending(
+                    file_id,
+                    request_id.clone(),
+                    conn_id,
+                    PendingBufferRequestKind::SaveBuffer,
+                );
+                HandlerOutcome::Async(None)
+            }
+            Err(err) => HandlerOutcome::Sync(server_message::Message::SaveBufferResponse(
+                SaveBufferResponse {
+                    result: Some(save_buffer_response::Result::Error(FileOperationError {
+                        message: format!("Failed to save: {err}"),
+                    })),
+                },
+            )),
+        }
+    }
+
+    /// Handles `ResolveConflict` by replacing the server buffer with the
+    /// client's content and persisting to disk. Returns an async
+    /// `HandlerOutcome` — the response is sent when `FileSaved` or
+    /// `FailedToSave` fires.
+    #[cfg(feature = "local_fs")]
+    fn handle_resolve_conflict(
+        &mut self,
+        msg: ResolveConflict,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling ResolveConflict path={} (request_id={request_id})",
+            msg.path
+        );
+
+        let Some(file_id) = self.buffers.file_id_for_path(&msg.path) else {
+            return HandlerOutcome::Sync(server_message::Message::ResolveConflictResponse(
+                ResolveConflictResponse {
+                    result: Some(resolve_conflict_response::Result::Error(
+                        FileOperationError {
+                            message: format!("Buffer not open: {}", msg.path),
+                        },
+                    )),
+                },
+            ));
+        };
+
+        let ack_sv = ContentVersion::from_raw(msg.acknowledged_server_version as usize);
+        let current_cv = ContentVersion::from_raw(msg.current_client_version as usize);
+        let result = GlobalBufferModel::handle(ctx).update(ctx, |gbm, ctx| {
+            gbm.resolve_conflict(file_id, ack_sv, current_cv, &msg.client_content, ctx)
+        });
+
+        match result {
+            Ok(()) => {
+                self.buffers.insert_pending(
+                    file_id,
+                    request_id.clone(),
+                    conn_id,
+                    PendingBufferRequestKind::ResolveConflict,
+                );
+                HandlerOutcome::Async(None)
+            }
+            Err(err) => HandlerOutcome::Sync(server_message::Message::ResolveConflictResponse(
+                ResolveConflictResponse {
+                    result: Some(resolve_conflict_response::Result::Error(
+                        FileOperationError {
+                            message: format!("Failed to resolve conflict: {err}"),
+                        },
+                    )),
+                },
+            )),
+        }
+    }
+
+    /// Handles `CloseBuffer` notification (fire-and-forget).
+    /// Removes the connection from the buffer's connection set.
+    /// Deallocates the buffer if no connections remain.
+    #[cfg(feature = "local_fs")]
+    fn handle_close_buffer(
+        &mut self,
+        msg: CloseBuffer,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        log::info!("Handling CloseBuffer path={} conn={conn_id}", msg.path);
+        self.buffers.close_buffer(&msg.path, conn_id, ctx);
     }
 }
 

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -374,14 +374,21 @@ async fn cross_compile_remote_server(backend: &DevBuildBackend) -> Result<PathBu
         ));
     }
 
-    // 产物位置:`target/<triple>/<profile>/<bin_name>`。
-    let binary = root
-        .join("target")
+    // 产物位置:`<target_dir>/<triple>/<profile>/<bin_name>`。
+    // 优先读 `CARGO_TARGET_DIR`,否则回退到 `<workspace>/target`。仓库未在
+    // `.cargo/config.toml` 里设 `[build] target-dir`,故只需考虑 env。
+    let target_root = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| root.join("target"));
+    let binary = target_root
         .join(remote_server::setup::DEV_MUSL_TARGET)
         .join(remote_server::setup::DEV_REMOTE_PROFILE)
         .join(bin_name);
     if !binary.is_file() {
-        return Err(anyhow!("交叉编译完成但未在 {} 找到产物", binary.display()));
+        return Err(anyhow!(
+            "交叉编译完成但未在 {} 找到产物(若设置了 CARGO_TARGET_DIR 请确认路径)",
+            binary.display()
+        ));
     }
     Ok(binary)
 }

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -155,6 +155,308 @@ fn should_skip_scp_fallback(error: &InstallError) -> bool {
     matches!(error, InstallError::ScriptFailed { exit_code: 2, .. })
 }
 
+// ===========================================================================
+// OpenWarp fork:开发模式 remote-server 安装路径
+//
+// 上游 / release 构建会让远端安装脚本从 GitHub releases 下载预编译的
+// remote-server 二进制。但在本地源码构建(`cargo run`)时,这会下载到
+// 「最新已发布」的陈旧二进制,而不是开发者刚改过的代码,导致根本无法
+// 调试 remote-server 的改动。
+//
+// 因此在 DEBUG 且无 release tag 的源码构建下(见
+// `remote_server::setup::is_dev_source_build()`),`install_binary()` 改为:
+//   1. 本地把 `warp` 二进制交叉编译到 x86_64 musl(profile/features 与
+//      `script/deploy_remote_server` 完全一致);
+//   2. 通过已有的 SSH ControlMaster socket,用 `scp_upload` 把产物上传到
+//      `remote_server::setup::remote_server_binary()` 解析出的远端路径;
+//   3. 完全跳过 GitHub 下载安装脚本。
+//
+// 如果交叉编译前置条件缺失(没装 musl target、没有 musl 链接器),不会
+// 硬失败,而是打印清晰告警并回退到原有下载安装流程,保证 dev 仍可用。
+// ===========================================================================
+
+/// 开发模式交叉编译可能用到的 musl 链接器候选(按优先级)。
+/// macOS 上一般是 `x86_64-linux-musl-gcc`(filosottile/musl-cross),
+/// Linux 上常见为 `musl-gcc`。
+const DEV_MUSL_LINKER_CANDIDATES: &[&str] = &["x86_64-linux-musl-gcc", "musl-gcc"];
+
+/// 返回当前 workspace 根目录。
+///
+/// `ssh_transport.rs` 属于 `app` crate,`CARGO_MANIFEST_DIR` 指向
+/// `<workspace>/app`,其父目录即 workspace 根。
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        // 理论上 `app` 一定有父目录;万一没有就退回 manifest 目录本身。
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}
+
+/// 返回追加了 `~/.cargo/bin`(及 `$CARGO_HOME/bin`)的 PATH。
+///
+/// warp 进程常由桌面环境或系统 `cargo` 拉起,其 PATH 可能只含 `/usr/bin`
+/// 而不含 `~/.cargo/bin`。这会导致:
+///   - `cargo zigbuild` 找不到 `cargo-zigbuild` 子命令 → 回退到 musl-gcc;
+///   - cargo-zigbuild 自身找不到 `cargo` / `rustc`。
+/// 交叉编译相关的子进程统一用这里返回的 PATH,保证两者都能解析到。
+/// 若无需调整(无 HOME / 无法拼接)返回 `None`,调用方沿用继承的 PATH。
+fn dev_build_path_env() -> Option<std::ffi::OsString> {
+    let mut extra: Vec<PathBuf> = Vec::new();
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        extra.push(PathBuf::from(cargo_home).join("bin"));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        extra.push(PathBuf::from(home).join(".cargo").join("bin"));
+    }
+    if extra.is_empty() {
+        return None;
+    }
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    extra.extend(std::env::split_paths(&current));
+    std::env::join_paths(extra).ok()
+}
+
+/// 在 `PATH` 中查找首个可用的 musl 链接器,找不到返回 `None`。
+fn find_musl_linker() -> Option<&'static str> {
+    DEV_MUSL_LINKER_CANDIDATES.iter().copied().find(|linker| {
+        command::blocking::Command::new(linker)
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// dev 交叉编译使用的构建后端。
+enum DevBuildBackend {
+    /// `cargo zigbuild`:zig 充当完整的 C/C++ musl 交叉工具链,无需单独安装
+    /// `*-musl-gcc` / `*-musl-g++`,能正确编译 `freetype-sys` 等带 C/C++ 源码
+    /// 的依赖。这是首选后端。
+    Zigbuild,
+    /// 原生 `cargo build` + musl 链接器。仅当系统装有完整的 musl C/C++ 交叉
+    /// 工具链时才可靠 —— 只有 `*-musl-gcc`、缺 `*-musl-g++` 时,`freetype-sys`
+    /// 之类的 C++ 依赖会编译失败。
+    MuslGcc(&'static str),
+}
+
+/// 检测 `cargo-zigbuild` 是否可用。
+///
+/// 直接探测 `cargo-zigbuild --version`(二进制本身),而不是
+/// `cargo zigbuild --version` —— 后者会被 `zigbuild` 子命令解析为未知参数
+/// 而失败。探测用的 PATH 与实际构建一致(注入 `~/.cargo/bin`)。
+fn cargo_zigbuild_available() -> bool {
+    let mut cmd = command::blocking::Command::new("cargo-zigbuild");
+    cmd.arg("--version");
+    if let Some(path) = dev_build_path_env() {
+        cmd.env("PATH", path);
+    }
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// 选择 dev 交叉编译后端:优先 `cargo zigbuild`,回退到原生 `cargo build`
+/// + musl 链接器。两者都不可用时返回 `None`,由调用方回退到下载安装。
+fn select_dev_build_backend() -> Option<DevBuildBackend> {
+    if cargo_zigbuild_available() {
+        return Some(DevBuildBackend::Zigbuild);
+    }
+    find_musl_linker().map(DevBuildBackend::MuslGcc)
+}
+
+/// 检查 `x86_64-unknown-linux-musl` target 是否已通过 rustup 安装。
+async fn musl_target_installed() -> bool {
+    let output = command::r#async::Command::new("rustup")
+        .arg("target")
+        .arg("list")
+        .arg("--installed")
+        .kill_on_drop(true)
+        .output()
+        .await;
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line.trim() == remote_server::setup::DEV_MUSL_TARGET),
+        // 拿不到 rustup 输出时保守地认为未安装,从而触发回退。
+        _ => false,
+    }
+}
+
+/// 交叉编译本地 `warp` 二进制到 musl,返回产物路径。
+///
+/// profile / features 与 `script/deploy_remote_server` 对齐。
+async fn cross_compile_remote_server(backend: &DevBuildBackend) -> Result<PathBuf> {
+    let root = workspace_root();
+    // 当前 channel 对应的 `[[bin]]` 名 —— OSS fork 是 `warp-oss`(见 app/Cargo.toml)。
+    // 不能写死 `warp`:`warp` 那个 bin 走 `load_config!("local")`,需要私有的
+    // `warp-channel-config` 才能生成 `local_config.json`,OSS fork 没有它会编译失败;
+    // `warp-oss`(src/bin/oss.rs)内联 `ChannelConfig`,无此依赖。
+    let bin_name = remote_server::setup::binary_name();
+    let backend_desc = match backend {
+        DevBuildBackend::Zigbuild => "cargo-zigbuild".to_string(),
+        DevBuildBackend::MuslGcc(linker) => format!("cargo-build/{linker}"),
+    };
+    log::info!(
+        "dev remote-server: 交叉编译 {bin_name} -> {} (profile={}, backend={backend_desc})",
+        remote_server::setup::DEV_MUSL_TARGET,
+        remote_server::setup::DEV_REMOTE_PROFILE,
+    );
+    // 首次会编译整个 warp,耗时通常数分钟。stdout/stderr 直接 inherit 到运行
+    // OpenWarp 的终端,这样开发者能看到 cargo 的实时编译进度(否则全程静默,
+    // 容易误以为卡死)。
+    log::info!(
+        "dev remote-server: 正在交叉编译,首次通常需数分钟 —— cargo 进度会打印到\
+         运行 OpenWarp 的终端"
+    );
+
+    let status = async {
+        let mut cmd = command::r#async::Command::new("cargo");
+        cmd.current_dir(&root);
+        // 注入 `~/.cargo/bin`,确保 `cargo zigbuild` 能解析 `cargo-zigbuild`
+        // 子命令,且 cargo-zigbuild 能找到 `cargo` / `rustc`。
+        if let Some(path) = dev_build_path_env() {
+            cmd.env("PATH", path);
+        }
+        match backend {
+            // zigbuild 是 cargo 子命令,自带 zig 链接器与 C/C++ 交叉编译器,
+            // 无需再设 LINKER env。
+            DevBuildBackend::Zigbuild => {
+                cmd.arg("zigbuild");
+            }
+            // 原生 cargo build:通过 env 指定 musl 链接器并覆盖 rustflags,
+            // 避免 .cargo/config.toml 里 macOS 专用 flag 污染交叉编译。
+            DevBuildBackend::MuslGcc(linker) => {
+                cmd.arg("build")
+                    .env("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER", *linker)
+                    .env(
+                        "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS",
+                        "-C symbol-mangling-version=v0",
+                    );
+            }
+        }
+        cmd.arg("-p")
+            .arg("warp")
+            .arg("--bin")
+            .arg(bin_name)
+            .arg("--target")
+            .arg(remote_server::setup::DEV_MUSL_TARGET)
+            .arg("--profile")
+            .arg(remote_server::setup::DEV_REMOTE_PROFILE)
+            .arg("--features")
+            .arg(remote_server::setup::DEV_REMOTE_FEATURES)
+            // inherit:把 cargo 实时进度透到终端,而不是全程静默缓冲。
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .kill_on_drop(true)
+            .status()
+            .await
+    }
+    .with_timeout(remote_server::setup::DEV_CROSS_COMPILE_TIMEOUT)
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "dev remote-server 交叉编译超时(>{:?})",
+            remote_server::setup::DEV_CROSS_COMPILE_TIMEOUT
+        )
+    })?
+    .map_err(|e| anyhow!("无法启动 cargo 构建: {e}"))?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(-1);
+        return Err(anyhow!(
+            "cargo 交叉编译失败(exit {code}),详见运行 OpenWarp 的终端的 cargo 输出"
+        ));
+    }
+
+    // 产物位置:`target/<triple>/<profile>/<bin_name>`。
+    let binary = root
+        .join("target")
+        .join(remote_server::setup::DEV_MUSL_TARGET)
+        .join(remote_server::setup::DEV_REMOTE_PROFILE)
+        .join(bin_name);
+    if !binary.is_file() {
+        return Err(anyhow!("交叉编译完成但未在 {} 找到产物", binary.display()));
+    }
+    Ok(binary)
+}
+
+/// 开发模式安装:交叉编译本地 `warp` 并上传到远端 remote-server 路径。
+///
+/// 上传目标与 `remote_server_binary()` 完全一致,确保随后的
+/// `check_binary()` / proxy 启动能找到它。
+async fn dev_install_local_binary(socket_path: &Path) -> Result<()> {
+    // 前置条件检查:缺任意一项都返回错误,由调用方回退到下载安装。
+    if !musl_target_installed().await {
+        return Err(anyhow!(
+            "未安装 rust target {};可执行 `rustup target add {}`",
+            remote_server::setup::DEV_MUSL_TARGET,
+            remote_server::setup::DEV_MUSL_TARGET,
+        ));
+    }
+    // 选择交叉编译后端:优先 `cargo zigbuild`(zig 自带完整 C/C++ musl 工具链,
+    // 能编译 freetype-sys 等 C++ 依赖),否则回退到 musl-gcc。两者皆无则报错。
+    let backend = select_dev_build_backend().ok_or_else(|| {
+        anyhow!(
+            "未找到可用的 musl 交叉编译后端。建议安装 cargo-zigbuild + zig\
+             (`cargo install cargo-zigbuild`,并用包管理器安装 `zig`),\
+             或安装完整的 musl C/C++ 交叉工具链({})",
+            DEV_MUSL_LINKER_CANDIDATES.join(" / ")
+        )
+    })?;
+
+    let local_binary = cross_compile_remote_server(&backend).await?;
+
+    // 上传到 `remote_server_binary()` 解析出的精确路径,先建好父目录。
+    let remote_binary = remote_server::setup::remote_server_binary();
+    let remote_dir = remote_server::setup::remote_server_dir();
+    let mkdir_output = remote_server::ssh::run_ssh_command(
+        socket_path,
+        &format!("mkdir -p {remote_dir}"),
+        remote_server::setup::CHECK_TIMEOUT,
+    )
+    .await?;
+    if !mkdir_output.status.success() {
+        let code = mkdir_output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&mkdir_output.stderr);
+        return Err(anyhow!(
+            "远端 remote-server 目录创建失败(exit {code}): {stderr}"
+        ));
+    }
+
+    log::info!("dev remote-server: 上传本地交叉编译产物到 {remote_binary}(scp -C 压缩,数百 MB 可能需数分钟)");
+    // dev 产物有数百 MB,用 DEV_UPLOAD_TIMEOUT(远超 SCP_INSTALL_TIMEOUT),
+    // 避免大文件上传被 120s 超时打断后回退到下载陈旧 release。
+    remote_server::ssh::scp_upload(
+        socket_path,
+        &local_binary,
+        &remote_binary,
+        remote_server::setup::DEV_UPLOAD_TIMEOUT,
+    )
+    .await?;
+
+    // 赋予可执行权限。
+    let chmod_output = remote_server::ssh::run_ssh_command(
+        socket_path,
+        &format!("chmod 755 {remote_binary}"),
+        remote_server::setup::CHECK_TIMEOUT,
+    )
+    .await?;
+    if !chmod_output.status.success() {
+        let code = chmod_output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&chmod_output.stderr);
+        return Err(anyhow!("远端 chmod 失败(exit {code}): {stderr}"));
+    }
+
+    // 复用既有校验逻辑确认上传的二进制可运行。
+    verify_installed_binary(socket_path).await
+}
+
 async fn download_remote_server_tarball(download_url: &str, tarball_path: &Path) -> Result<()> {
     let output = async {
         command::r#async::Command::new("curl")
@@ -341,6 +643,24 @@ impl RemoteTransport for SshTransport {
                 "Installing remote server binary to {}",
                 remote_server::setup::remote_server_binary()
             );
+
+            // OpenWarp fork:DEBUG 源码构建(无 release tag)走开发模式,
+            // 交叉编译本地 `warp` 并上传,而不是下载陈旧的 GitHub release。
+            // 失败时(交叉编译前置条件缺失等)打印告警并回退到下载安装,
+            // 保证 dev 体验不被破坏。release 构建跳过整段逻辑,行为不变。
+            if remote_server::setup::is_dev_source_build() {
+                log::info!("dev remote-server: 检测到 DEBUG 源码构建,改用本地交叉编译安装");
+                match dev_install_local_binary(&socket_path).await {
+                    Ok(()) => return Ok(()),
+                    Err(error) => {
+                        log::warn!(
+                            "dev remote-server: 本地交叉编译安装不可用,回退到下载安装: {error:#}"
+                        );
+                        // 落空,继续走下方常规下载安装流程。
+                    }
+                }
+            }
+
             match run_install_script(&socket_path, None, remote_server::setup::INSTALL_TIMEOUT)
                 .await
             {

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -174,6 +174,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+                | RemoteServerManagerEvent::BufferUpdated { .. }
                 | RemoteServerManagerEvent::BinaryCheckComplete { .. }
                 | RemoteServerManagerEvent::BinaryInstallComplete { .. }
                 | RemoteServerManagerEvent::ClientRequestFailed { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2393,15 +2393,17 @@ pub struct TerminalView {
 
     /// OpenWarp:远端 SSH 会话的 cwd 目录列表缓存,用于精确校验终端文件链接。
     ///
-    /// 键是远端 cwd 绝对路径,值为该目录的真实子项列表;`None` 表示该 cwd
-    /// 的列表正在异步拉取中(daemon `ListDirectory` RPC)。仅保留少量条目
-    /// (拉取新 cwd 时清掉旧的),保持有界。本地会话永不写入此缓存。
+    /// 键是 `(session_id, cwd 绝对路径)`,值为该目录的真实子项列表;`None`
+    /// 表示该 cwd 的列表正在异步拉取中(daemon `ListDirectory` RPC)。
+    /// 用 `IndexMap` 保持插入顺序,容量上限定义在
+    /// `link_detection::remote_dir_listing_context` 中的 `MAX_ENTRIES`,
+    /// 拉取新 cwd 触发 FIFO 淘汰。本地会话永不写入此缓存。
     #[cfg(all(
         feature = "local_tty",
         feature = "local_fs",
         not(target_family = "wasm")
     ))]
-    remote_dir_listing_cache: HashMap<
+    remote_dir_listing_cache: indexmap::IndexMap<
         (warp_core::SessionId, PathBuf),
         Option<std::sync::Arc<crate::util::file::RemoteDirListing>>,
     >,
@@ -3814,7 +3816,7 @@ impl TerminalView {
                 feature = "local_fs",
                 not(target_family = "wasm")
             ))]
-            remote_dir_listing_cache: HashMap::new(),
+            remote_dir_listing_cache: indexmap::IndexMap::new(),
             last_focus_ts: None,
             tips_completed: resources.tips_completed.clone(),
             was_ever_visible: false,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2401,8 +2401,10 @@ pub struct TerminalView {
         feature = "local_fs",
         not(target_family = "wasm")
     ))]
-    remote_dir_listing_cache:
-        HashMap<PathBuf, Option<std::sync::Arc<crate::util::file::RemoteDirListing>>>,
+    remote_dir_listing_cache: HashMap<
+        (warp_core::SessionId, PathBuf),
+        Option<std::sync::Arc<crate::util::file::RemoteDirListing>>,
+    >,
 
     last_focus_ts: Option<NaiveDateTime>,
     tips_completed: ModelHandle<TipsCompleted>,
@@ -15735,10 +15737,14 @@ impl TerminalView {
         feature = "local_fs",
         not(target_family = "wasm")
     ))]
-    fn remote_clicked_path_is_dir(&self, path: &std::path::Path) -> bool {
+    fn remote_clicked_path_is_dir(
+        &self,
+        session_id: warp_core::SessionId,
+        path: &std::path::Path,
+    ) -> bool {
         path.parent().is_some_and(|parent| {
             self.remote_dir_listing_cache
-                .get(parent)
+                .get(&(session_id, parent.to_path_buf()))
                 .and_then(|entry| entry.as_ref())
                 .is_some_and(|listing| crate::util::file::remote_path_is_dir(path, listing))
         })
@@ -15750,9 +15756,10 @@ impl TerminalView {
     /// 在该远端 shell 会话中执行 `cd <dir>`。
     #[cfg(all(feature = "local_tty", feature = "local_fs"))]
     fn cd_into_remote_directory(&mut self, path: &std::path::Path, ctx: &mut ViewContext<Self>) {
-        let dir = path.to_string_lossy();
+        // 对路径做 shell 转义,防止包含 `"`、`$(...)`、反引号等字符时被远端 shell 执行注入命令。
+        let quoted_dir = shell_words::quote(&path.to_string_lossy()).into_owned();
         self.input.update(ctx, |input, ctx| {
-            input.try_execute_command(format!("cd \"{dir}\"").as_str(), ctx);
+            input.try_execute_command(format!("cd -- {quoted_dir}").as_str(), ctx);
         });
     }
 
@@ -15770,9 +15777,11 @@ impl TerminalView {
         if let Some(host_id) = self.active_session_remote_host_id(ctx) {
             // 远端目录点击:不在编辑器里打开,改为在该远端会话里 `cd` 进去。
             #[cfg(not(target_family = "wasm"))]
-            if self.remote_clicked_path_is_dir(&path) {
-                self.cd_into_remote_directory(&path, ctx);
-                return;
+            if let Some(session_id) = self.active_block_session_id() {
+                if self.remote_clicked_path_is_dir(session_id, &path) {
+                    self.cd_into_remote_directory(&path, ctx);
+                    return;
+                }
             }
             if let Some(remote_path) = Self::remote_path_from_terminal_path(host_id, &path) {
                 ctx.emit(Event::OpenRemoteFileFromTerminal {
@@ -15809,9 +15818,11 @@ impl TerminalView {
         if let Some(host_id) = self.active_session_remote_host_id(ctx) {
             // 远端目录点击:不在编辑器里打开,改为在该远端会话里 `cd` 进去。
             #[cfg(not(target_family = "wasm"))]
-            if self.remote_clicked_path_is_dir(&path) {
-                self.cd_into_remote_directory(&path, ctx);
-                return;
+            if let Some(session_id) = self.active_block_session_id() {
+                if self.remote_clicked_path_is_dir(session_id, &path) {
+                    self.cd_into_remote_directory(&path, ctx);
+                    return;
+                }
             }
             if let Some(remote_path) = Self::remote_path_from_terminal_path(host_id, &path) {
                 ctx.emit(Event::OpenRemoteFileFromTerminal {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1784,6 +1784,13 @@ pub enum Event {
         target: FileTarget,
         line_col: Option<LineAndColumnArg>,
     },
+    /// OpenWarp:终端里 Ctrl/Cmd+点击远端 SSH 会话输出中的文件路径时发出。
+    /// 走 buffer-sync 协议在编辑器里打开远端文件,而不是本地 `OpenFileWithTarget`。
+    #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+    OpenRemoteFileFromTerminal {
+        remote_path: crate::code::buffer_location::RemotePath,
+        line_col: Option<LineAndColumnArg>,
+    },
     /// Emitted when a file in the file tree is renamed.
     #[cfg(feature = "local_fs")]
     FileRenamed {
@@ -2383,6 +2390,19 @@ pub struct TerminalView {
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     file_link_scanning_join_handle: Option<JoinHandle<()>>,
+
+    /// OpenWarp:远端 SSH 会话的 cwd 目录列表缓存,用于精确校验终端文件链接。
+    ///
+    /// 键是远端 cwd 绝对路径,值为该目录的真实子项列表;`None` 表示该 cwd
+    /// 的列表正在异步拉取中(daemon `ListDirectory` RPC)。仅保留少量条目
+    /// (拉取新 cwd 时清掉旧的),保持有界。本地会话永不写入此缓存。
+    #[cfg(all(
+        feature = "local_tty",
+        feature = "local_fs",
+        not(target_family = "wasm")
+    ))]
+    remote_dir_listing_cache:
+        HashMap<PathBuf, Option<std::sync::Arc<crate::util::file::RemoteDirListing>>>,
 
     last_focus_ts: Option<NaiveDateTime>,
     tips_completed: ModelHandle<TipsCompleted>,
@@ -3787,6 +3807,12 @@ impl TerminalView {
             inline_banners_state: Default::default(),
             bookmarked_blocks: Default::default(),
             file_link_scanning_join_handle: None,
+            #[cfg(all(
+                feature = "local_tty",
+                feature = "local_fs",
+                not(target_family = "wasm")
+            ))]
+            remote_dir_listing_cache: HashMap::new(),
             last_focus_ts: None,
             tips_completed: resources.tips_completed.clone(),
             was_ever_visible: false,
@@ -15659,6 +15685,77 @@ impl TerminalView {
         }
     }
 
+    /// OpenWarp:若当前活动 block 所属会话是 remote-server 会话,返回其 `HostId`。
+    ///
+    /// 用于在终端里 Ctrl/Cmd+点击文件路径时,判断应当走本地还是远端 buffer-sync
+    /// 打开流程。非 remote-server 会话返回 `None`(保持本地行为不变)。
+    #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+    fn active_session_remote_host_id(&self, ctx: &AppContext) -> Option<warp_core::HostId> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            if !FeatureFlag::SshRemoteServer.is_enabled() {
+                return None;
+            }
+            let session_id = self.active_block_session_id()?;
+            let mgr = RemoteServerManager::handle(ctx);
+            mgr.as_ref(ctx).host_id_for_session(session_id).cloned()
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = ctx;
+            None
+        }
+    }
+
+    /// OpenWarp:把终端文件链接里已解析出的绝对路径当作远端路径,构造 `RemotePath`。
+    /// 远端 SSH 主机均为 Unix,路径字符串由 shell-integration 上报的远端 cwd 拼接而来。
+    #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+    fn remote_path_from_terminal_path(
+        host_id: warp_core::HostId,
+        path: &std::path::Path,
+    ) -> Option<crate::code::buffer_location::RemotePath> {
+        let path_str = path.to_str()?;
+        let standardized = warp_util::standardized_path::StandardizedPath::try_new(path_str)
+            .map_err(|e| {
+                log::warn!("无法将终端文件路径转换为远端路径 {path_str:?}: {e}");
+            })
+            .ok()?;
+        Some(crate::code::buffer_location::RemotePath::new(
+            host_id,
+            standardized,
+        ))
+    }
+
+    /// OpenWarp:判断终端文件链接里的远端路径是否指向目录。
+    ///
+    /// 依据是缓存下来的远端 cwd 目录列表(由 `link_detection.rs` 拉取并写入)。
+    /// 未缓存或非目录返回 `false`(按文件处理)。
+    #[cfg(all(
+        feature = "local_tty",
+        feature = "local_fs",
+        not(target_family = "wasm")
+    ))]
+    fn remote_clicked_path_is_dir(&self, path: &std::path::Path) -> bool {
+        path.parent().is_some_and(|parent| {
+            self.remote_dir_listing_cache
+                .get(parent)
+                .and_then(|entry| entry.as_ref())
+                .is_some_and(|listing| crate::util::file::remote_path_is_dir(path, listing))
+        })
+    }
+
+    /// OpenWarp:在当前(远端)终端会话里 `cd` 进指定目录。
+    ///
+    /// 与本地点击目录链接的行为对齐 —— 远端目录无法在编辑器里打开,改为
+    /// 在该远端 shell 会话中执行 `cd <dir>`。
+    #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+    fn cd_into_remote_directory(&mut self, path: &std::path::Path, ctx: &mut ViewContext<Self>) {
+        let dir = path.to_string_lossy();
+        self.input.update(ctx, |input, ctx| {
+            input.try_execute_command(format!("cd \"{dir}\"").as_str(), ctx);
+        });
+    }
+
     #[cfg(feature = "local_fs")]
     fn open_file_path(
         &mut self,
@@ -15667,6 +15764,24 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         ctx.notify();
+
+        // OpenWarp:远端 SSH 会话走 buffer-sync 协议打开远端文件。
+        #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+        if let Some(host_id) = self.active_session_remote_host_id(ctx) {
+            // 远端目录点击:不在编辑器里打开,改为在该远端会话里 `cd` 进去。
+            #[cfg(not(target_family = "wasm"))]
+            if self.remote_clicked_path_is_dir(&path) {
+                self.cd_into_remote_directory(&path, ctx);
+                return;
+            }
+            if let Some(remote_path) = Self::remote_path_from_terminal_path(host_id, &path) {
+                ctx.emit(Event::OpenRemoteFileFromTerminal {
+                    remote_path,
+                    line_col: line_and_column_num,
+                });
+            }
+            return;
+        }
 
         let settings = EditorSettings::as_ref(ctx);
         let target = resolve_file_target(&path, settings, None);
@@ -15687,6 +15802,26 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         ctx.notify();
+
+        // OpenWarp:远端 SSH 会话走 buffer-sync 协议打开远端文件。
+        // 远端文件统一在内嵌代码编辑器打开,忽略 `target`(外部编辑器无法访问远端文件)。
+        #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+        if let Some(host_id) = self.active_session_remote_host_id(ctx) {
+            // 远端目录点击:不在编辑器里打开,改为在该远端会话里 `cd` 进去。
+            #[cfg(not(target_family = "wasm"))]
+            if self.remote_clicked_path_is_dir(&path) {
+                self.cd_into_remote_directory(&path, ctx);
+                return;
+            }
+            if let Some(remote_path) = Self::remote_path_from_terminal_path(host_id, &path) {
+                ctx.emit(Event::OpenRemoteFileFromTerminal {
+                    remote_path,
+                    line_col: line_and_column_num,
+                });
+            }
+            return;
+        }
+
         ctx.emit(Event::OpenFileWithTarget {
             path,
             target,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4110,6 +4110,7 @@ impl TerminalView {
                     | RemoteServerManagerEvent::HostDisconnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                    | RemoteServerManagerEvent::BufferUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. } => {}
                 }
             });

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -490,9 +490,11 @@ impl super::TerminalView {
         use crate::util::file::{LinkValidationContext, RemoteDirListing};
 
         let cwd_path = PathBuf::from(cwd);
+        // 缓存按 (会话, cwd) 复合键索引,避免不同 host 的相同路径互相串扰。
+        let cache_key = (session_id, cwd_path.clone());
 
         // 命中缓存(已就绪或拉取中)直接返回。
-        if let Some(entry) = self.remote_dir_listing_cache.get(&cwd_path) {
+        if let Some(entry) = self.remote_dir_listing_cache.get(&cache_key) {
             return LinkValidationContext::Remote(entry.clone());
         }
 
@@ -507,17 +509,19 @@ impl super::TerminalView {
 
         // 拉取新 cwd:清掉旧条目保持有界,插入 `None` 占位(标记拉取中)。
         self.remote_dir_listing_cache.clear();
-        self.remote_dir_listing_cache.insert(cwd_path.clone(), None);
+        self.remote_dir_listing_cache
+            .insert(cache_key.clone(), None);
 
         let cwd_for_request = cwd.to_string();
         let cwd_for_store = cwd_path.clone();
+        let key_for_store = cache_key.clone();
         ctx.spawn(
             async move { client.list_directory(cwd_for_request).await },
             move |me, result, ctx| {
                 use crate::remote_server::proto::list_directory_response;
 
                 // 拉取期间用户可能已经切换 cwd / 清空缓存,只有占位还在才写入。
-                if !me.remote_dir_listing_cache.contains_key(&cwd_for_store) {
+                if !me.remote_dir_listing_cache.contains_key(&key_for_store) {
                     return;
                 }
                 match result {
@@ -531,7 +535,7 @@ impl super::TerminalView {
                             let listing =
                                 Arc::new(RemoteDirListing::new(cwd_for_store.clone(), entries));
                             me.remote_dir_listing_cache
-                                .insert(cwd_for_store.clone(), Some(listing));
+                                .insert(key_for_store.clone(), Some(listing));
                             // 列表到达,触发 re-render 让链接重新扫描并点亮。
                             ctx.notify();
                         }
@@ -541,15 +545,15 @@ impl super::TerminalView {
                                 err.message
                             );
                             // 拉取失败:移除占位,下次悬停时会重试。
-                            me.remote_dir_listing_cache.remove(&cwd_for_store);
+                            me.remote_dir_listing_cache.remove(&key_for_store);
                         }
                         None => {
-                            me.remote_dir_listing_cache.remove(&cwd_for_store);
+                            me.remote_dir_listing_cache.remove(&key_for_store);
                         }
                     },
                     Err(err) => {
                         log::warn!("远端 ListDirectory RPC 出错 {cwd_for_store:?}: {err}");
-                        me.remote_dir_listing_cache.remove(&cwd_for_store);
+                        me.remote_dir_listing_cache.remove(&key_for_store);
                     }
                 }
             },
@@ -619,10 +623,11 @@ impl super::TerminalView {
             Some(path) if matches!(from_editor, TerminalEditor::No) => {
                 let possible_paths = self.model.lock().possible_file_paths_at_point(position);
                 let max_columns = self.size_info.columns;
-                let shell_launch_data = self
-                    .active_block_session_id()
-                    .and_then(|active_session_id| self.sessions.as_ref(ctx).get(active_session_id))
-                    .and_then(|active_session| active_session.launch_data().cloned());
+                // 用被悬停 block 自己的 launch data,避免跨会话/host/WSL 时
+                // 用错 shell 规则解析路径。
+                let shell_launch_data = block_session_id
+                    .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
+                    .and_then(|session| session.launch_data().cloned());
 
                 // Using the thread builder instead of ctx.spawn here so that the previous
                 // scanning job will be dropped once there is a new scanning job created.

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -507,8 +507,14 @@ impl super::TerminalView {
             return LinkValidationContext::Remote(None);
         };
 
-        // 拉取新 cwd:清掉旧条目保持有界,插入 `None` 占位(标记拉取中)。
-        self.remote_dir_listing_cache.clear();
+        // 拉取新 cwd:超出容量上限时按插入顺序 FIFO 淘汰最旧条目,
+        // 然后插入 `None` 占位(标记拉取中)。`MAX_ENTRIES` 选 8 足够覆盖
+        // 用户在终端里常切的几个工作目录,避免每次切回都要 RPC。
+        const MAX_ENTRIES: usize = 8;
+        while self.remote_dir_listing_cache.len() >= MAX_ENTRIES {
+            // shift_remove_index 保持插入顺序;FIFO 头部是最旧的。
+            self.remote_dir_listing_cache.shift_remove_index(0);
+        }
         self.remote_dir_listing_cache
             .insert(cache_key.clone(), None);
 
@@ -545,15 +551,15 @@ impl super::TerminalView {
                                 err.message
                             );
                             // 拉取失败:移除占位,下次悬停时会重试。
-                            me.remote_dir_listing_cache.remove(&key_for_store);
+                            me.remote_dir_listing_cache.shift_remove(&key_for_store);
                         }
                         None => {
-                            me.remote_dir_listing_cache.remove(&key_for_store);
+                            me.remote_dir_listing_cache.shift_remove(&key_for_store);
                         }
                     },
                     Err(err) => {
                         log::warn!("远端 ListDirectory RPC 出错 {cwd_for_store:?}: {err}");
-                        me.remote_dir_listing_cache.remove(&key_for_store);
+                        me.remote_dir_listing_cache.shift_remove(&key_for_store);
                     }
                 }
             },

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -433,6 +433,131 @@ impl super::TerminalView {
 // where we can spawn a local tty.
 #[cfg(feature = "local_fs")]
 impl super::TerminalView {
+    /// OpenWarp:判断给定会话是否是 remote-server(SSH)会话。
+    ///
+    /// 当 `local_tty` 未启用 / 在 wasm 上 / `SshRemoteServer` feature flag 关闭时,
+    /// 一律返回 `false`,即保持本地行为完全不变。
+    fn session_is_remote(
+        &self,
+        session_id: Option<crate::terminal::model::session::SessionId>,
+        ctx: &warpui::AppContext,
+    ) -> bool {
+        #[cfg(all(feature = "local_tty", not(target_family = "wasm")))]
+        {
+            use warpui::SingletonEntity as _;
+
+            use crate::features::FeatureFlag;
+            use crate::remote_server::manager::RemoteServerManager;
+
+            if FeatureFlag::SshRemoteServer.is_enabled() {
+                if let Some(session_id) = session_id {
+                    return RemoteServerManager::handle(ctx)
+                        .as_ref(ctx)
+                        .host_id_for_session(session_id)
+                        .is_some();
+                }
+            }
+        }
+
+        let _ = (session_id, ctx);
+        false
+    }
+
+    /// OpenWarp:取得远端会话某个 cwd 的目录列表校验上下文。
+    ///
+    /// 命中缓存则直接返回 `Remote(Some(..))`;未命中则异步发起 daemon
+    /// `ListDirectory` RPC 拉取该目录列表,本轮返回 `Remote(None)`(不高亮),
+    /// 拉取完成后写入缓存并 `ctx.notify()` 触发 re-render 把链接点亮。
+    ///
+    /// 缓存保持有界:拉取新 cwd 时清掉所有旧条目,只保留当前 cwd。
+    #[cfg(all(
+        feature = "local_tty",
+        feature = "local_fs",
+        not(target_family = "wasm")
+    ))]
+    fn remote_dir_listing_context(
+        &mut self,
+        session_id: crate::terminal::model::session::SessionId,
+        cwd: &str,
+        ctx: &mut ViewContext<Self>,
+    ) -> crate::util::file::LinkValidationContext {
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        use warpui::SingletonEntity as _;
+
+        use crate::remote_server::manager::RemoteServerManager;
+        use crate::util::file::{LinkValidationContext, RemoteDirListing};
+
+        let cwd_path = PathBuf::from(cwd);
+
+        // 命中缓存(已就绪或拉取中)直接返回。
+        if let Some(entry) = self.remote_dir_listing_cache.get(&cwd_path) {
+            return LinkValidationContext::Remote(entry.clone());
+        }
+
+        // 取该会话的 daemon 客户端。
+        let Some(client) = RemoteServerManager::handle(ctx)
+            .as_ref(ctx)
+            .client_for_session(session_id)
+            .cloned()
+        else {
+            return LinkValidationContext::Remote(None);
+        };
+
+        // 拉取新 cwd:清掉旧条目保持有界,插入 `None` 占位(标记拉取中)。
+        self.remote_dir_listing_cache.clear();
+        self.remote_dir_listing_cache.insert(cwd_path.clone(), None);
+
+        let cwd_for_request = cwd.to_string();
+        let cwd_for_store = cwd_path.clone();
+        ctx.spawn(
+            async move { client.list_directory(cwd_for_request).await },
+            move |me, result, ctx| {
+                use crate::remote_server::proto::list_directory_response;
+
+                // 拉取期间用户可能已经切换 cwd / 清空缓存,只有占位还在才写入。
+                if !me.remote_dir_listing_cache.contains_key(&cwd_for_store) {
+                    return;
+                }
+                match result {
+                    Ok(resp) => match resp.result {
+                        Some(list_directory_response::Result::Success(success)) => {
+                            let entries = success
+                                .entries
+                                .into_iter()
+                                .map(|e| (e.name, e.is_dir))
+                                .collect();
+                            let listing =
+                                Arc::new(RemoteDirListing::new(cwd_for_store.clone(), entries));
+                            me.remote_dir_listing_cache
+                                .insert(cwd_for_store.clone(), Some(listing));
+                            // 列表到达,触发 re-render 让链接重新扫描并点亮。
+                            ctx.notify();
+                        }
+                        Some(list_directory_response::Result::Error(err)) => {
+                            log::warn!(
+                                "远端 ListDirectory 失败 {cwd_for_store:?}: {}",
+                                err.message
+                            );
+                            // 拉取失败:移除占位,下次悬停时会重试。
+                            me.remote_dir_listing_cache.remove(&cwd_for_store);
+                        }
+                        None => {
+                            me.remote_dir_listing_cache.remove(&cwd_for_store);
+                        }
+                    },
+                    Err(err) => {
+                        log::warn!("远端 ListDirectory RPC 出错 {cwd_for_store:?}: {err}");
+                        me.remote_dir_listing_cache.remove(&cwd_for_store);
+                    }
+                }
+            },
+        );
+
+        LinkValidationContext::Remote(None)
+    }
+
     /// Scans the terminal model at the given position to see if it is
     /// contained within a path that should be linkified.
     fn scan_for_file_path(
@@ -441,17 +566,51 @@ impl super::TerminalView {
         from_editor: TerminalEditor,
         ctx: &mut ViewContext<Self>,
     ) {
-        // For AltScreen we scan for relative path with the current working directory.
-        // For BlockList we scan for relative path with the pwd of the hovered block.
-        let pwd_to_scan_for = match position {
-            WithinModel::AltScreen(_) => self.pwd_if_local(ctx),
+        use crate::util::file::LinkValidationContext;
+
+        // OpenWarp:判断被悬停 block 所属会话是否是 remote-server 会话。
+        // 远端会话的文件不在本地磁盘上,需要用 `LinkValidationContext::Remote`
+        // 携带 daemon 拉取来的真实目录列表做精确校验。
+        let block_session_id = match position {
+            WithinModel::AltScreen(_) => self.active_block_session_id(),
             WithinModel::BlockList(inner) => self
                 .model
                 .lock()
                 .block_list()
                 .block_at(inner.block_index)
-                .filter(|block| !self.is_block_considered_remote(block.session_id(), None, ctx)) // Don't scan for file links if the block is on remote sessions
+                .and_then(|block| block.session_id()),
+        };
+        let is_remote = self.session_is_remote(block_session_id, ctx);
+
+        // For AltScreen we scan for relative path with the current working directory.
+        // For BlockList we scan for relative path with the pwd of the hovered block.
+        //
+        // OpenWarp:远端会话的 block `pwd()` 是 shell-integration 上报的远端 cwd,
+        // 拼接后即得到正确的远端绝对路径,因此远端 block 也参与扫描(不再跳过)。
+        let pwd_to_scan_for = match position {
+            WithinModel::AltScreen(_) => {
+                if is_remote {
+                    // 远端会话:`pwd()` 返回的是 shell-integration 上报的远端活动 cwd。
+                    self.pwd()
+                } else {
+                    self.pwd_if_local(ctx)
+                }
+            }
+            WithinModel::BlockList(inner) => self
+                .model
+                .lock()
+                .block_list()
+                .block_at(inner.block_index)
                 .and_then(|block| block.pwd().map(String::from)),
+        };
+
+        // OpenWarp:远端会话用缓存的 cwd 目录列表精确校验;本地会话保持 `Local`。
+        let validation_ctx = match (&pwd_to_scan_for, block_session_id) {
+            #[cfg(all(feature = "local_tty", not(target_family = "wasm")))]
+            (Some(cwd), Some(session_id)) if is_remote => {
+                self.remote_dir_listing_context(session_id, cwd, ctx)
+            }
+            _ => LinkValidationContext::Local,
         };
 
         match pwd_to_scan_for {
@@ -476,6 +635,7 @@ impl super::TerminalView {
                             possible_paths,
                             max_columns,
                             shell_launch_data,
+                            validation_ctx,
                         );
                         let _ = tx.send(paths);
                     })
@@ -502,6 +662,7 @@ impl super::TerminalView {
         possible_paths: impl Iterator<Item = WithinModel<grid_handler::PossiblePath>>,
         max_columns: usize,
         shell_launch_data: Option<ShellLaunchData>,
+        validation_ctx: crate::util::file::LinkValidationContext,
     ) -> Option<GridHighlightedLink> {
         let mut link = None;
         'path_loop: for within_model_possible_path in possible_paths {
@@ -512,6 +673,7 @@ impl super::TerminalView {
                 &possible_path.path,
                 ShellPathType::ShellNative(working_directory.to_string()),
                 shell_launch_data.as_ref(),
+                &validation_ctx,
             );
 
             if let Some(absolute_path) = absolute_path {
@@ -534,6 +696,7 @@ impl super::TerminalView {
                         &new_possible_cleaned_path,
                         ShellPathType::ShellNative(working_directory.to_string()),
                         shell_launch_data.as_ref(),
+                        &validation_ctx,
                     );
 
                     // check if new_possible_path is valid
@@ -566,6 +729,7 @@ impl super::TerminalView {
                         &new_possible_cleaned_path,
                         ShellPathType::ShellNative(working_directory.to_string()),
                         shell_launch_data.as_ref(),
+                        &validation_ctx,
                     );
 
                     // check if new_possible_path is valid

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -143,6 +143,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::BufferUpdated { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::ClientRequestFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. } => {}

--- a/app/src/util/file.rs
+++ b/app/src/util/file.rs
@@ -1,7 +1,9 @@
 pub mod external_editor;
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[cfg(windows)]
 use warp_util::path::is_network_resource;
@@ -28,11 +30,48 @@ pub enum ShellPathType {
     PlatformNative(PathBuf),
 }
 
+/// OpenWarp:某个远端目录(cwd)下真实子项的快照。
+///
+/// 由 daemon 的 `ListDirectory` RPC 返回的结果填充。终端链接检测器
+/// 在远端会话里用它做精确校验:把 `ls -l` 整行候选子串里真正的文件名
+/// 切出来 —— 这正是本地会话里 `fs::metadata` 存在性校验所起的作用。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoteDirListing {
+    /// 该目录的绝对路径(远端 cwd)。
+    pub dir: PathBuf,
+    /// 目录下的直接子项:文件名 -> 是否为目录。
+    pub entries: HashMap<String, bool>,
+}
+
+impl RemoteDirListing {
+    pub fn new(dir: PathBuf, entries: HashMap<String, bool>) -> Self {
+        Self { dir, entries }
+    }
+}
+
+/// OpenWarp:终端文件链接的校验来源。
+///
+/// 本地会话用本地文件系统 `fs::metadata` 判断路径是否存在;远端 SSH
+/// (remote-server)会话的文件不在本地磁盘上,本地校验必然失败,因此远端
+/// 会话改用 daemon `ListDirectory` RPC 缓存下来的真实目录列表做精确校验。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum LinkValidationContext {
+    /// 本地会话:用本地文件系统校验路径是否真实存在。
+    #[default]
+    Local,
+    /// 远端 SSH 会话:用缓存下来的远端 cwd 目录列表精确校验。
+    ///
+    /// `None` 表示该 cwd 的目录列表尚未缓存(异步拉取中或拉取失败),
+    /// 此时本轮校验一律视为"无效"(不高亮),等列表到达后 re-render 再点亮。
+    Remote(Option<Arc<RemoteDirListing>>),
+}
+
 /// Checks if a file path exists and is valid for a file link.
 pub fn absolute_path_if_valid(
     clean_path_result: &CleanPathResult,
     working_directory: ShellPathType,
     shell_launch_data: Option<&ShellLaunchData>,
+    validation_ctx: &LinkValidationContext,
 ) -> Option<PathBuf> {
     let (maybe_absolute_path, relative_path) = match shell_launch_data {
         Some(shell_launch_data) => {
@@ -65,12 +104,12 @@ pub fn absolute_path_if_valid(
 
     if relative_path
         .as_ref()
-        .is_some_and(|path| is_path_valid(path, clean_path_result))
+        .is_some_and(|path| is_path_valid(path, clean_path_result, validation_ctx))
     {
         return relative_path;
     } else if maybe_absolute_path
         .as_ref()
-        .is_some_and(|path| is_path_valid(path, clean_path_result))
+        .is_some_and(|path| is_path_valid(path, clean_path_result, validation_ctx))
     {
         return maybe_absolute_path;
     }
@@ -78,12 +117,40 @@ pub fn absolute_path_if_valid(
     None
 }
 
-fn is_path_valid(path: &Path, clean_path_result: &CleanPathResult) -> bool {
+fn is_path_valid(
+    path: &Path,
+    clean_path_result: &CleanPathResult,
+    validation_ctx: &LinkValidationContext,
+) -> bool {
     // Checking for the existence of a network resource takes a long time (~15s),
     // and hangs the UI, so we skip validating it.
     #[cfg(windows)]
     if is_network_resource(path) {
         return false;
+    }
+
+    // OpenWarp:远端 SSH 会话的文件不在本地磁盘上,`fs::metadata` 必然失败。
+    // 改用 daemon `ListDirectory` 缓存下来的真实目录列表精确校验:候选解析
+    // 路径有效 ⇔ 其父目录恰好等于缓存的 cwd 且其文件名是该目录下的已知子项。
+    // 这给链接检测器的子串搜索提供了和本地 `fs::metadata` 等价的消歧依据,
+    // 能从 `ls -l` 整行里准确切出真正的文件名。
+    if let LinkValidationContext::Remote(listing) = validation_ctx {
+        // cwd 列表尚未缓存(异步拉取中/失败):本轮视为无效,等列表到达后再点亮。
+        let Some(listing) = listing else {
+            return false;
+        };
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            return false;
+        };
+        // 父目录必须正好是缓存的那个 cwd。
+        if path.parent() != Some(listing.dir.as_path()) {
+            return false;
+        }
+        let Some(&is_dir) = listing.entries.get(file_name) else {
+            return false;
+        };
+        // 与本地一致:带行列号时不能是目录。
+        return !is_dir || clean_path_result.line_and_column_num.is_none();
     }
 
     // It should only be a valid path if the path links to a file or a folder without
@@ -92,6 +159,21 @@ fn is_path_valid(path: &Path, clean_path_result: &CleanPathResult) -> bool {
         return false;
     };
     metadata.is_file() || (metadata.is_dir() && clean_path_result.line_and_column_num.is_none())
+}
+
+/// OpenWarp:判断一个已解析的远端路径是否指向目录。
+///
+/// 仅在远端会话点击链接、需要决定"打开文件 vs `cd` 进目录"时调用;
+/// 依据是缓存下来的远端 cwd 目录列表。列表未缓存或路径不在其中时返回
+/// `false`(按文件处理,与不缓存时的保守行为一致)。
+pub fn remote_path_is_dir(path: &Path, listing: &RemoteDirListing) -> bool {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if path.parent() != Some(listing.dir.as_path()) {
+        return false;
+    }
+    listing.entries.get(file_name).copied().unwrap_or(false)
 }
 
 impl FilePathType {

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -302,7 +302,7 @@ fn compute_valid_file_path(
     files_and_folders_in_working_directory: &HashSet<PathBuf>,
     shell_launch_data: Option<&crate::terminal::ShellLaunchData>,
 ) -> Option<DetectedLinkType> {
-    use crate::util::file::{absolute_path_if_valid, ShellPathType};
+    use crate::util::file::{absolute_path_if_valid, LinkValidationContext, ShellPathType};
     // Scan for line and column number in the current word (left + right).
     let cleaned_path = CleanPathResult::with_line_and_column_number(expanded_path);
 
@@ -325,6 +325,7 @@ fn compute_valid_file_path(
         &cleaned_path,
         ShellPathType::PlatformNative(working_directory.to_owned()),
         shell_launch_data,
+        &LinkValidationContext::Local,
     );
 
     absolute_path.map(|absolute_path| DetectedLinkType::FilePath {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5314,9 +5314,9 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         log::info!(
-            "Opening remote file: host={} path={}",
-            remote_path.host_id,
-            remote_path.path.as_str()
+            "Opening remote file: host={host} path={path}",
+            host = remote_path.host_id,
+            path = remote_path.path.as_str()
         );
 
         let layout = *EditorSettings::as_ref(ctx).open_file_layout.value();

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5301,6 +5301,18 @@ impl Workspace {
         remote_path: crate::code::buffer_location::RemotePath,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.open_remote_file_with_target(remote_path, None, ctx);
+    }
+
+    /// 与 [`Self::open_remote_file`] 相同,但可携带 `line_col`(行:列跳转)。
+    /// 终端里 Ctrl/Cmd+点击远端文件路径时使用,把行号一路透传给 `open_code`。
+    #[cfg(feature = "local_tty")]
+    pub fn open_remote_file_with_target(
+        &mut self,
+        remote_path: crate::code::buffer_location::RemotePath,
+        line_col: Option<LineAndColumnArg>,
+        ctx: &mut ViewContext<Self>,
+    ) {
         log::info!(
             "Opening remote file: host={} path={}",
             remote_path.host_id,
@@ -5311,7 +5323,7 @@ impl Workspace {
         self.open_code(
             CodeSource::RemoteFileTree { remote_path },
             layout,
-            None,  /* line_col */
+            line_col,
             false, /* preview */
             &[],   /* additional_paths */
             ctx,
@@ -12887,6 +12899,14 @@ impl Workspace {
                     },
                     ctx,
                 );
+            }
+            // OpenWarp:终端里 Ctrl/Cmd+点击远端 SSH 文件路径,走 buffer-sync 协议打开。
+            #[cfg(all(feature = "local_tty", feature = "local_fs"))]
+            pane_group::Event::OpenRemoteFileFromTerminal {
+                remote_path,
+                line_col,
+            } => {
+                self.open_remote_file_with_target(remote_path.clone(), *line_col, ctx);
             }
             #[cfg(feature = "local_fs")]
             pane_group::Event::FileRenamed { old_path, new_path } => {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5214,6 +5214,12 @@ impl Workspace {
                     ctx,
                 );
             }
+            #[cfg(feature = "local_tty")]
+            LeftPanelEvent::OpenRemoteFile { remote_path } => {
+                self.open_remote_file(remote_path.clone(), ctx);
+            }
+            #[cfg(not(feature = "local_tty"))]
+            LeftPanelEvent::OpenRemoteFile { .. } => {}
             LeftPanelEvent::OpenSkillFile { source } => {
                 #[cfg(feature = "local_fs")]
                 {
@@ -5277,6 +5283,39 @@ impl Workspace {
                 ctx,
             );
         });
+    }
+
+    /// 在远端文件树里点击一个文件后,以 buffer-sync 协议打开它。
+    ///
+    /// 远端文件与本地文件统一走 [`Self::open_code`] / `CodePane` / `CodeView`:
+    /// 这样它就和本地文件一样遵守 `open_file_layout`(新 tab / 分屏)以及多文件
+    /// 分组开关(多个远端文件并入同一个代码编辑器 pane 的内部 tab)。
+    ///
+    /// buffer 内容仍由 `GlobalBufferModel` 的 `BufferLocation::Remote` 路径打开
+    /// (向 daemon 发 `OpenBuffer`,后续 `BufferEdit` / `BufferUpdatedPush` 同步),
+    /// 这一段由 `LocalCodeEditorView::new_with_remote_buffer` 在 `CodeView` 内部
+    /// 完成。
+    #[cfg(feature = "local_tty")]
+    pub fn open_remote_file(
+        &mut self,
+        remote_path: crate::code::buffer_location::RemotePath,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        log::info!(
+            "Opening remote file: host={} path={}",
+            remote_path.host_id,
+            remote_path.path.as_str()
+        );
+
+        let layout = *EditorSettings::as_ref(ctx).open_file_layout.value();
+        self.open_code(
+            CodeSource::RemoteFileTree { remote_path },
+            layout,
+            None,  /* line_col */
+            false, /* preview */
+            &[],   /* additional_paths */
+            ctx,
+        );
     }
 
     /// 在当前 tab 开新 terminal pane,自动跑 `ssh ...` 命令,并 spawn 一个
@@ -6676,15 +6715,21 @@ impl Workspace {
                         .is_pane_hidden_for_close(*pane_id)
                 });
             // If the tabbed editor view is enabled and there is an existing CodeView, we should group the newly opened file into this view.
-            if let (Some(path), Some((pane_id, code_view))) = (source.path(), code_view) {
+            if let (Some(location), Some((pane_id, code_view))) = (source.location(), code_view) {
                 code_view.update(ctx, |code_view, ctx| {
                     if preview {
-                        code_view.open_in_preview_or_promote_and_jump(path, line_col, ctx);
+                        code_view.open_in_preview_or_promote_and_jump(location, line_col, ctx);
                     } else {
-                        code_view.open_or_focus_existing(Some(path), line_col, ctx);
+                        code_view.open_or_focus_existing(Some(location), line_col, ctx);
                     }
                     for extra in additional_paths {
-                        code_view.open_or_focus_existing(Some(extra.clone()), None, ctx);
+                        code_view.open_or_focus_existing(
+                            Some(crate::code::buffer_location::BufferLocation::Local(
+                                extra.clone(),
+                            )),
+                            None,
+                            ctx,
+                        );
                     }
                 });
                 // Only focus the pane for non-preview opens
@@ -6698,10 +6743,10 @@ impl Workspace {
         } else {
             // When grouping is off, avoid opening duplicate code panes for the same file in the
             // current pane group. Instead, focus the existing pane and jump.
-            if let Some(path) = source.path() {
+            if let Some(location) = source.location() {
                 let pane_group_id = self.active_tab_pane_group().id();
                 let existing_locator = CodeManager::handle(ctx).read(ctx, |manager, _| {
-                    manager.get_locator_for_path_in_tab(pane_group_id, path.as_path())
+                    manager.get_locator_for_location_in_tab(pane_group_id, &location)
                 });
 
                 if let Some(locator) = existing_locator {
@@ -6714,13 +6759,13 @@ impl Workspace {
                             code_view.update(ctx, |code_view, ctx| {
                                 if preview {
                                     code_view.open_in_preview_or_promote_and_jump(
-                                        path.clone(),
+                                        location.clone(),
                                         line_col,
                                         ctx,
                                     );
                                 } else {
                                     code_view.open_or_focus_existing(
-                                        Some(path.clone()),
+                                        Some(location.clone()),
                                         line_col,
                                         ctx,
                                     );
@@ -6728,7 +6773,9 @@ impl Workspace {
 
                                 for extra in additional_paths {
                                     code_view.open_or_focus_existing(
-                                        Some(extra.clone()),
+                                        Some(crate::code::buffer_location::BufferLocation::Local(
+                                            extra.clone(),
+                                        )),
                                         None,
                                         ctx,
                                     );
@@ -6786,7 +6833,13 @@ impl Workspace {
             if let Some(code_view) = code_view_handle {
                 code_view.update(ctx, |code_view, ctx| {
                     for path in additional_paths {
-                        code_view.open_or_focus_existing(Some(path.clone()), None, ctx);
+                        code_view.open_or_focus_existing(
+                            Some(crate::code::buffer_location::BufferLocation::Local(
+                                path.clone(),
+                            )),
+                            None,
+                            ctx,
+                        );
                     }
                 });
             }
@@ -12429,23 +12482,25 @@ impl Workspace {
                                             return;
                                         }
 
-                                        let moved_file_path =
+                                        let moved_file_location =
                                             pane_group.update(ctx, |pane_group, ctx| {
                                                 pane_group.code_pane_by_id(*pane_id).and_then(
                                                     |pane| {
                                                         pane.file_view(ctx).update(
                                                             ctx,
                                                             |file_view, ctx| {
-                                                                let moved_file_path = file_view
+                                                                let moved_file_location = file_view
                                                                     .tab_at(*editor_tab_index)
-                                                                    .and_then(|t| t.path());
+                                                                    .and_then(|t| {
+                                                                        t.location().cloned()
+                                                                    });
 
                                                                 file_view.remove_tab_for_move(
                                                                     *editor_tab_index,
                                                                     ctx,
                                                                 );
 
-                                                                moved_file_path
+                                                                moved_file_location
                                                             },
                                                         )
                                                     },
@@ -12453,9 +12508,13 @@ impl Workspace {
                                             });
 
                                         // After removing the file from the origin's editor, we want to open it in the target's editor.
-                                        if let Some(path) = moved_file_path {
+                                        if let Some(location) = moved_file_location {
                                             target_code_view.update(ctx, |view, ctx| {
-                                                view.open_or_focus_existing(Some(path), None, ctx);
+                                                view.open_or_focus_existing(
+                                                    Some(location),
+                                                    None,
+                                                    ctx,
+                                                );
                                             });
                                         }
                                         return;

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -101,6 +101,11 @@ pub enum LeftPanelEvent {
     OpenSkillFile {
         source: CodeSource,
     },
+    /// 用户在远端文件树里点击一个文件 → 主窗口应以远端 buffer 方式打开它。
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    OpenRemoteFile {
+        remote_path: crate::code::buffer_location::RemotePath,
+    },
     NewConversationInNewTab,
     ShowDeleteConfirmationDialog {
         conversation_id: AIConversationId,
@@ -871,6 +876,14 @@ impl LeftPanelView {
                 ctx.emit(LeftPanelEvent::FileTree(
                     pane_group::Event::OpenDirectoryInNewTab { path: path.clone() },
                 ));
+            }
+            FileTreeEvent::OpenRemoteFile { remote_path } => {
+                #[cfg(feature = "local_tty")]
+                ctx.emit(LeftPanelEvent::OpenRemoteFile {
+                    remote_path: remote_path.clone(),
+                });
+                #[cfg(not(feature = "local_tty"))]
+                let _ = remote_path;
             }
         }
     }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -340,8 +340,18 @@ message OpenBufferResponse {
 // If the server accepts (expected_server_version matches its local version),
 // it applies the edit silently — no response needed since the client already
 // has the edit applied locally.
-// If the server rejects (version mismatch), it pushes a BufferUpdatedPush
-// with its current state.
+// If the server rejects (version mismatch), the edit is silently dropped;
+// the client discovers the divergence on the next file-watcher
+// BufferUpdatedPush that carries the server's current state. (The earlier
+// "server pushes BufferUpdatedPush on reject" wording did not match the
+// implementation and has been removed.)
+//
+// V0 limitation (single-client per buffer): when buffer B is open on
+// connections A and C, an accepted BufferEdit from A is NOT forwarded to
+// C. SyncClock.client_version is daemon-wide rather than per-connection,
+// so there is no safe expected_client_version to put in a push targeted
+// at C. Multi-client push is tracked as follow-up work; until then, only
+// one client should hold a writable view of a remote buffer at a time.
 message BufferEdit {
   string path = 1;
   uint64 expected_server_version = 2;

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -28,6 +28,7 @@ message ClientMessage {
     CloseBuffer close_buffer = 15;
     SaveBuffer save_buffer = 16;
     ResolveConflict resolve_conflict = 17;
+    ListDirectory list_directory = 18;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -50,6 +51,7 @@ message ServerMessage {
     BufferUpdatedPush buffer_updated = 15;
     SaveBufferResponse save_buffer_response = 16;
     ResolveConflictResponse resolve_conflict_response = 17;
+    ListDirectoryResponse list_directory_response = 18;
   }
 }
 
@@ -405,3 +407,33 @@ message ResolveConflictResponse {
 }
 
 message ResolveConflictSuccess {}
+
+// ── ListDirectory ─────────────────────────────────────────────────
+// OpenWarp:终端文件链接的远端精确校验。客户端在远端 SSH 会话里
+// Ctrl/Cmd+点击文件路径时,需要知道某个 cwd 下的真实目录项,
+// 才能从 `ls -l` 这类整行输出里准确切出文件名(本地会话靠
+// `fs::metadata` 存在性校验做这件事,远端文件不在本地磁盘上)。
+
+// Client → server: list the immediate entries of a directory.
+message ListDirectory {
+  string path = 1;
+}
+
+// A single directory entry returned by ListDirectory.
+message DirEntry {
+  string name = 1;
+  bool is_dir = 2;
+}
+
+// Server → client: the entries contained directly in the requested directory.
+message ListDirectorySuccess {
+  repeated DirEntry entries = 1;
+}
+
+// Server → client: result of a ListDirectory request.
+message ListDirectoryResponse {
+  oneof result {
+    ListDirectorySuccess success = 1;
+    FileOperationError error = 2;
+  }
+}

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -23,6 +23,11 @@ message ClientMessage {
     RunCommandRequest run_command = 9;
     ReadFileContextRequest read_file_context = 10;
     Authenticate authenticate = 11;
+    OpenBuffer open_buffer = 13;
+    BufferEdit buffer_edit = 14;
+    CloseBuffer close_buffer = 15;
+    SaveBuffer save_buffer = 16;
+    ResolveConflict resolve_conflict = 17;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -41,6 +46,10 @@ message ServerMessage {
     DeleteFileResponse delete_file_response = 9;
     RunCommandResponse run_command_response = 10;
     ReadFileContextResponse read_file_context_response = 11;
+    OpenBufferResponse open_buffer_response = 14;
+    BufferUpdatedPush buffer_updated = 15;
+    SaveBufferResponse save_buffer_response = 16;
+    ResolveConflictResponse resolve_conflict_response = 17;
   }
 }
 
@@ -310,3 +319,89 @@ message RepoMetadataUpdatePush {
   repeated string remove_entries = 2;
   repeated RepoMetadataEntryUpdate update_entries = 3;
 }
+
+// ── Buffer syncing ────────────────────────────────────────────────
+
+// Client → server: open a buffer for bidirectional syncing.
+// The server reads the file, starts watching it, and returns the content.
+message OpenBuffer {
+  string path = 1;
+}
+
+// Server → client: response to OpenBuffer with the initial file content.
+message OpenBufferResponse {
+  string content = 1;
+  uint64 server_version = 2;
+}
+
+// Client → server: push an incremental edit (fire-and-forget notification).
+// If the server accepts (expected_server_version matches its local version),
+// it applies the edit silently — no response needed since the client already
+// has the edit applied locally.
+// If the server rejects (version mismatch), it pushes a BufferUpdatedPush
+// with its current state.
+message BufferEdit {
+  string path = 1;
+  uint64 expected_server_version = 2;
+  uint64 new_client_version = 3;
+  repeated TextEdit edits = 4;
+}
+
+// A single text edit within a buffer, using 1-indexed character offsets (matching CharOffset).
+message TextEdit {
+  uint64 start_offset = 1;
+  uint64 end_offset = 2;
+  string text = 3;
+}
+
+// Server → client push: file changed on disk.
+// The client uses expected_client_version to detect conflicts.
+// Carries only incremental edits — full content is served by OpenBufferResponse.
+message BufferUpdatedPush {
+  string path = 1;
+  uint64 new_server_version = 2;
+  uint64 expected_client_version = 3;
+  repeated TextEdit edits = 4;
+}
+
+// Client → server: close a buffer (stop watching).
+message CloseBuffer {
+  string path = 1;
+}
+
+// Client → server: persist the current in-memory buffer to disk.
+message SaveBuffer {
+  string path = 1;
+}
+
+// Server → client: result of a SaveBuffer request.
+message SaveBufferResponse {
+  oneof result {
+    SaveBufferSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
+
+message SaveBufferSuccess {}
+
+// Client → server: resolve a conflict by accepting the client's content.
+// The server replaces its in-memory buffer with client_content,
+// updates the clock to {acknowledged_server_version, current_client_version},
+// and persists to disk (updates base_content_version to avoid re-triggering).
+// For "accept server", the client simply re-sends OpenBuffer instead.
+message ResolveConflict {
+  string path = 1;
+  uint64 acknowledged_server_version = 2;
+  string client_content = 3;
+  uint64 current_client_version = 4;
+}
+
+// Server → client: result of a ResolveConflict request.
+message ResolveConflictResponse {
+  oneof result {
+    ResolveConflictSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
+
+message ResolveConflictSuccess {}

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -411,18 +411,18 @@ impl RemoteServerClient {
         }
     }
 
-    /// Sends a buffer edit notification (fire-and-forget) to the remote host.
+    /// Sends a buffer edit notification to the remote host.
     ///
-    // TODO(ssh-remote): `send_notification` 在 `outbound_tx` 关闭时只记日志,
-    // 此处会静默吞掉投递失败,本地 buffer 仍继续推进而 daemon 收不到编辑。
-    // 应改为返回 `Result` 或发失败事件,让 manager 把 buffer 标记为未同步。
+    /// OpenWarp:与其它 fire-and-forget 通知不同,buffer 编辑投递失败必须上报。
+    /// `outbound_tx` 关闭(连接已死)时若静默吞掉,本地 buffer 会继续推进而
+    /// daemon 收不到编辑,造成不可见的失步。失败返回 `Err` 让调用方处理。
     pub fn send_buffer_edit(
         &self,
         path: String,
         expected_server_version: u64,
         new_client_version: u64,
         edits: Vec<TextEdit>,
-    ) {
+    ) -> Result<(), ClientError> {
         let msg = ClientMessage {
             request_id: String::new(), // notification — no response expected
             message: Some(client_message::Message::BufferEdit(BufferEdit {
@@ -432,7 +432,10 @@ impl RemoteServerClient {
                 edits,
             })),
         };
-        self.send_notification(msg);
+        self.outbound_tx.try_send(msg).map_err(|e| {
+            log::error!("Failed to enqueue buffer edit: {e}");
+            ClientError::Disconnected
+        })
     }
 
     /// Tells the remote host to close a buffer (stop watching).

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -412,6 +412,10 @@ impl RemoteServerClient {
     }
 
     /// Sends a buffer edit notification (fire-and-forget) to the remote host.
+    ///
+    // TODO(ssh-remote): `send_notification` 在 `outbound_tx` 关闭时只记日志,
+    // 此处会静默吞掉投递失败,本地 buffer 仍继续推进而 daemon 收不到编辑。
+    // 应改为返回 `Result` 或发失败事件,让 manager 把 buffer 标记为未同步。
     pub fn send_buffer_edit(
         &self,
         path: String,

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -11,11 +11,11 @@ use warpui::r#async::{executor, FutureExt as _};
 
 use crate::proto::{
     client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
-    DeleteFile, ErrorCode, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
-    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, RunCommandRequest,
-    RunCommandResponse, SaveBuffer, SaveBufferResponse, ServerMessage, SessionBootstrapped,
-    TextEdit, WriteFile,
+    DeleteFile, ErrorCode, Initialize, InitializeResponse, ListDirectory, ListDirectoryResponse,
+    LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse, ResolveConflict,
+    ResolveConflictResponse, RunCommandRequest, RunCommandResponse, SaveBuffer, SaveBufferResponse,
+    ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
 };
 
 use crate::protocol::{self, ProtocolError, RequestId};
@@ -367,6 +367,28 @@ impl RemoteServerClient {
             },
             other => {
                 log::error!("Unexpected response variant for DeleteFile: {other:?}");
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// OpenWarp:列举远端主机上某个目录的直接子项。
+    ///
+    /// 终端文件链接检测用它精确校验远端路径形态(本地会话靠
+    /// `fs::metadata` 做这件事,远端文件不在本地磁盘上)。
+    pub async fn list_directory(&self, path: String) -> Result<ListDirectoryResponse, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::ListDirectory(ListDirectory {
+                path,
+            })),
+        };
+        let response = self.send_request(request_id, msg).await?;
+        match response.message {
+            Some(server_message::Message::ListDirectoryResponse(resp)) => Ok(resp),
+            other => {
+                log::error!("Unexpected response variant for ListDirectory: {other:?}");
                 Err(ClientError::UnexpectedResponse)
             }
         }

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -10,10 +10,12 @@ use futures::io::{AsyncRead, AsyncWrite};
 use warpui::r#async::{executor, FutureExt as _};
 
 use crate::proto::{
-    client_message, server_message, Abort, Authenticate, ClientMessage, DeleteFile, ErrorCode,
-    Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, ReadFileContextRequest, ReadFileContextResponse,
-    RunCommandRequest, RunCommandResponse, ServerMessage, SessionBootstrapped, WriteFile,
+    client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
+    DeleteFile, ErrorCode, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
+    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
+    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, RunCommandRequest,
+    RunCommandResponse, SaveBuffer, SaveBufferResponse, ServerMessage, SessionBootstrapped,
+    TextEdit, WriteFile,
 };
 
 use crate::protocol::{self, ProtocolError, RequestId};
@@ -66,6 +68,13 @@ pub enum ClientEvent {
     /// An incremental repo metadata update was pushed by the server.
     RepoMetadataUpdated {
         update: repo_metadata::RepoMetadataUpdate,
+    },
+    /// A buffer was updated on the server (file changed on disk).
+    BufferUpdated {
+        path: String,
+        new_server_version: u64,
+        expected_client_version: u64,
+        edits: Vec<TextEdit>,
     },
     /// A server message could not be decoded and had no parseable request_id.
     MessageDecodingError,
@@ -363,6 +372,97 @@ impl RemoteServerClient {
         }
     }
 
+    /// Opens a buffer on the remote host for bidirectional syncing.
+    pub async fn open_buffer(&self, path: String) -> Result<OpenBufferResponse, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::OpenBuffer(OpenBuffer { path })),
+        };
+        let response = self.send_request(request_id, msg).await?;
+        match response.message {
+            Some(server_message::Message::OpenBufferResponse(resp)) => Ok(resp),
+            other => {
+                log::error!("Unexpected response variant for OpenBuffer: {other:?}");
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Sends a buffer edit notification (fire-and-forget) to the remote host.
+    pub fn send_buffer_edit(
+        &self,
+        path: String,
+        expected_server_version: u64,
+        new_client_version: u64,
+        edits: Vec<TextEdit>,
+    ) {
+        let msg = ClientMessage {
+            request_id: String::new(), // notification — no response expected
+            message: Some(client_message::Message::BufferEdit(BufferEdit {
+                path,
+                expected_server_version,
+                new_client_version,
+                edits,
+            })),
+        };
+        self.send_notification(msg);
+    }
+
+    /// Tells the remote host to close a buffer (stop watching).
+    pub fn close_buffer(&self, path: String) {
+        let msg = ClientMessage {
+            request_id: String::new(),
+            message: Some(client_message::Message::CloseBuffer(CloseBuffer { path })),
+        };
+        self.send_notification(msg);
+    }
+
+    /// Persists the current in-memory buffer to disk on the remote host.
+    pub async fn save_buffer(&self, path: String) -> Result<SaveBufferResponse, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::SaveBuffer(SaveBuffer { path })),
+        };
+        let response = self.send_request(request_id, msg).await?;
+        match response.message {
+            Some(server_message::Message::SaveBufferResponse(resp)) => Ok(resp),
+            other => {
+                log::error!("Unexpected response variant for SaveBuffer: {other:?}");
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Resolves a buffer conflict by accepting the client's content.
+    pub async fn resolve_conflict(
+        &self,
+        path: String,
+        acknowledged_server_version: u64,
+        client_content: String,
+        current_client_version: u64,
+    ) -> Result<ResolveConflictResponse, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::ResolveConflict(ResolveConflict {
+                path,
+                acknowledged_server_version,
+                client_content,
+                current_client_version,
+            })),
+        };
+        let response = self.send_request(request_id, msg).await?;
+        match response.message {
+            Some(server_message::Message::ResolveConflictResponse(resp)) => Ok(resp),
+            other => {
+                log::error!("Unexpected response variant for ResolveConflict: {other:?}");
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
     /// Converts a server push message (empty request_id) into a domain event.
     fn push_message_to_event(msg: ServerMessage) -> Option<ClientEvent> {
         match msg.message? {
@@ -374,6 +474,12 @@ impl RemoteServerClient {
                 let update = crate::repo_metadata_proto::proto_to_repo_metadata_update(&push)?;
                 Some(ClientEvent::RepoMetadataUpdated { update })
             }
+            server_message::Message::BufferUpdated(push) => Some(ClientEvent::BufferUpdated {
+                path: push.path,
+                new_server_version: push.new_server_version,
+                expected_client_version: push.expected_client_version,
+                edits: push.edits,
+            }),
             other => {
                 log::warn!("Unhandled push message variant: {other:?}");
                 None

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1397,11 +1397,28 @@ impl RemoteServerManager {
             let exit_status = Self::capture_exit_status(&mut _child, session_id);
             // Drop the old child process explicitly before reconnecting.
             drop(_child);
-            let Some(auth_context) = self.auth_context.clone() else {
-                log::warn!(
-                    "Spontaneous disconnect for session {session_id:?}, \
-                     but no auth context is available for reconnect"
-                );
+            // 如果子进程已经退出(`exit_status.is_some()`),说明对端 daemon 已经
+            // 真的不在了 —— 例如用户在远端 shell 内 `exit`,ssh ControlMaster
+            // 把所有 slave channel 一起收掉,`remote-server-proxy` 也跟着退出。
+            // 这种情况下立刻重连大概率失败,反而会让 terminal pane 卡 2~4 秒
+            // 才彻底结束;因此跳过自动重连,直接走 Disconnected 路径。
+            // 只有 `exit_status.is_none()`(child 仍在跑但 reader 收到 EOF)
+            // 这种"真·瞬时网络抖动"才保留重连逻辑。
+            let child_already_exited = exit_status.is_some();
+            let Some(auth_context) = self.auth_context.clone().filter(|_| !child_already_exited)
+            else {
+                if child_already_exited {
+                    log::info!(
+                        "Spontaneous disconnect for session {session_id:?}: \
+                         child already exited (exit_status={exit_status:?}), \
+                         skipping reconnect"
+                    );
+                } else {
+                    log::warn!(
+                        "Spontaneous disconnect for session {session_id:?}, \
+                         but no auth context is available for reconnect"
+                    );
+                }
                 self.sessions
                     .insert(session_id, RemoteSessionState::Disconnected);
                 self.remove_from_host_index(&host_id, session_id);

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -313,6 +313,16 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         update: RepoMetadataUpdate,
     },
+    /// A remote buffer was updated on the server (file changed on disk).
+    /// Forwarded from the client's `ClientEvent::BufferUpdated` push channel
+    /// so `GlobalBufferModel` can apply the incremental edits.
+    BufferUpdated {
+        host_id: HostId,
+        path: String,
+        new_server_version: u64,
+        expected_client_version: u64,
+        edits: Vec<crate::proto::TextEdit>,
+    },
 
     // --- Setup events ---
     /// Intermediate state change during the binary check/install flow.
@@ -387,7 +397,8 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::HostDisconnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
-            | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. } => None,
+            | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::BufferUpdated { .. } => None,
         }
     }
 }
@@ -1231,6 +1242,20 @@ impl RemoteServerManager {
             }
             ClientEvent::RepoMetadataUpdated { update } => {
                 ctx.emit(RemoteServerManagerEvent::RepoMetadataUpdated { host_id, update });
+            }
+            ClientEvent::BufferUpdated {
+                path,
+                new_server_version,
+                expected_client_version,
+                edits,
+            } => {
+                ctx.emit(RemoteServerManagerEvent::BufferUpdated {
+                    host_id,
+                    path,
+                    new_server_version,
+                    expected_client_version,
+                    edits,
+                });
             }
             ClientEvent::MessageDecodingError => {
                 ctx.emit(RemoteServerManagerEvent::ServerMessageDecodingError { session_id });

--- a/crates/remote_server/src/preinstall_check.sh
+++ b/crates/remote_server/src/preinstall_check.sh
@@ -3,15 +3,24 @@
 #
 # stdout 输出结构化 key=value 摘要。退出码 0 表示探测完成;
 # 非 0 表示探测过程失败,客户端会按 `status=unknown` 处理并 fail open。
+#
+# 重要:OpenWarp Linux remote-server 现在由 openwarp_release.yml 以
+# `x86_64-unknown-linux-musl` 目标静态链接构建(static-musl)。产物不依赖
+# 宿主的动态 libc,因此可以在任意 Linux x86_64 主机上运行 —— 包括旧 glibc
+# 发行版(CentOS 7 = 2.17、Amazon Linux 2 = 2.26、Ubuntu 20.04 / Debian 11
+# = 2.31)以及 musl 发行版(Alpine 等)。
+#
+# 既然二进制是静态的,libc 探测不再用于「门禁」,只作为遥测信息保留。
 
 set -u
 
-# OpenWarp Linux remote-server 由 openwarp_release.yml 的 ubuntu-22.04
-# job 构建,glibc floor 是 2.35。runner 镜像升级时同步调整。
-required_glibc="2.35"
+# 历史字段:保留 required_glibc 以兼容旧客户端的解析逻辑。
+# 静态 musl 二进制实际上没有 glibc 下限,此处仅为向后兼容输出,
+# 不再参与下面的 status 判定。
+required_glibc="2.17"
 echo "required_glibc=${required_glibc}"
 
-# 1. 识别 libc family,并在 glibc 场景下识别版本。
+# 1. 识别 libc family,并在 glibc 场景下识别版本(纯遥测,不影响 status)。
 libc_family="unknown"
 libc_version=""
 
@@ -36,26 +45,20 @@ fi
 echo "libc_family=${libc_family}"
 [ -n "$libc_version" ] && echo "libc_version=${libc_version}"
 
-# 2. 根据探测结果判断支持状态。
+# 2. 判断支持状态。
+#
+# remote-server 是静态 musl 二进制,不链接宿主 libc,所以任何 glibc 版本
+# (含 2.35 以下)以及 musl / uclibc 宿主都能运行。只要成功识别出这是一台
+# Linux x86_64 主机,就报告 `supported`;探测不出任何 libc 线索(连
+# getconf 和 ldd 都没有)时回退 `unknown`,让客户端 fail open 照常尝试安装。
 status="unknown"
 reason=""
 
-if [ "$libc_family" = "glibc" ] && [ -n "$libc_version" ]; then
-    have_major="${libc_version%%.*}"
-    have_minor="${libc_version#*.}"
-    have_minor="${have_minor%%.*}"
-    req_major="${required_glibc%%.*}"
-    req_minor="${required_glibc#*.}"
-    if [ "$have_major" -gt "$req_major" ] \
-       || { [ "$have_major" -eq "$req_major" ] && [ "$have_minor" -ge "$req_minor" ]; }; then
-        status="supported"
-    else
-        status="unsupported"
-        reason="glibc_too_old"
-    fi
-elif [ "$libc_family" = "musl" ] || [ "$libc_family" = "bionic" ] || [ "$libc_family" = "uclibc" ]; then
-    status="unsupported"
-    reason="non_glibc"
+if [ "$libc_family" = "glibc" ] \
+   || [ "$libc_family" = "musl" ] \
+   || [ "$libc_family" = "uclibc" ] \
+   || [ "$libc_family" = "bionic" ]; then
+    status="supported"
 fi
 
 echo "status=${status}"

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -406,11 +406,23 @@ pub const DEV_REMOTE_FEATURES: &str = "release_bundle,crash_reporting,standalone
 
 /// 判断当前是否处于「开发模式 remote-server 安装」路径。
 ///
-/// 条件:DEBUG 构建(`debug_assertions`)且没有注入 `GIT_RELEASE_TAG`
+/// 默认条件:DEBUG 构建(`debug_assertions`)且没有注入 `GIT_RELEASE_TAG`
 /// (`app_version().is_none()`,即源码本地构建,非发行版)。这与
 /// `remote_server_binary()` / `download_url()` 中对「无 release tag」的
 /// 判定保持同一标准。release 构建恒为 `false`,行为完全不变。
+///
+/// 显式覆盖:设置 `WARP_REMOTE_SERVER_FROM_LOCAL=1` 强制走本地交叉编译路径
+/// (`0`/未设视为关闭)。用于 release 构建里临时联调本地 remote-server。
 pub fn is_dev_source_build() -> bool {
+    if let Some(raw) = std::env::var_os("WARP_REMOTE_SERVER_FROM_LOCAL") {
+        let lossy = raw.to_string_lossy();
+        let trimmed = lossy.trim();
+        let disabled =
+            trimmed.is_empty() || trimmed == "0" || trimmed.eq_ignore_ascii_case("false");
+        if !disabled {
+            return true;
+        }
+    }
     cfg!(debug_assertions) && ChannelState::app_version().is_none()
 }
 

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -152,37 +152,21 @@ impl PreinstallCheckResult {
 fn parse_status(
     status: Option<&str>,
     reason: Option<&str>,
-    libc: &RemoteLibc,
-    required_glibc: Option<&str>,
+    _libc: &RemoteLibc,
+    _required_glibc: Option<&str>,
 ) -> PreinstallStatus {
+    // remote-server 现在是静态 musl 二进制(见 `preinstall_check.sh` 顶部
+    // 注释),不链接宿主的动态 libc。因此 `glibc_too_old` / `non_glibc`
+    // 已不再是「不支持」的理由 —— 任意 glibc 版本与 musl/uclibc 宿主都能
+    // 运行该二进制。新版脚本不会再发出这两个 reason;但旧版 remote 端可能
+    // 仍缓存着老脚本,所以这里把这些 libc 门禁理由一并当作 `Supported`,
+    // 而不是 `Unsupported`,保持新旧脚本的判定一致。
     match status {
         Some("supported") => PreinstallStatus::Supported,
         Some("unsupported") => match reason {
-            Some("glibc_too_old") => {
-                let detected = match libc {
-                    RemoteLibc::Glibc(v) => Some(*v),
-                    _ => None,
-                };
-                let required = required_glibc.and_then(GlibcVersion::parse);
-                match (detected, required) {
-                    (Some(detected), Some(required)) => PreinstallStatus::Unsupported {
-                        reason: UnsupportedReason::GlibcTooOld { detected, required },
-                    },
-                    // The script said `unsupported` + `glibc_too_old` but we
-                    // can't recover the numbers — fail open rather than
-                    // surface a malformed reason.
-                    _ => PreinstallStatus::Unknown,
-                }
-            }
-            Some("non_glibc") => {
-                let name = match libc {
-                    RemoteLibc::NonGlibc { name } => name.clone(),
-                    _ => "unknown".to_string(),
-                };
-                PreinstallStatus::Unsupported {
-                    reason: UnsupportedReason::NonGlibc { name },
-                }
-            }
+            // 旧脚本残留的 libc 门禁理由:静态二进制下已失效,视为支持。
+            Some("glibc_too_old") | Some("non_glibc") => PreinstallStatus::Supported,
+            // 其他无法识别的 unsupported 理由:保守起见 fail open。
             _ => PreinstallStatus::Unknown,
         },
         // status=unknown, missing, or anything else → fail open.
@@ -404,6 +388,32 @@ pub fn download_tarball_url(platform: &RemotePlatform) -> String {
     )
 }
 
+/// OpenWarp fork:开发模式(DEBUG 源码构建,无 release tag)下,
+/// SSH transport 不再从 GitHub 下载陈旧的发行版,而是本地交叉编译
+/// 当前 `warp` 二进制并上传。下面这些常量集中描述该交叉编译产物,
+/// 与 `script/deploy_remote_server` 保持一致(同 profile / 同 features /
+/// 同 target),避免两处分叉。
+///
+/// 交叉编译目标三元组。
+pub const DEV_MUSL_TARGET: &str = "x86_64-unknown-linux-musl";
+
+/// 交叉编译使用的 cargo profile。对应 `Cargo.toml` 的 `[profile.dev-remote]`,
+/// 它继承 `dev` 并 strip 符号以减小体积、加快上传。
+pub const DEV_REMOTE_PROFILE: &str = "dev-remote";
+
+/// 交叉编译启用的 features,与 `script/deploy_remote_server` 一致。
+pub const DEV_REMOTE_FEATURES: &str = "release_bundle,crash_reporting,standalone,agent_mode_debug";
+
+/// 判断当前是否处于「开发模式 remote-server 安装」路径。
+///
+/// 条件:DEBUG 构建(`debug_assertions`)且没有注入 `GIT_RELEASE_TAG`
+/// (`app_version().is_none()`,即源码本地构建,非发行版)。这与
+/// `remote_server_binary()` / `download_url()` 中对「无 release tag」的
+/// 判定保持同一标准。release 构建恒为 `false`,行为完全不变。
+pub fn is_dev_source_build() -> bool {
+    cfg!(debug_assertions) && ChannelState::app_version().is_none()
+}
+
 /// 检查二进制是否存在的超时。
 pub const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -412,6 +422,14 @@ pub const INSTALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// SCP fallback 包含本地下载、上传和远端解压,给它更宽松的超时。
 pub const SCP_INSTALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// 开发模式交叉编译可能要从头编译整个 crate 图,给它一个很宽松的超时。
+pub const DEV_CROSS_COMPILE_TIMEOUT: Duration = Duration::from_secs(900);
+
+/// 开发模式上传本地交叉编译产物的超时。dev 二进制(未优化 + 调试信息)有
+/// 数百 MB,即便 scp 开了 `-C` 压缩,跨公网上传也可能要数分钟,因此给一个
+/// 远超 `SCP_INSTALL_TIMEOUT` 的宽松上限。
+pub const DEV_UPLOAD_TIMEOUT: Duration = Duration::from_secs(1800);
 
 #[cfg(test)]
 #[path = "setup_tests.rs"]

--- a/crates/remote_server/src/setup/glibc.rs
+++ b/crates/remote_server/src/setup/glibc.rs
@@ -4,6 +4,11 @@
 //! This is split into its own submodule so the libc-specific logic
 //! (version parsing, family classification) can evolve independently
 //! from the rest of [`crate::setup`].
+//!
+//! 注意:remote-server 二进制现在是静态 musl 链接(见 `preinstall_check.sh`),
+//! 不依赖宿主 libc。这里解析出的 libc family / version 已不再用于安装门禁,
+//! 仅作为遥测/诊断信息保留。`RemoteLibc` 与 `GlibcVersion` 继续被
+//! [`crate::setup::PreinstallCheckResult`] 和 `UnsupportedReason` 使用。
 
 use std::fmt;
 

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -127,47 +127,60 @@ fn parse_preinstall_supported_glibc() {
 }
 
 #[test]
-fn parse_preinstall_unsupported_glibc_too_old() {
-    let stdout = "required_glibc=2.31\n\
+fn parse_preinstall_legacy_glibc_too_old_now_supported() {
+    // remote-server 现在是静态 musl 二进制,旧脚本的 `glibc_too_old` 门禁
+    // 已失效。即使老 remote 端缓存着旧脚本并报出该理由,客户端也应把它当
+    // 作支持处理,而不是回退到 ControlMaster。
+    let stdout = "required_glibc=2.17\n\
                   libc_family=glibc\n\
                   libc_version=2.17\n\
                   status=unsupported\n\
                   reason=glibc_too_old\n";
     let result = PreinstallCheckResult::parse(stdout);
-    assert_eq!(
-        result.status,
-        PreinstallStatus::Unsupported {
-            reason: UnsupportedReason::GlibcTooOld {
-                detected: GlibcVersion::new(2, 17),
-                required: GlibcVersion::new(2, 31),
-            }
-        }
-    );
-    assert!(!result.is_supported());
+    assert_eq!(result.status, PreinstallStatus::Supported);
+    assert!(result.is_supported());
 }
 
 #[test]
-fn parse_preinstall_unsupported_non_glibc() {
-    let stdout = "required_glibc=2.31\n\
+fn parse_preinstall_legacy_non_glibc_now_supported() {
+    // 同理:musl/uclibc 宿主在静态二进制下也能运行。旧脚本的 `non_glibc`
+    // 不再触发 fall-back。
+    let stdout = "required_glibc=2.17\n\
                   libc_family=musl\n\
                   status=unsupported\n\
                   reason=non_glibc\n";
     let result = PreinstallCheckResult::parse(stdout);
-    assert_eq!(
-        result.status,
-        PreinstallStatus::Unsupported {
-            reason: UnsupportedReason::NonGlibc {
-                name: "musl".to_string()
-            }
-        }
-    );
+    assert_eq!(result.status, PreinstallStatus::Supported);
     assert_eq!(
         result.libc,
         RemoteLibc::NonGlibc {
             name: "musl".to_string()
         }
     );
-    assert!(!result.is_supported());
+    assert!(result.is_supported());
+}
+
+#[test]
+fn parse_preinstall_musl_host_supported() {
+    // 新版脚本在 musl 宿主上直接报 `status=supported`。
+    let stdout = "required_glibc=2.17\n\
+                  libc_family=musl\n\
+                  status=supported\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert_eq!(result.status, PreinstallStatus::Supported);
+    assert!(result.is_supported());
+}
+
+#[test]
+fn parse_preinstall_old_glibc_host_supported() {
+    // 新版脚本在旧 glibc(< 2.35)宿主上也直接报 `status=supported`。
+    let stdout = "required_glibc=2.17\n\
+                  libc_family=glibc\n\
+                  libc_version=2.17\n\
+                  status=supported\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert_eq!(result.status, PreinstallStatus::Supported);
+    assert!(result.is_supported());
 }
 
 #[test]

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -163,6 +163,9 @@ pub async fn scp_upload(
 ) -> Result<()> {
     let output = async {
         Command::new("scp")
+            // -C:压缩传输。dev 模式上传的 remote-server 二进制有数百 MB,
+            // 压缩能大幅缩短上传时间、降低超时风险。
+            .arg("-C")
             .arg("-o")
             .arg(format!("ControlPath={}", socket_path.display()))
             .arg("-o")

--- a/crates/warp_core/src/host_id.rs
+++ b/crates/warp_core/src/host_id.rs
@@ -1,11 +1,13 @@
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// Opaque identifier for a remote host.
 ///
 /// Returned by the server in `InitializeResponse`. Used by
 /// `RemoteServerManager` and downstream features to deduplicate
 /// host-scoped models (e.g. `RepoMetadataModel`) across sessions.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HostId(String);
 
 impl HostId {

--- a/crates/warp_util/src/content_version.rs
+++ b/crates/warp_util/src/content_version.rs
@@ -18,6 +18,20 @@ impl ContentVersion {
     pub fn as_i32(&self) -> i32 {
         self.0 as i32
     }
+
+    /// Reconstructs a `ContentVersion` from a raw value received over the wire.
+    ///
+    /// This bypasses the global atomic counter and should only be used at
+    /// protocol deserialization boundaries (e.g. converting a `u64` from a
+    /// proto message back into a `ContentVersion`).
+    pub fn from_raw(val: usize) -> Self {
+        ContentVersion(val)
+    }
+
+    /// Returns the underlying value as a `u64` for wire serialization.
+    pub fn as_u64(&self) -> u64 {
+        self.0 as u64
+    }
 }
 
 #[cfg(test)]

--- a/crates/warp_util/src/content_version.rs
+++ b/crates/warp_util/src/content_version.rs
@@ -28,6 +28,14 @@ impl ContentVersion {
         ContentVersion(val)
     }
 
+    /// 协议反序列化辅助:从 wire 上的 `u64` 构造 `ContentVersion`,
+    /// 在 32-bit 平台上做饱和(`usize::MAX`)而不是隐式截断。
+    /// 当前仓库的 native build 都是 64-bit,这里只是把行为显式化,避免
+    /// `as usize` 在小概率 32-bit 编译里悄悄丢高位。
+    pub fn from_wire_u64(val: u64) -> Self {
+        ContentVersion(usize::try_from(val).unwrap_or(usize::MAX))
+    }
+
     /// Returns the underlying value as a `u64` for wire serialization.
     pub fn as_u64(&self) -> u64 {
         self.0 as u64

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -255,9 +255,19 @@ if [[ "$CHECK_ONLY" == "true" ]]; then
 fi
 
 # Build the binary.
+#
+# `USE_ZIGBUILD=true` 时改用 `cargo zigbuild`:zig 自带完整 C/C++ 交叉工具链,
+# musl 目标下不需要手工准备 `musl-gcc`/`musl-g++`,也不需要给 cc-rs 装
+# `<triple>-{gcc,g++}` 符号链接。CI 的静态 musl CLI build 走这条路。
+# 本地不设置该变量时维持原有 `cargo build` 行为(host glibc 路径不受影响)。
 if [[ "$BUILD" == "true" ]]; then
   echo "Building and bundling Warp for channel $RELEASE_CHANNEL and bundle id $BUNDLE_ID"
-  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" "${CARGO_TARGET_ARG[@]}"
+  if [[ "${USE_ZIGBUILD:-false}" == "true" ]]; then
+    echo "Using cargo zigbuild (zig-backed cross toolchain)"
+    cargo zigbuild -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" "${CARGO_TARGET_ARG[@]}"
+  else
+    cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" "${CARGO_TARGET_ARG[@]}"
+  fi
   echo "Making debug copy of '$EXECUTABLE_PATH' at '$DEBUG_EXECUTABLE_PATH'"
   cp "$EXECUTABLE_PATH" "$DEBUG_EXECUTABLE_PATH"
 

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -27,6 +27,11 @@ BUILD="true"
 BUILD_ARCH="$(uname -m)"
 DEBUG=false
 ARTIFACT="app"
+# Optional Rust target triple override. When set (e.g. via --target or the
+# BUNDLE_TARGET env var), cargo builds for that target instead of the host
+# default. Used to produce a static musl CLI/remote-server binary that runs
+# on any Linux x86_64 host regardless of its glibc version.
+BUILD_TARGET="${BUNDLE_TARGET:-}"
 
 # Cache all params so we can pass them to downstream scripts.
 ALL_PARAMS=$@
@@ -103,6 +108,17 @@ while (( "$#" )); do
         exit 1
       fi
       ;;
+    --target)
+      # Rust target triple override (e.g. x86_64-unknown-linux-musl).
+      # Lets the CLI/remote-server artifact build as a static musl binary.
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+        BUILD_TARGET="$2"
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
     *) # preserve positional arguments
       PARAMS="$PARAMS $1"
       shift
@@ -131,10 +147,17 @@ else
   fi
 fi
 
-if [[ "$CARGO_PROFILE" == "dev" ]]; then
-  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_DIR/debug"
+# When building for an explicit target triple (e.g. musl), cargo nests the
+# output under target/<triple>/<profile>/ instead of target/<profile>/.
+if [[ -n "$BUILD_TARGET" ]]; then
+  CARGO_TARGET_PREFIX="$CARGO_TARGET_DIR/$BUILD_TARGET"
 else
-  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_DIR/$CARGO_PROFILE"
+  CARGO_TARGET_PREFIX="$CARGO_TARGET_DIR"
+fi
+if [[ "$CARGO_PROFILE" == "dev" ]]; then
+  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_PREFIX/debug"
+else
+  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_PREFIX/$CARGO_PROFILE"
 fi
 # NOTE: if you change this path, update the "Clean stale bundle output"
 # steps in .github/workflows/create_release.yml so they continue to wipe
@@ -214,18 +237,27 @@ DEBUG_EXECUTABLE_PATH="$EXECUTABLE_PATH.debug"
 # expected name of the AppImage when downloading updates).
 export APPIMAGE_NAME="$APP_NAME-$BUILD_ARCH.AppImage"
 
+# Optional `--target <triple>` passthrough for cargo. Empty when building for
+# the host (the default for the GUI AppImage/deb); set to a musl triple for
+# the static CLI/remote-server artifact.
+CARGO_TARGET_ARG=()
+if [[ -n "$BUILD_TARGET" ]]; then
+  echo "Building for Rust target $BUILD_TARGET"
+  CARGO_TARGET_ARG=(--target "$BUILD_TARGET")
+fi
+
 # If we only want to check that compilation will succeed, perform the checks
 # then exit.  We use this script to invoke `cargo check` to ensure that we are
 # using the same feature flags and profile that we would be using in production.
 if [[ "$CHECK_ONLY" == "true" ]]; then
-  cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES"
+  cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" "${CARGO_TARGET_ARG[@]}"
   exit 0
 fi
 
 # Build the binary.
 if [[ "$BUILD" == "true" ]]; then
   echo "Building and bundling Warp for channel $RELEASE_CHANNEL and bundle id $BUNDLE_ID"
-  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES"
+  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" "${CARGO_TARGET_ARG[@]}"
   echo "Making debug copy of '$EXECUTABLE_PATH' at '$DEBUG_EXECUTABLE_PATH'"
   cp "$EXECUTABLE_PATH" "$DEBUG_EXECUTABLE_PATH"
 
@@ -277,7 +309,8 @@ export \
   BUILD_ARCH \
   ARTIFACT \
   CARGO_PROFILE \
-  FEATURES
+  FEATURES \
+  BUILD_TARGET
 
 # Build the AppImage bundle.
 if [[ ${PACKAGES[@]} =~ "appimage" ]]; then


### PR DESCRIPTION
Related to #106 —— 实现 SSH 远程文件访问。移植上游 Warp 的 remote-server buffer-sync 协议,并把远程文件接入代码编辑器,使其与本地文件体验一致。

## 远程文件打开 / 编辑 / 保存(buffer-sync 协议)
- 新增 proto 消息:`OpenBuffer` / `BufferEdit` / `BufferUpdatedPush` / `SaveBuffer` / `CloseBuffer` / `ResolveConflict`
- 新增 `app/src/code/buffer_location.rs`(`SyncClock` / `RemotePath` / `BufferLocation`)与 `app/src/remote_server/server_buffer_tracker.rs`
- `GlobalBufferModel` 引入 `BufferSource`(Local / Remote / ServerLocal),支持客户端 Remote buffer 与 daemon 端 ServerLocal buffer 双向同步
- 远程文件接入 `CodeSource` / `open_code` / `CodeView`:遵循「打开文件布局」设置、参与同面板多文件 tab 分组、焦点高亮正常(移除独立的 `RemoteFilePane`)
- 客户端保存远程文件走 `SaveBuffer` 协议

## daemon 修复
- `run_daemon_app` 注册 `GlobalBufferModel` 单例(否则启动 panic)
- `GlobalBufferModel::new` 不再订阅客户端专属的 `RemoteServerManager`,改由客户端 app 注册时显式接线
- `ServerBufferTracker` 持有 buffer 强引用,避免 daemon 无 view 时 buffer 在 `FileModel` 异步加载完成前被回收

## dev 模式二进制下发
- DEBUG 源码构建连接 SSH 主机时,自动交叉编译本地 `warp` 到 `x86_64-unknown-linux-musl` 并上传,跳过 GitHub 旧 release 下载
- 优先用 `cargo-zigbuild`(zig 自带 C/C++ musl 工具链),回退 musl-gcc;scp 加 `-C` 压缩、放宽上传超时
- DEBUG 构建默认开启 `SshRemoteServer` flag,便于本地联调

## glibc 兼容
- release CLI / remote-server 产物改为 musl 静态构建,可在绝大多数 Linux x86_64 服务器运行,不再受 glibc 版本限制
- `keyring` 启用 `vendored`,从源码编译 dbus,musl 交叉编译不再卡 `libdbus-sys` 的 pkg-config

## 测试状态
- `cargo check` / `cargo clippy`(`warp-oss` + `remote_server`)干净
- `cargo test -p remote_server`:61 passed / 0 failed
- 已在真实 SSH 主机上端到端验证:打开 / 编辑 / 保存远程文件均正常
- ⚠️ 后续仍需更广泛测试(多主机、并发编辑冲突、断连恢复、release 构建的 musl 产物在各发行版上的运行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open, edit, and save files on remote hosts with real-time bidirectional sync, incremental updates, versioned edits, and conflict resolution.
  * Remote file tree browsing and directory listing over SSH.
  * Ctrl/Cmd+click terminal links for remote paths (open file at line/col).

* **Improvements**
  * Linux CLI now produced as a statically-linked musl binary for wider compatibility.
  * Unified tab/editor behavior and improved deduplication for local & remote files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->