### PR TITLE
ci(release): build RPM package for Linux x86_64

### DIFF
--- a/.github/workflows/openwarp_release.yml
+++ b/.github/workflows/openwarp_release.yml
@@ -1,10 +1,10 @@
 # OpenWarp 发布流水线 — 在 openWarp 分支上 push tag (v*) 即触发
 #
 # 与上游 create_release.yml 的差异:
-# - 仅 macOS arm64 + macOS Intel + Windows x64 + Linux x86_64(AppImage),
-#   Web/CLI/Universal/Win-arm64/Linux 的 rpm/arch 全砍
-#   (macOS 双架构分别产单架构 DMG 与 CLI tarball;Linux 只产 AppImage/deb,
-#    不发布上游 Warp 仓库源或签名 key)
+# - 仅 macOS arm64 + macOS Intel + Windows x64 + Linux x86_64,
+#   Web/CLI/Universal/Win-arm64 全砍
+#   (macOS 双架构分别产单架构 DMG 与 CLI tarball;Linux 产 AppImage/deb/rpm
+#    以及尽力而为的 Arch 包,不发布上游 Warp 仓库源或签名 key)
 # - 单 channel: preview(由 release_configurations.json 提供配置)
 # - 不签名:不传 --read-passwords-from-env(macOS) / 不设 SIGN_TOOL_CMD(Windows)
 # - 不上传 GCS / 第三方 crash 平台 / Slack / changelog,不调 channel-versions repository_dispatch
@@ -236,10 +236,11 @@ jobs:
           is_self_hosted: false
           install_release_deps: true
 
-      - name: Install extra dependencies for deb and build
+      - name: Install extra dependencies for deb/rpm and build
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev fakeroot
+          # `rpm` 包提供 /usr/bin/rpmbuild,给后面的 RPM 打包步骤用。
+          sudo apt-get install -y libdbus-1-dev fakeroot rpm
         shell: bash
 
       - name: Ensure rust target is installed
@@ -269,6 +270,19 @@ jobs:
           # ubuntu-22.04 默认有 libfuse2 但 24.04 没有;统一开 EXTRACT_AND_RUN
           # 让 linuxdeploy/appimagetool 不依赖 FUSE 内核模块,跨 runner 版本都稳。
           APPIMAGE_EXTRACT_AND_RUN: 1
+
+      # RPM 包:复用上一步 release-lto 已经 strip 过的 `target/release-lto/warp-oss`,
+      # 不重新 `cargo build`。`--skip-build` 让 `script/bundle` 跳过编译与 strip,
+      # 直接进入 staging(`bundle_install` → 复制二进制 + resources)+ rpmbuild。
+      # 与 deb 同一台 ubuntu-22.04 runner 上跑,共享 host glibc 链接的产物;
+      # 用 Fedora 26+ / RHEL 8+ 上的 RPM 4.13+ 安装(spec 用了 boolean dep 语法)。
+      # continue-on-error: 即便 rpmbuild 失败也不应阻塞 AppImage/deb 已经成功的发布。
+      - name: Build RPM package (reuse release-lto binary)
+        continue-on-error: true
+        run: script/bundle --skip-build --channel "$CHANNEL" --arch x86_64 --packages rpm
+        shell: bash
+        env:
+          GIT_RELEASE_TAG: ${{ needs.prepare_metadata.outputs.release_tag }}
 
       # Arch 包:复用上一步 release-lto 已经 strip 过的 `target/release-lto/warp-oss`,
       # 不重新 `cargo build` 主二进制 —— `--skip-build` 让 `script/bundle` 跳过编译与 strip,

