### PR TITLE
fix(ai): 避免交互式 ssh 读取长等待

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -28,6 +28,7 @@ use crate::terminal::model::block::{
     formatted_terminal_contents_for_input, Block, BlockId, CURSOR_MARKER,
 };
 use crate::terminal::shell::ShellType;
+use crate::terminal::ssh::util::parse_interactive_ssh_command;
 use crate::{
     ai::agent::AIAgentActionResultType,
     terminal::{
@@ -259,12 +260,6 @@ impl ShellCommandExecutor {
         // Determine the action we want to take based on the input.
         let action_id = input.action.id.clone();
 
-        let command = model
-            .block_list()
-            .active_block()
-            .command_with_secrets_unobfuscated(false)
-            .clone();
-
         let handle = ctx.handle();
         match &input.action.action {
             AIAgentActionType::RequestCommandOutput {
@@ -311,7 +306,7 @@ impl ShellCommandExecutor {
                 drop(model);
 
                 ActionExecution::new_async(
-                    self.action_result_future(block_selector.clone(), None),
+                    self.action_result_future(block_selector.clone(), ActionResultDelay::Default),
                     move |result, ctx| {
                         // Remove the senders from the maps.
                         if let Some(handle) = handle.upgrade(ctx) {
@@ -370,7 +365,7 @@ impl ShellCommandExecutor {
                 ActionExecution::new_async(
                     self.action_result_future(
                         block_selector.clone(),
-                        Some(ShellCommandDelay::Duration(Duration::from_millis(200))),
+                        ActionResultDelay::Duration(Duration::from_millis(200)),
                     ),
                     move |result, ctx| {
                         // Remove the senders from the maps.
@@ -404,11 +399,13 @@ impl ShellCommandExecutor {
                         },
                     ));
                 }
+                let command = block.command_with_secrets_unobfuscated(false);
+                let delay = effective_read_shell_command_delay(&command, delay.clone());
                 drop(model);
 
                 let block_selector = BlockSelector::Id(block_id.clone());
                 ActionExecution::new_async(
-                    self.action_result_future(block_selector.clone(), delay.clone()),
+                    self.action_result_future(block_selector.clone(), delay),
                     move |result, ctx| {
                         // Remove the senders from the maps.
                         if let Some(handle) = handle.upgrade(ctx) {
@@ -546,7 +543,7 @@ impl ShellCommandExecutor {
     fn action_result_future(
         &mut self,
         block_selector: BlockSelector,
-        delay: Option<ShellCommandDelay>,
+        delay: ActionResultDelay,
     ) -> impl Spawnable<Output = ActionResult> {
         // Create a channel to notify us when we receive block metadata.
         let (block_metadata_received_tx, block_metadata_received_rx) = oneshot::channel();
@@ -578,16 +575,16 @@ impl ShellCommandExecutor {
             // current state.  Otherwise, we'll wait indefinitely for the command to
             // finish executing.
             let mut timeout = match delay {
-                Some(ShellCommandDelay::Duration(duration)) => {
+                ActionResultDelay::Duration(duration) => {
                     // Enforce a maximum allowed delay that the agent may request, never waiting longer than MAX_AGENT_DELAY_DURATION.
                     // If the requested duration exceeds this cap, we'll still behave as if the agent may expect a running command,
                     // so there's no need to signal preemption (the agent already anticipates an incomplete command state).
                     Timer::after(duration.min(Self::MAX_AGENT_DELAY_DURATION))
                 }
-                Some(ShellCommandDelay::OnCompletion) => {
-                    Timer::after(Self::MAX_AGENT_DELAY_DURATION)
+                ActionResultDelay::OnCompletion { timeout } => {
+                    Timer::after(timeout.min(Self::MAX_AGENT_DELAY_DURATION))
                 }
-                None => Timer::after(Self::MAX_WAIT_DURATION),
+                ActionResultDelay::Default => Timer::after(Self::MAX_WAIT_DURATION),
             }
             .fuse();
 
@@ -614,8 +611,8 @@ impl ShellCommandExecutor {
             // true completion from a forced client poll (`ForceRefresh`) or a timeout during `on_completion`.
             let is_preempted = matches!(wake_reason, WakeReason::ForceRefresh)
                 || matches!(
-                    (&wake_reason, &delay),
-                    (WakeReason::Timeout, Some(ShellCommandDelay::OnCompletion))
+                    (wake_reason, delay),
+                    (WakeReason::Timeout, ActionResultDelay::OnCompletion { .. })
                 );
 
             // At this point, we've either received block metadata or we've timed out.
@@ -715,6 +712,126 @@ impl ShellCommandExecutor {
     ) -> BoxFuture<'static, ()> {
         futures::future::ready(()).boxed()
     }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ActionResultDelay {
+    Default,
+    Duration(Duration),
+    OnCompletion { timeout: Duration },
+}
+
+impl ActionResultDelay {
+    fn from_shell_command_delay(delay: Option<ShellCommandDelay>) -> Self {
+        match delay {
+            Some(ShellCommandDelay::Duration(duration)) => Self::Duration(duration),
+            Some(ShellCommandDelay::OnCompletion) => Self::OnCompletion {
+                timeout: ShellCommandExecutor::MAX_AGENT_DELAY_DURATION,
+            },
+            None => Self::Default,
+        }
+    }
+}
+
+fn effective_read_shell_command_delay(
+    command: &str,
+    delay: Option<ShellCommandDelay>,
+) -> ActionResultDelay {
+    if command_starts_non_terminating_session(command)
+        && matches!(delay, None | Some(ShellCommandDelay::OnCompletion))
+    {
+        return ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_WAIT_DURATION,
+        };
+    }
+
+    ActionResultDelay::from_shell_command_delay(delay)
+}
+
+fn command_starts_non_terminating_session(command: &str) -> bool {
+    let command = command.trim_start();
+    in_band_generator_command(command)
+        .as_deref()
+        .is_some_and(command_starts_non_terminating_session)
+        || parse_interactive_ssh_command(command).is_some()
+        || normalized_ssh_command(command)
+            .as_deref()
+            .is_some_and(|command| parse_interactive_ssh_command(command).is_some())
+        || first_executable_name(command).is_some_and(|name| {
+            matches!(
+                name.as_str(),
+                "mosh" | "mosh.exe" | "sftp" | "sftp.exe" | "telnet" | "telnet.exe"
+            )
+        })
+}
+
+fn in_band_generator_command(command: &str) -> Option<String> {
+    let tokens = shell_words::split(command.trim_start()).ok()?;
+    if tokens.len() >= 3
+        && (tokens[0].eq_ignore_ascii_case("Warp-Run-GeneratorCommand")
+            || tokens[0] == "warp_run_generator_command")
+    {
+        Some(tokens[2].clone())
+    } else {
+        None
+    }
+}
+
+fn normalized_ssh_command(command: &str) -> Option<String> {
+    let (token, rest) = first_executable_token(command)?;
+    let name = command_basename(token);
+    if name.eq_ignore_ascii_case("ssh") || name.eq_ignore_ascii_case("ssh.exe") {
+        Some(format!("ssh{rest}"))
+    } else {
+        None
+    }
+}
+
+fn first_executable_name(command: &str) -> Option<String> {
+    let (token, _) = first_executable_token(command)?;
+    Some(command_basename(token).to_ascii_lowercase())
+}
+
+fn first_executable_token(command: &str) -> Option<(&str, &str)> {
+    let (token, rest) = first_command_token(command)?;
+    if token == "&" || token.eq_ignore_ascii_case("command") {
+        first_command_token(rest)
+    } else {
+        Some((token, rest))
+    }
+}
+
+fn first_command_token(command: &str) -> Option<(&str, &str)> {
+    let command = command.trim_start();
+    if command.is_empty() {
+        return None;
+    }
+
+    let mut chars = command.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return None;
+    };
+    if first == '"' || first == '\'' {
+        for (idx, ch) in chars {
+            if ch == first {
+                let token = &command[first.len_utf8()..idx];
+                let rest = &command[idx + ch.len_utf8()..];
+                return Some((token, rest));
+            }
+        }
+
+        return Some((&command[first.len_utf8()..], ""));
+    }
+
+    let end = command.find(char::is_whitespace).unwrap_or(command.len());
+    Some((&command[..end], &command[end..]))
+}
+
+fn command_basename(command_token: &str) -> &str {
+    command_token
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(command_token)
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -944,3 +1061,7 @@ enum ActionResult {
     Cancelled,
     BlockNotFound,
 }
+
+#[cfg(test)]
+#[path = "shell_command_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -400,6 +400,12 @@ impl ShellCommandExecutor {
                     ));
                 }
                 let command = block.command_with_secrets_unobfuscated(false);
+                // 仅在 `ReadShellCommandOutput` 路径上根据命令内容下调等待时长:此处
+                // 是 agent 对一个**仍在运行**的 block 的二次轮询,默认走 `OnCompletion`
+                // 时会等满 `MAX_AGENT_DELAY_DURATION`(120s)。对 ssh / mosh / sftp /
+                // telnet 等永不主动退出的交互会话来说,这种等待没有意义。
+                // `RequestCommandOutput`(首次发起)使用 `MAX_WAIT_DURATION = 2s` 的默
+                // 认超时,本就不会卡 120s,因此无需同样处理。
                 let delay = effective_read_shell_command_delay(&command, delay.clone());
                 drop(model);
 
@@ -714,6 +720,11 @@ impl ShellCommandExecutor {
     }
 }
 
+/// `action_result_future` 内部使用的等待策略。
+///
+/// 相比对外的 `Option<ShellCommandDelay>`,这里把 `OnCompletion` 的 timeout
+/// 从隐式常量提升为显式字段,便于按命令场景动态调整(见
+/// `effective_read_shell_command_delay`)。
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum ActionResultDelay {
     Default,
@@ -733,6 +744,19 @@ impl ActionResultDelay {
     }
 }
 
+/// 把 agent 请求的 `ShellCommandDelay` 映射成内部使用的 `ActionResultDelay`,
+/// 并对**永不主动退出**的交互会话(ssh / mosh / sftp / telnet 等)做特殊处理:
+///
+/// 1. `Some(OnCompletion)` —— 把 timeout 从 `MAX_AGENT_DELAY_DURATION`(120s)
+///    缩短到 `MAX_WAIT_DURATION`(2s),避免 agent 在永不结束的命令上死等。
+/// 2. `None`(默认)—— 主动**升级**为 `OnCompletion { 2s }`,而不是保留
+///    `Default`。注意这会同步改变 `action_result_future` 内 `is_preempted` 的
+///    取值:`Default` + `Timeout` 不算抢占,而 `OnCompletion` + `Timeout` 会
+///    标记为抢占,从而让 server 把这次快照理解为"先看一眼"而非"命令完成"。
+///    对交互会话来说这是正确语义。
+/// 3. `Some(Duration(d))` —— 保留 agent 的显式请求,不做改写。
+///
+/// 非交互命令一律走 `from_shell_command_delay` 的原始映射。
 fn effective_read_shell_command_delay(
     command: &str,
     delay: Option<ShellCommandDelay>,
@@ -748,6 +772,15 @@ fn effective_read_shell_command_delay(
     ActionResultDelay::from_shell_command_delay(delay)
 }
 
+/// 判断 `command` 是否会启动一个**永不主动退出**的交互会话。命中规则:
+/// - 被 Warp generator wrapper 包裹的命令,递归判断内部命令。
+/// - 裸 `ssh ...`(走 `parse_interactive_ssh_command`,会正确排除 `-T` / `-W`
+///   等非交互形式)。
+/// - 带路径或带 `.exe` 的 ssh(改写为裸 `ssh` 后再判)。
+/// - `mosh` / `sftp` / `telnet`(含 `.exe`)等没有 ssh 那样的非交互旗标,直接按
+///   可执行名匹配即可。
+///
+/// 仅供 `effective_read_shell_command_delay` 使用的启发式检测,误判后果有限。
 fn command_starts_non_terminating_session(command: &str) -> bool {
     let command = command.trim_start();
     in_band_generator_command(command)
@@ -765,6 +798,17 @@ fn command_starts_non_terminating_session(command: &str) -> bool {
         })
 }
 
+/// 解开 Warp 自身的 generator wrapper,把里面真正要跑的命令抽出来。
+///
+/// wrapper 协议形如:`<wrapper> <generator_id> '<inner_command>' [extra flags...]`
+/// 其中:
+/// - `<wrapper>` 是 `warp_run_generator_command`(POSIX shell)或
+///   `Warp-Run-GeneratorCommand`(PowerShell,大小写不敏感)。
+/// - `<generator_id>` 是数字 id,这里不解析,直接跳过。
+/// - `<inner_command>` 是被单引号包裹的真实命令字符串,也就是我们要返回的内容。
+///
+/// 协议固定按位置取 `tokens[2]`;若后续 wrapper 新增可选参数破坏了位置假设,这
+/// 里会静默失配(返回 None),最坏情况只是退回到旧的 120s 等待,不会引入错误行为。
 fn in_band_generator_command(command: &str) -> Option<String> {
     let tokens = shell_words::split(command.trim_start()).ok()?;
     if tokens.len() >= 3
@@ -777,6 +821,14 @@ fn in_band_generator_command(command: &str) -> Option<String> {
     }
 }
 
+/// 当命令的可执行入口是带路径或带 `.exe` 后缀的 ssh 时,把它改写为裸 `ssh`,
+/// 以便复用 `parse_interactive_ssh_command` 这套只接受 `^ssh\s+...` 的解析。
+///
+/// 例如 `"C:\Windows\System32\OpenSSH\ssh.exe" host -p 22` 会被改写为
+/// `ssh host -p 22`。其余参数原样保留(`rest` 是 `first_executable_token` 切
+/// 完第一个 token 后的剩余字符串)。
+///
+/// 命名上只做"前缀改写",不规范化路径中的反斜杠/引号,也不展开转义。
 fn normalized_ssh_command(command: &str) -> Option<String> {
     let (token, rest) = first_executable_token(command)?;
     let name = command_basename(token);
@@ -792,6 +844,11 @@ fn first_executable_name(command: &str) -> Option<String> {
     Some(command_basename(token).to_ascii_lowercase())
 }
 
+/// 返回命令真正的"可执行入口" token,跳过常见的调用前缀:
+/// - PowerShell 调用运算符 `&`(必须是独立 token,如 `& "C:\...\ssh.exe" host`)。
+/// - POSIX `command` 内建(`command ssh host`),用于绕过 alias/function。
+///
+/// 只剥离一层前缀,够覆盖实际场景;不支持 `&&` 链、`call`、`exec` 等其他形态。
 fn first_executable_token(command: &str) -> Option<(&str, &str)> {
     let (token, rest) = first_command_token(command)?;
     if token == "&" || token.eq_ignore_ascii_case("command") {
@@ -801,6 +858,18 @@ fn first_executable_token(command: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// 启发式 tokenization:取出命令的第一个 token,以及它后面剩余的原始字符串。
+///
+/// 故意**不**使用 `shell_words::split`,原因有二:
+/// 1. `shell_words` 会因 PowerShell 调用运算符 `&` 等非 POSIX 字符直接 fail,
+///    而我们需要识别这类形态。
+/// 2. 我们只需要"第一个 token + rest"两段,不需要完整 token 流,手写更直接。
+///
+/// 引号处理只识别字符串**起始位置**的 `"` 或 `'`,且不处理转义。为了避免
+/// `"foo"bar`、`"ssh"hello-world` 这类"右引号后还粘着字符"的输入被错切成
+/// `foo` / `ssh` 进而触发**误检**(把普通命令认成交互会话),这里要求右引号
+/// 后必须紧跟空白或字符串结尾;不满足就返回 `None`,让上层走"退回到旧的等待
+/// 行为"这条安全分支,而不是冒着 false-positive 风险硬切。
 fn first_command_token(command: &str) -> Option<(&str, &str)> {
     let command = command.trim_start();
     if command.is_empty() {
@@ -808,19 +877,23 @@ fn first_command_token(command: &str) -> Option<(&str, &str)> {
     }
 
     let mut chars = command.char_indices();
-    let Some((_, first)) = chars.next() else {
-        return None;
-    };
+    let (_, first) = chars.next()?;
     if first == '"' || first == '\'' {
         for (idx, ch) in chars {
             if ch == first {
                 let token = &command[first.len_utf8()..idx];
                 let rest = &command[idx + ch.len_utf8()..];
+                // 右引号后必须是空白或字符串末尾;否则视为无法 tokenize,
+                // 让调用方退回到不抢占的安全路径。
+                if !rest.is_empty() && !rest.starts_with(char::is_whitespace) {
+                    return None;
+                }
                 return Some((token, rest));
             }
         }
 
-        return Some((&command[first.len_utf8()..], ""));
+        // 没找到配对的右引号:同样视为无法 tokenize。
+        return None;
     }
 
     let end = command.find(char::is_whitespace).unwrap_or(command.len());

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -1,0 +1,111 @@
+use std::time::Duration;
+
+use super::*;
+
+#[test]
+fn detects_interactive_session_commands_across_platforms() {
+    for command in [
+        "ssh root@example.com",
+        "command ssh localhost",
+        "ssh.exe -p 2222 root@example.com",
+        "/usr/bin/ssh host",
+        r#""C:\Windows\System32\OpenSSH\ssh.exe" -p 22 host"#,
+        r#"& "C:\Program Files\OpenSSH\ssh.exe" host"#,
+        "warp_run_generator_command 42 'ssh host'",
+        " warp_run_generator_command 42 'ssh host'",
+        "Warp-Run-GeneratorCommand 42 'ssh host' -ErrorAction Ignore",
+        r#"warp_run_generator_command 42 '"C:\Windows\System32\OpenSSH\ssh.exe" host'"#,
+        "gcloud compute ssh --zone us-west1-a my-instance",
+        "eb ssh --profile my-profile my-env",
+        "doctl compute ssh --region nyc1 my-droplet",
+        "mosh root@example.com",
+        "sftp root@example.com",
+        "telnet example.com",
+    ] {
+        assert_eq!(
+            command_starts_non_terminating_session(command),
+            true,
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn does_not_detect_unrelated_or_non_interactive_ssh_commands() {
+    for command in [
+        "",
+        "echo ssh",
+        "git status",
+        "ssh-add-key",
+        "ssh -T user@host",
+        "ssh -v user@host -W localhost:22",
+        "ssh user@host ls",
+        "ssh.exe user@host ls",
+        r#""C:\Windows\System32\OpenSSH\ssh.exe" user@host ls"#,
+        r#"& "C:\Program Files\OpenSSH\ssh.exe" user@host ls"#,
+        "warp_run_generator_command 42 'ssh user@host ls'",
+        "Warp-Run-GeneratorCommand 42 'git status' -ErrorAction Ignore",
+        "rsync myfile.txt ssh://user@server.com",
+    ] {
+        assert_eq!(
+            command_starts_non_terminating_session(command),
+            false,
+            "{command}"
+        );
+    }
+}
+
+#[test]
+fn shortens_on_completion_delay_for_interactive_sessions() {
+    assert_eq!(
+        effective_read_shell_command_delay("ssh host", Some(ShellCommandDelay::OnCompletion)),
+        ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_WAIT_DURATION
+        }
+    );
+    assert_eq!(
+        effective_read_shell_command_delay(
+            r#"& "C:\Program Files\OpenSSH\ssh.exe" host"#,
+            Some(ShellCommandDelay::OnCompletion)
+        ),
+        ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_WAIT_DURATION
+        }
+    );
+    assert_eq!(
+        effective_read_shell_command_delay(
+            "warp_run_generator_command 42 'ssh host'",
+            Some(ShellCommandDelay::OnCompletion)
+        ),
+        ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_WAIT_DURATION
+        }
+    );
+    assert_eq!(
+        effective_read_shell_command_delay("mosh host", None),
+        ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_WAIT_DURATION
+        }
+    );
+}
+
+#[test]
+fn preserves_explicit_or_non_interactive_read_delays() {
+    assert_eq!(
+        effective_read_shell_command_delay(
+            "ssh host",
+            Some(ShellCommandDelay::Duration(Duration::from_secs(8)))
+        ),
+        ActionResultDelay::Duration(Duration::from_secs(8))
+    );
+    assert_eq!(
+        effective_read_shell_command_delay("git status", Some(ShellCommandDelay::OnCompletion)),
+        ActionResultDelay::OnCompletion {
+            timeout: ShellCommandExecutor::MAX_AGENT_DELAY_DURATION
+        }
+    );
+    assert_eq!(
+        effective_read_shell_command_delay("git status", None),
+        ActionResultDelay::Default
+    );
+}

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -46,6 +46,11 @@ fn does_not_detect_unrelated_or_non_interactive_ssh_commands() {
         "warp_run_generator_command 42 'ssh user@host ls'",
         "Warp-Run-GeneratorCommand 42 'git status' -ErrorAction Ignore",
         "rsync myfile.txt ssh://user@server.com",
+        // 右引号后还粘着字符,故意拒绝 tokenize,避免被错切成 `ssh`
+        // 然后通过 `ssh hello-world` 误判为交互会话。
+        r#""ssh"hello-world"#,
+        // 未闭合的引号同样拒绝 tokenize。
+        r#""ssh hello world"#,
     ] {
         assert_eq!(
             command_starts_non_terminating_session(command),

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use super::super::proto::{Authenticate, Initialize};
 use super::super::protocol::RequestId;
+#[cfg(feature = "local_fs")]
+use super::super::server_buffer_tracker::ServerBufferTracker;
 use super::{PendingFileOps, ServerModel};
 
 fn test_model() -> ServerModel {
@@ -13,6 +15,8 @@ fn test_model() -> ServerModel {
         host_id: "test-host-id".to_string(),
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
+        #[cfg(feature = "local_fs")]
+        buffers: ServerBufferTracker::new(),
         auth_token: None,
     }
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [x] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command execution to better detect interactive/non-terminating sessions and adjust polling, timeouts, and completion behavior for more reliable output handling.

* **Tests**
  * Added unit tests covering interactive-command detection and mapping of read delays to ensure correct timeout and completion semantics.
  * Extended a test model setup to conditionally include a buffer tracker under a specific feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->