### PR TITLE
fix(context_chips): refresh branch dropdown when initially empty

### DIFF
--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -303,7 +303,3 @@ fn package_name(channel: Channel) -> &'static str {
         Channel::Oss => "warp-oss",
     }
 }
-
-#[cfg(test)]
-#[path = "linux_test.rs"]
-mod tests;

--- a/app/src/autoupdate/linux_test.rs
+++ b/app/src/autoupdate/linux_test.rs
@@ -1,7 +1,0 @@
-use super::*;
-
-#[test]
-fn test_repo_name() {
-    assert_eq!(repo_name(Channel::Dev), "warpdotdev-dev");
-    assert_eq!(repo_name(Channel::Stable), "warpdotdev");
-}

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1458,12 +1458,37 @@ impl CurrentPrompt {
                         let current_branch = me
                             .latest_chip_value(&ContextChipKind::ShellGitBranch)
                             .cloned();
-                        if current_branch.as_ref() != Some(&new_branch) {
+                        let branch_changed = current_branch.as_ref() != Some(&new_branch);
+                        if branch_changed {
                             me.update_chip_value(
                                 &ContextChipKind::ShellGitBranch,
                                 Some(new_branch),
                             );
-                            // Refresh the branch dropdown so it stays in sync.
+                        }
+                        // Refresh the branch dropdown when the branch name
+                        // changed, OR when the dropdown has never been
+                        // populated yet. Once the filesystem watcher takes
+                        // over (`is_updated_externally` returns true), the
+                        // 30s periodic timer in `fetch_chip_value_at_interval`
+                        // is suppressed, so this `MetadataChanged` path is the
+                        // only one that keeps the dropdown in sync. Gating the
+                        // refresh on a branch-name change alone left the
+                        // dropdown permanently empty for users who never
+                        // switch branches, because earlier attempts to
+                        // populate it (during the initial `run_chips` /
+                        // `fetch_chip_value_once` call) can silently early-
+                        // return when the session isn't ready yet
+                        // (`prepare_shell_command_context` returns `None`) or
+                        // when chip availability hasn't transitioned to
+                        // `Enabled`. The `last_on_click_values.is_none()`
+                        // guard re-attempts the fetch in that case while
+                        // avoiding a `git branch` invocation on every
+                        // file-save event once the dropdown is populated.
+                        let dropdown_empty = me
+                            .states
+                            .get(&ContextChipKind::ShellGitBranch)
+                            .is_some_and(|state| state.last_on_click_values.is_none());
+                        if branch_changed || dropdown_empty {
                             let chip_kind = ContextChipKind::ShellGitBranch;
                             if let Some(chip) = chip_kind.to_chip() {
                                 if let Some(on_click_gen) = chip.on_click_generator().cloned() {

--- a/app/src/context_chips/current_prompt_test.rs
+++ b/app/src/context_chips/current_prompt_test.rs
@@ -1268,6 +1268,233 @@ fn test_git_status_change_updates_chip_value() {
     });
 }
 
+/// Regression test for the branch-chip dropdown being permanently empty.
+///
+/// Once the filesystem watcher (`GitRepoStatusModel`) takes over updates for
+/// `ShellGitBranch`, the only path that refreshes the dropdown's on-click
+/// values (run via `git --no-optional-locks branch --no-color
+/// --sort=-committerdate`) is the `MetadataChanged` event handler in
+/// `set_git_repo_status`. Previously that handler only refreshed the dropdown
+/// when the **current branch name** changed, so a user sitting on `main` and
+/// never switching branches would see an empty dropdown forever if the
+/// initial population attempt early-returned (e.g. because the session
+/// wasn't ready yet).
+///
+/// This test asserts:
+///   1. When `MetadataChanged` fires and `last_on_click_values` is `None`,
+///      the dropdown is refreshed even if the branch name didn't change.
+///   2. Once `last_on_click_values` is populated, subsequent
+///      `MetadataChanged` events on the same branch do NOT re-run
+///      `git branch` (so file-save bursts don't spawn a shell process every
+///      time).
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_branch_dropdown_refreshes_when_initially_empty() {
+    App::test((), |mut app| async move {
+        let session_id = SessionId::from(901);
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::ShellGitBranch],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        // Executor responses, in order:
+        //   1. `load_external_commands` probe — return "git" so the chip's
+        //      runtime policy sees `git` as available and the chip is Enabled.
+        //   2. First `git branch ... --sort=-committerdate` invocation triggered
+        //      by the same-branch `MetadataChanged` event after we manually
+        //      clear `last_on_click_values`.
+        let executor = Arc::new(RecordingCommandExecutor::with_success_responses([
+            "git\n",
+            "* main\n  feature-a\n  feature-b\n",
+        ]));
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let sessions_for_prompt = sessions.clone();
+        let current_prompt =
+            app.add_model(move |ctx| CurrentPrompt::new(sessions_for_prompt.clone(), ctx));
+
+        let session = app
+            .read(|ctx| sessions.as_ref(ctx).get(session_id))
+            .expect("session should exist");
+        session.load_external_commands().await;
+
+        // Set up the per-repo git status watcher with initial metadata on `main`.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "main".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats::default(),
+        };
+        let git_status = app.add_model(move |_| {
+            GitRepoStatusModel::new_for_test(repo_handle, Some(initial_metadata))
+        });
+
+        // Subscribe to git status and seed the prompt context so that
+        // `prepare_shell_command_context` can succeed.
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    Some(session_id),
+                    Some("/tmp/project".to_string()),
+                ),
+                environment: Environment::default(),
+            });
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context_and_session(ctx);
+        });
+
+        // Wait for any in-flight generators kicked off by the initial run to
+        // settle. The `RecordingCommandExecutor` will respond to anything that
+        // happens to fire here using its queue; we explicitly clear the queue
+        // afterwards so the regression assertion only sees the on-click call
+        // we trigger below.
+        current_prompt
+            .update(&mut app, |cp, ctx| cp.await_generators(ctx))
+            .await;
+
+        // Force the empty-dropdown precondition: clear `last_on_click_values`
+        // so the chip looks like it never received a successful on-click
+        // result. Also drain the recorded commands and re-prime the response
+        // queue with the branch-list output so the regression assertion has a
+        // clean baseline.
+        current_prompt.update(&mut app, |cp, _ctx| {
+            let state = cp
+                .states
+                .get_mut(&ContextChipKind::ShellGitBranch)
+                .expect("ShellGitBranch state should exist");
+            state.last_on_click_values = None;
+        });
+        executor.clear();
+        {
+            let mut queue = executor.response_queue.lock();
+            queue.clear();
+            queue.push_back(RecordingCommandExecutor::success_output(
+                "* main\n  feature-a\n  feature-b\n",
+            ));
+        }
+
+        // Fire a `MetadataChanged` event on the SAME branch (`main`). Under
+        // the old code path this was a no-op because the branch name didn't
+        // change. Under the fix, the empty dropdown triggers a refresh.
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(
+                Some(GitStatusMetadata {
+                    current_branch_name: "main".to_string(),
+                    main_branch_name: "main".to_string(),
+                    stats_against_head: DiffStats::default(),
+                }),
+                ctx,
+            );
+        });
+
+        // Await the spawned on-click future so the result lands in state.
+        current_prompt
+            .update(&mut app, |cp, ctx| cp.await_generators(ctx))
+            .await;
+
+        // Assertion 1: the branch-list command was actually run.
+        let commands = executor.commands.lock().clone();
+        assert!(
+            commands
+                .iter()
+                .any(|c| c.contains("git --no-optional-locks branch")),
+            "expected `git branch --sort=-committerdate` to run on same-branch \
+             MetadataChanged when the dropdown was empty; recorded commands: {commands:?}"
+        );
+
+        // Assertion 2: the dropdown is now populated.
+        app.read(|ctx| {
+            let state = current_prompt
+                .as_ref(ctx)
+                .states
+                .get(&ContextChipKind::ShellGitBranch)
+                .expect("ShellGitBranch state should exist");
+            let values = state
+                .last_on_click_values
+                .as_ref()
+                .expect("dropdown should be populated after the refresh");
+            assert!(
+                values.iter().any(|v| v == "main"),
+                "dropdown should contain `main`; got {values:?}"
+            );
+            assert!(
+                values.iter().any(|v| v == "feature-a"),
+                "dropdown should contain `feature-a`; got {values:?}"
+            );
+        });
+
+        // Assertion 3 (anti-regression for file-save bursts): a subsequent
+        // same-branch `MetadataChanged` with `last_on_click_values` already
+        // populated must NOT spawn another `git branch` invocation.
+        executor.clear();
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(
+                Some(GitStatusMetadata {
+                    current_branch_name: "main".to_string(),
+                    main_branch_name: "main".to_string(),
+                    stats_against_head: DiffStats::default(),
+                }),
+                ctx,
+            );
+        });
+        current_prompt
+            .update(&mut app, |cp, ctx| cp.await_generators(ctx))
+            .await;
+        let commands_after = executor.commands.lock().clone();
+        assert!(
+            !commands_after
+                .iter()
+                .any(|c| c.contains("git --no-optional-locks branch")),
+            "no `git branch` should run on same-branch MetadataChanged once the \
+             dropdown is already populated; recorded commands: {commands_after:?}"
+        );
+    });
+}
+
 /// A [`CommandExecutor`] implementation that records which commands were run, but does not
 /// execute them.
 #[derive(Debug, Default)]