--- a/script/linux/bundle_rpm
+++ b/script/linux/bundle_rpm
@@ -62,11 +62,15 @@ cleanup() {
 trap cleanup EXIT
 
 # Construct a directory that contains the build tree.
+# rpmbuild 在 _topdir 下需要 SPEC/RPMS/BUILD/BUILDROOT/SOURCES/SRPMS 六个目录,
+# 部分版本不会自动创建,事先建好避免「No such file or directory」。
 rm -rf "$RPMBUILD_DIR"
-mkdir -p "$RPMBUILD_DIR"/{SPEC,RPMS}
+mkdir -p "$RPMBUILD_DIR"/{SPEC,RPMS,BUILD,BUILDROOT,SOURCES,SRPMS}
 
 # Move the RPM-specific package metadata into the package directory.
-VERSION="$GIT_RELEASE_TAG"
+# 去掉标签的前导 `v`,与 deb 保持一致;RPM 的 Version 字段按惯例不带 `v` 前缀,
+# 同时也避免下游 `RPM_NAME` 拼接时混入 `v` 让文件名不规范。
+VERSION="${GIT_RELEASE_TAG#v}"
 RELEASE="1"
 sed \
     "s#@@CHANNEL_SUFFIX@@#$CHANNEL_SUFFIX#g; \


### PR DESCRIPTION
Closes #79

## Summary

- 在 `release_linux` job 的 apt-get 中追加 `rpm` 包(Ubuntu 22.04 上提供 `/usr/bin/rpmbuild`)。
- 在 AppImage/deb 步骤之后追加独立的 **Build RPM package** 步骤,沿用 Arch 步骤的 `continue-on-error: true` 模式,通过 `--skip-build --packages rpm` 复用已 strip 的 `release-lto` 二进制。
- 产物落到现有 `packages_dir`,会自动随 `Upload package artifacts` 一起进 GitHub Release,无需改 upload 步骤。
- 修 `script/linux/bundle_rpm` 两个潜在 bug:版本字符串没去掉 `v` 前缀(与 `bundle_deb` 不一致,且 RPM 拒绝以字母开头的版本);`rpmbuild` `_topdir` 下子目录不全(只建了 `SPEC/RPMS`,缺 `BUILD/BUILDROOT/SOURCES/SRPMS`)。
- 更新 workflow 头部注释,反映 rpm 已恢复。
- 不签名、不发布 DNF/YUM repo,纯产物随 GitHub Release 分发,与现有 deb/AppImage 策略一致。

## Plan

1. `script/linux/bundle_rpm`:`VERSION="${GIT_RELEASE_TAG#v}"`,去掉前导 `v`,与 deb 保持一致。
2. `script/linux/bundle_rpm`:`mkdir -p "$RPMBUILD_DIR"/{SPEC,RPMS,BUILD,BUILDROOT,SOURCES,SRPMS}` 预建全部六个 rpmbuild 工作目录。
3. `.github/workflows/openwarp_release.yml`:apt-get install 增加 `rpm`。
4. `.github/workflows/openwarp_release.yml`:在 AppImage/deb 步骤之后插入独立的 **Build RPM package (reuse release-lto binary)** 步骤,`continue-on-error: true`,`run: script/bundle --skip-build --channel "$CHANNEL" --arch x86_64 --packages rpm`,env 注入 `GIT_RELEASE_TAG`。
5. 更新头部说明:`Linux 产 AppImage/deb/rpm 以及尽力而为的 Arch 包`。

## Verification

- `bash -n script/linux/bundle_rpm` → syntax OK。
- 验证 `VERSION="${GIT_RELEASE_TAG#v}"`:`v0.2026.05.20.0000` → `0.2026.05.20.0000`;空值 → 空(无回归)。
- 验证 `mkdir -p .../{SPEC,RPMS,BUILD,BUILDROOT,SOURCES,SRPMS}` 创建全部六个目录。
- `cargo check --workspace --exclude command-signatures-v2` 通过(未触及 Rust 代码,仅形式上验证)。
- YAML 经目视审查(环境无 `pyyaml` / `actionlint` 可用);新步骤缩进与既有 Arch 步骤完全一致。
- 端到端真实验证需要在 tag push 后触发 workflow。`continue-on-error: true` 兜底,即便 rpmbuild 在生产环境首次跑失败,AppImage/deb 仍能正常发布。

## Unresolved

以下均为 reviewer 标记的 minor,本 PR 故意不动(AGENTS.md rule 3:surgical changes only),建议作为独立 follow-up:

- `resources/linux/rpm/cli/warp.spec.template` lines 14–18 的 `Obsoletes:` 用了 `v0.2026.*` 前缀,与新版本字符串不再匹配 — 历史遗留(改 `v` 前 RPM 也会拒绝以字母开头的版本)。
- 仓库无 `actionlint` 校验步骤,workflow 改动只能靠目视审查 + 首次 release 暴露问题。
- 两个 spec 模板的 `Vendor:` / `Url:` 仍指向上游 Warp(纯品牌文案)。
- spec `Requires:` 用了 RPM 4.13+ 的 boolean dep 语法,RHEL 7 / RPM 4.11 用户装不上(可在 release notes 标注;Fedora 26+ / RHEL 8+ / openSUSE Leap 15+ 都满足)。