### PR TITLE
fix(ai): read_skill 在 cache miss 时按路径读盘兜底

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/read_skill.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill.rs
@@ -1,7 +1,9 @@
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
-use crate::ai::skills::{SkillManager, SkillTelemetryEvent};
+use crate::ai::agent::AIAgentActionResultType;
+use crate::ai::skills::{extract_skill_parent_directory, SkillManager, SkillTelemetryEvent};
 use crate::send_telemetry_from_ctx;
 use ai::agent::action_result::AnyFileContent;
+use ai::skills::{parse_skill, SkillReference};
 use warpui::{ModelContext, SingletonEntity};
 
 use crate::ai::agent::AIAgentActionType;
@@ -35,7 +37,7 @@ impl ReadSkillExecutor {
         let ExecuteActionInput { action, .. } = input;
         let AIAgentActionType::ReadSkill(ReadSkillRequest { skill: skill_ref }) = &action.action
         else {
-            return ActionExecution::<ReadSkillResult>::InvalidAction;
+            return ActionExecution::InvalidAction;
         };
 
         match SkillManager::as_ref(ctx).skill_by_reference(skill_ref) {
@@ -59,6 +61,48 @@ impl ReadSkillExecutor {
                 ActionExecution::Sync(ReadSkillResult::Success { content }.into())
             }
             None => {
+                // Cache miss 兜底:对于 `SkillReference::Path` 形式的引用,
+                // 如果路径形状是合法的 skill 文件
+                // (`.../<provider>/skills/<name>/SKILL.md` 或 warp managed skill 目录下),
+                // 直接读盘解析,修复 issue #99 中描述的「skill 已存在但 cache 未热」场景。
+                //
+                // 设计取舍:
+                // - 不主动 warm SkillManager cache。Cache 由 SkillWatcher 单向维护,
+                //   在这里写入会破坏数据流。重复 read_skill 同一路径会重复读盘,
+                //   但 SKILL.md 通常很小,可忽略。
+                // - `extract_skill_parent_directory` 只校验路径形状,与 cache hit 时
+                //   返回的 path 安全等级一致 —— 都不限定家目录前缀。这是有意的:
+                //   project 内 skill (`/some/repo/.agents/skills/...`) 也需要能读。
+                // - Windows 下正则用反斜杠分隔,Linux 风格 `/home/<u>/...` 路径会被
+                //   拒绝;这意味着本兜底对 "Windows 主进程 + WSL session" 不生效,
+                //   是 issue #99 的已知限制(见 PR 描述)。
+                if let SkillReference::Path(path) = skill_ref {
+                    if extract_skill_parent_directory(path).is_ok() {
+                        let path = path.clone();
+                        let skill_ref_for_async = skill_ref.clone();
+                        return ActionExecution::new_async(
+                            async move { parse_skill(&path) },
+                            move |parsed, _app| match parsed {
+                                Ok(skill) => AIAgentActionResultType::ReadSkill(
+                                    ReadSkillResult::Success {
+                                        content: FileContext::new(
+                                            skill.path.to_string_lossy().into_owned(),
+                                            AnyFileContent::StringContent(skill.content.clone()),
+                                            skill.line_range.clone(),
+                                            None,
+                                        ),
+                                    },
+                                ),
+                                Err(err) => AIAgentActionResultType::ReadSkill(
+                                    ReadSkillResult::Error(format!(
+                                        "Skill not found: {skill_ref_for_async:?} ({err})"
+                                    )),
+                                ),
+                            },
+                        );
+                    }
+                }
+
                 send_telemetry_from_ctx!(
                     SkillTelemetryEvent::Read {
                         reference: skill_ref.clone(),

--- a/app/src/ai/blocklist/action_model/execute/read_skill.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill.rs
@@ -1,9 +1,14 @@
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+#[cfg(feature = "local_fs")]
 use crate::ai::agent::AIAgentActionResultType;
-use crate::ai::skills::{extract_skill_parent_directory, SkillManager, SkillTelemetryEvent};
+use crate::ai::skills::{SkillManager, SkillTelemetryEvent};
+#[cfg(feature = "local_fs")]
+use crate::ai::skills::extract_skill_parent_directory;
 use crate::send_telemetry_from_ctx;
 use ai::agent::action_result::AnyFileContent;
-use ai::skills::{parse_skill, SkillReference};
+use ai::skills::SkillReference;
+#[cfg(feature = "local_fs")]
+use ai::skills::parse_skill;
 use warpui::{ModelContext, SingletonEntity};
 
 use crate::ai::agent::AIAgentActionType;
@@ -76,6 +81,10 @@ impl ReadSkillExecutor {
                 // - Windows 下正则用反斜杠分隔,Linux 风格 `/home/<u>/...` 路径会被
                 //   拒绝;这意味着本兜底对 "Windows 主进程 + WSL session" 不生效,
                 //   是 issue #99 的已知限制(见 PR 描述)。
+                // Cache miss fallback 仅在拥有本地文件系统的构建中可用;
+                // WASM 等无 fs 构建里 `extract_skill_parent_directory` / `parse_skill`
+                // 不存在,自然也无从读盘。
+                #[cfg(feature = "local_fs")]
                 if let SkillReference::Path(path) = skill_ref {
                     if extract_skill_parent_directory(path).is_ok() {
                         let path = path.clone();

--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -140,3 +140,158 @@ fn test_read_skill_executor_file_not_found() {
         });
     });
 }
+
+/// Issue #99 兜底:cache 未命中时,若 SkillReference::Path 指向合法形状的 skill 文件,
+/// 直接读盘并成功返回(走 Async 分支)。
+#[test]
+fn test_read_skill_executor_fallback_reads_disk_on_cache_miss() {
+    let temp_dir = TempDir::new().unwrap();
+    let skill_path = create_test_skill_file(&temp_dir, "fallback-skill", "Read from disk");
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // 注意:不调用 add_skill_for_testing,模拟 cache miss。
+        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("fallback-action".to_string()),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::Path(skill_path.clone()),
+            }),
+            task_id: TaskId::new("fallback-task".to_string()),
+            requires_result: false,
+        };
+
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        let execution = executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            result
+        });
+
+        let AnyActionExecution::Async {
+            execute_future,
+            on_complete,
+        } = execution
+        else {
+            panic!("Cache miss with valid skill path should produce Async execution");
+        };
+
+        let async_result = execute_future.await;
+        let result = app.update(|ctx| on_complete(async_result, ctx));
+
+        match result {
+            AIAgentActionResultType::ReadSkill(ReadSkillResult::Success { content }) => {
+                assert_eq!(content.file_name, skill_path.to_string_lossy().to_string());
+                let body = match &content.content {
+                    ai::agent::action_result::AnyFileContent::StringContent(s) => s.clone(),
+                    ai::agent::action_result::AnyFileContent::BinaryContent(_) => {
+                        panic!("SKILL.md should be parsed as text")
+                    }
+                };
+                assert!(body.contains("fallback-skill"));
+            }
+            other => panic!("Fallback should return Success, got: {other:?}"),
+        }
+    });
+}
+
+/// Issue #99 兜底失败路径:cache 未命中时,若路径形状合法但磁盘上文件不存在
+///(例如校验后被删的竞态),Async 分支的 parse_skill 失败,on_complete 应返回 Error。
+#[test]
+fn test_read_skill_executor_fallback_returns_error_when_file_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    // 路径形状合法,但 SKILL.md 从未被创建。
+    let skill_path = temp_dir
+        .path()
+        .join(".agents/skills/missing-skill/SKILL.md");
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("missing-action".to_string()),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::Path(skill_path),
+            }),
+            task_id: TaskId::new("missing-task".to_string()),
+            requires_result: false,
+        };
+
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        let execution = executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            result
+        });
+
+        let AnyActionExecution::Async {
+            execute_future,
+            on_complete,
+        } = execution
+        else {
+            panic!("Legal-shaped skill path should still produce Async execution before disk check");
+        };
+
+        let async_result = execute_future.await;
+        let result = app.update(|ctx| on_complete(async_result, ctx));
+
+        match result {
+            AIAgentActionResultType::ReadSkill(ReadSkillResult::Error(msg)) => {
+                assert!(msg.starts_with("Skill not found"));
+            }
+            other => panic!("Missing file should resolve to Error, got: {other:?}"),
+        }
+    });
+}
+
+/// Issue #99 安全门:cache 未命中时,若路径不匹配 skill 文件形状,
+/// 直接走 Sync Error 分支,不触发任何磁盘读取。
+#[test]
+fn test_read_skill_executor_rejects_non_skill_path_on_cache_miss() {
+    let temp_dir = TempDir::new().unwrap();
+    // 一个不在 `.<provider>/skills/<name>/SKILL.md` 结构里的随机 markdown 文件。
+    // 即使该文件存在,fallback 也不应读取它 —— extract_skill_parent_directory 会拒绝。
+    let non_skill_path = temp_dir.path().join("random.md");
+    fs::write(&non_skill_path, "not a skill").unwrap();
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("non-skill-action".to_string()),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::Path(non_skill_path),
+            }),
+            task_id: TaskId::new("non-skill-task".to_string()),
+            requires_result: false,
+        };
+
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            match result {
+                AnyActionExecution::Sync(AIAgentActionResultType::ReadSkill(
+                    ReadSkillResult::Error(msg),
+                )) => {
+                    assert!(msg.starts_with("Skill not found"));
+                }
+                _ => panic!(
+                    "Non-skill path on cache miss should return Sync Error, not Async fallback"
+                ),
+            }
+        });
+    });
+}