### PR DESCRIPTION
## 问题

终端输入框上方 `ShellGitBranch` chip 点开后的 "Search branches..." 菜单**永远是空的**，即使本地 git 仓库有多个分支、底栏的当前分支徽章也正常显示。

复现：
1. 在任意一个有 ≥2 个本地分支的 git 仓库里打开 Warp。
2. 在终端输入区点开 git 分支 chip 的 dropdown（截图里的 "Search branches..." 输入框）。
3. 列表为空。

跑过命令、cd 切目录都不能让列表出现——一直是空。

## 根因

`app/src/context_chips/current_prompt.rs` 的 `set_git_repo_status` 中 `MetadataChanged` handler 把 dropdown 刷新（`refresh_on_click_values`）**耦合**在了「当前分支名变化」这个条件里:

```rust
if current_branch.as_ref() != Some(&new_branch) {
    me.update_chip_value(...);
    me.refresh_on_click_values(...);   // ← 仅在分支名变化时才跑
}
```

一旦文件系统 watcher（`GitRepoStatusModel`）接管 `ShellGitBranch` 的更新源（`is_updated_externally(ShellGitBranch)` 返回 `true` 后），`fetch_chip_value_at_interval` 的 30s 定期 timer 就不会启动（见 `current_prompt.rs:1042-1077`），整个生命周期里只有 `MetadataChanged` 路径会刷新 chip。如果用户**不切分支**，`MetadataChanged` 事件因为分支名等值始终命中 `true`，**永远不会**触发 dropdown 刷新。