--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -7,6 +7,7 @@ use crate::ai::agent::{AIAgentAction, AIAgentActionId, AIAgentActionType};
 use crate::ai::blocklist::action_model::AIConversationId;
 use crate::ai::skills::SkillManager;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
+use ai::agent::action_result::AnyFileContent;
 use ai::skills::{parse_skill, SkillReference};
 use repo_metadata::{
     repositories::DetectedRepositories, watcher::DirectoryWatcher, RepoMetadataModel,
@@ -187,8 +188,8 @@ fn test_read_skill_executor_fallback_reads_disk_on_cache_miss() {
             AIAgentActionResultType::ReadSkill(ReadSkillResult::Success { content }) => {
                 assert_eq!(content.file_name, skill_path.to_string_lossy().to_string());
                 let body = match &content.content {
-                    ai::agent::action_result::AnyFileContent::StringContent(s) => s.clone(),
-                    ai::agent::action_result::AnyFileContent::BinaryContent(_) => {
+                    AnyFileContent::StringContent(s) => s.clone(),
+                    AnyFileContent::BinaryContent(_) => {
                         panic!("SKILL.md should be parsed as text")
                     }
                 };

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -31,7 +31,8 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         mod skill_manager;
         pub use skill_manager::{
-            SkillInventoryDuplicate, SkillInventoryItem, SkillManager, SkillManagerEvent,
+            extract_skill_parent_directory, SkillInventoryDuplicate, SkillInventoryItem,
+            SkillManager, SkillManagerEvent,
         };
         #[allow(unused_imports)]
         pub use skill_manager::SkillWatcher;


### PR DESCRIPTION
Closes #99

## Summary

- `ReadSkillExecutor::execute` 在 `SkillManager` 内存 cache miss 时,如果 `SkillReference::Path` 通过结构性安全门 `extract_skill_parent_directory`,通过 `ActionExecution::new_async` 包装 `parse_skill` 直接读盘,返回 `Success`。
- 路径不合 skill 形状 / `BundledSkillId` / 解析失败:维持原 Error 行为。
- 不阻塞 UI 线程(Async),不主动 warm cache(SkillWatcher 单向数据流),不引入新依赖。
- 修复 issue #99 中"`read_skill` 不跟随 symlink"/"`Skill not found`"的实质机制 —— 真正原因不是不跟随 symlink(`parse_skill` 用标准 fs 调用是跟随的),而是 cache 还没建立索引就被调用。
- 上游对照:已搜索 `warpdotdev/warp` 同位置代码 + 全部 WSL/skill 相关 issue/PR,**与 fork 完全一致,且无对应修复**(最接近的 #8657 是 macOS skill discovery 问题,不同根因)。因此自研补丁,而非沿用上游。

## Plan(最终版,见 Phase 2 adversarial-planner 后由我裁定)

1. `app/src/ai/blocklist/action_model/execute/read_skill.rs`:cache miss 分支(`None` 臂)前置一个 fallback —— 仅当 `SkillReference::Path(p)` 且 `extract_skill_parent_directory(p).is_ok()` 时,走 `ActionExecution::new_async`,future 体 `async move { parse_skill(&p) }`,`on_complete` 把 `Result<ParsedSkill, anyhow::Error>` 转成 `ReadSkillResult::Success { content }` 或 `ReadSkillResult::Error(...)`。
2. `app/src/ai/skills/mod.rs`:re-export `extract_skill_parent_directory`(原本只在 `mod skill_manager` 内可见)。
3. `app/src/ai/blocklist/action_model/execute/read_skill_tests.rs`:新增 3 个测试:
   - `test_read_skill_executor_fallback_reads_disk_on_cache_miss`:cache 空 + 合法 skill 路径 → Async Success。
   - `test_read_skill_executor_fallback_returns_error_when_file_missing`:cache 空 + 合法 skill 路径但文件不存在(竞态)→ Async Error。
   - `test_read_skill_executor_rejects_non_skill_path_on_cache_miss`:cache 空 + 非 skill 形状路径 → Sync Error,不读盘。

**Out of scope**(显式不做的,避免 scope creep):

- 不动 `SkillManager` 扫描逻辑;不引入 WSL 端 skill discovery。后者需要 session-scoped `SkillManager` lifecycle,或 UNC 路径监听,改动远大于"修复"且与上游分歧大,作为 follow-up issue。
- 不主动 warm cache —— cache 由 `SkillWatcher` 单向维护,write-on-read 会破坏数据流;SKILL.md 通常 < 几 KB,重复读盘成本可忽略。
- 不改 `parse_skill` 的 `SkillScope`(fork 当前一律 `Project`,fallback 与 cache hit 行为一致)。
- 不动 `SKILL_FILE_PATTERN`(改动会牵连 project-level skills 的读盘)。
- 不发 fallback 路径 telemetry(fork 内 `send_telemetry_from_ctx!` 是 no-op shim,保持改动最小)。

## Verification

```
$ cargo check -p warp
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.08s
(0 error / 0 warning)

$ cargo test -p warp --lib read_skill
running 5 tests
test ai::blocklist::action_model::execute::read_skill::tests::test_read_skill_executor_file_not_found ... ok
test ai::blocklist::action_model::execute::read_skill::tests::test_read_skill_executor_fallback_returns_error_when_file_missing ... ok
test ai::blocklist::action_model::execute::read_skill::tests::test_read_skill_executor_success ... ok
test ai::blocklist::action_model::execute::read_skill::tests::test_read_skill_executor_fallback_reads_disk_on_cache_miss ... ok
test ai::blocklist::action_model::execute::read_skill::tests::test_read_skill_executor_rejects_non_skill_path_on_cache_miss ... ok

test result: ok. 5 passed; 0 failed; 0 ignored
```

注:`cargo nextest` 未安装,改用 `cargo test`。

## Known Limitations(本 PR 不处理,留作 follow-up)

1. **Skill discovery 阶段未修**:`SkillManager` 仍只用 `dirs::home_dir()` 扫一次。Warp 主进程在 Windows 上时,`dirs::home_dir()` 返回 `C:\Users\<u>`,看不到 WSL 端 `/home/<u>/.agents/skills`。这是 Warp 架构性限制,需要 session-scoped SkillManager 或 remote 端 SkillManager 镜像才能根治。
2. **Windows 进程下 fallback 也不奏效**:`SKILL_FILE_PATTERN` 在 `target_os = "windows"` 下用反斜杠,Linux 风格 `/home/<u>/.warp/skills/...` 路径会被结构正则拒绝,从而无法进入 fallback。所以本 PR 对 "Windows 进程 + WSL session" 这一 issue 描述的主场景**不生效**;它对 **Linux 原生 Warp** 与 **WSL 内运行的 Linux ELF Warp** 完全有效,以及对 SkillWatcher 还没扫到目录的竞态自愈也有效。
3. **未提供 in-product warning**:Windows 版本应在 SkillManager 初始化时给用户提示"WSL home 不会被扫描",本 PR 不做,留作 UI follow-up。

## Unresolved Findings(reviewer 标 minor,未阻塞)

- `test_read_skill_executor_file_not_found` 测试名称在新代码下语义不准(实际测的是"非 skill 形状路径被拒",而非"文件缺失");按 surgical changes 原则未改名。
- fork baseline `app/src/autoupdate/linux_test.rs` 引用已不存在的 `repo_name`,本地跑测试需临时绕过 —— **与本 PR 无关**,但建议另起 PR 修复。

## Agent Mode

本 PR 由 Claude Code 在 /issue 工作流下生成。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fallback mechanism to read skills directly from disk when not cached, improving system resilience and availability.
  * Enhanced error handling with more descriptive messages when skills are missing or invalid.

* **Tests**
  * Added comprehensive unit test coverage for skill cache-miss scenarios with various file validation conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerx-lab/warp/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->