又因为 `refresh_on_click_values` 有两个静默早退路径（`current_prompt.rs:889-895` availability 未 ready / `898-900` session 未就绪），首次 `run_chips` 时触发的初始填充可能在 session 还没就绪时就早退了——结果是 dropdown 永远填不上。

## 修复

把 dropdown 刷新从分支名等值检查中**解耦**。新条件：分支名变化 **OR** `last_on_click_values` 是 `None`（dropdown 从未被填充过）。

```rust
let branch_changed = current_branch.as_ref() != Some(&new_branch);
if branch_changed {
    me.update_chip_value(...);
}
let dropdown_empty = me.states.get(&ContextChipKind::ShellGitBranch)
    .is_some_and(|state| state.last_on_click_values.is_none());
if branch_changed || dropdown_empty {
    me.refresh_on_click_values(...);
}
```

这同时解决了三个关联问题:
1. **主 bug**：dropdown 不再仅在分支切换时刷新。
2. **session 抢跑**：如果初始 `refresh_on_click_values` 在 session 就绪前早退，下一次 `MetadataChanged` 会补救（即使分支名没变）。
3. **availability 抢跑**：同上，availability 未 ready 时早退的也能在后续被补救。

并且**没有引入文件保存洪水**：`last_on_click_values.is_none()` 这个 guard 保证一旦 dropdown 填上，后续同分支的 `MetadataChanged`（比如每 5s 节流的文件保存事件）不会重跑 `git branch`。

## 测试

新增 `test_branch_dropdown_refreshes_when_initially_empty`，端到端用 `RecordingCommandExecutor` 验证：

1. **正向**：手动把 `last_on_click_values` 清成 `None`（模拟"首次 refresh 早退"的场景），触发同名分支的 `MetadataChanged`，断言 `git --no-optional-locks branch ...` 真的通过 session 跑了，并且 `last_on_click_values` 被填上了 `main` + `feature-a` 等。
2. **反向（防文件保存洪水）**：dropdown 填上之后再触发一次同名分支的 `MetadataChanged`，断言 **不会**再跑 `git branch`。

测试覆盖了修复 OR 条件的两个分支。

## 相关附带改动

`app/src/autoupdate/linux_test.rs` 引用了在 4e3853fe（"Remove OpenWarp upstream release update paths"）中被删除的 `repo_name` 函数，导致 `cargo test -p warp` 编译失败、阻塞任何新测试的运行。我**作为独立 commit** 删掉了这个 orphan test，commit message 中明示了原因。这是解锁性的必要修复，不是 drive-by 重构。

## 验证

- `cargo check -p warp` 通过。
- `cargo check -p warp --tests` 通过。
- `cargo test -p warp --lib context_chips::current_prompt` 全部 **16/16 通过**（包括新加测试）。
- 全量 `cargo test -p warp --lib` 中有 ~150 个失败,但与本 PR 无关——我验证过这些失败（如 `terminal::view::tests::test_prompt_context_menu_items_*` 缺 `AgentProviderSecrets` 注册）在 main 上同样存在，且不属于 `context_chips` 模块。

## 文件改动

- `app/src/context_chips/current_prompt.rs` (+27 / -2)
- `app/src/context_chips/current_prompt_test.rs` (+227)
- `app/src/autoupdate/linux.rs` (-3)
- `app/src/autoupdate/linux_test.rs` (-7, 删除)