### PR TITLE
fix(warpui): handle text-only keyboard input

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/key_events.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/key_events.rs
@@ -134,6 +134,53 @@ pub fn convert_keyboard_input_event(
     })
 }
 
+pub fn text_fallback_event_for_unconverted_key(
+    chars: Option<String>,
+    state: ElementState,
+    modifiers: ModifiersState,
+    is_synthetic: bool,
+) -> Option<crate::Event> {
+    if is_synthetic
+        || state != ElementState::Pressed
+        || modifiers.control_key()
+        || modifiers.alt_key()
+        || modifiers.super_key()
+    {
+        return None;
+    }
+
+    let chars = chars.filter(|chars| !chars.is_empty())?;
+    if let Some((key, key_chars)) = key_down_for_control_text(&chars) {
+        return Some(crate::event::Event::KeyDown {
+            keystroke: Keystroke {
+                ctrl: false,
+                alt: false,
+                shift: modifiers.shift_key(),
+                cmd: false,
+                meta: false,
+                key: key.to_string(),
+            },
+            chars: key_chars.to_string(),
+            details: KeyEventDetails::default(),
+            is_composing: false,
+        });
+    }
+
+    Some(crate::event::Event::TypedCharacters { chars })
+}
+
+fn key_down_for_control_text(chars: &str) -> Option<(&'static str, &'static str)> {
+    match chars {
+        "\r" => Some(("enter", "\r")),
+        "\n" => Some(("enter", "\n")),
+        "\t" => Some(("tab", "\t")),
+        "\u{8}" => Some(("backspace", "\u{8}")),
+        "\u{7f}" => Some(("delete", "\u{7f}")),
+        "\u{1b}" => Some(("escape", "\u{1b}")),
+        _ => None,
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 /// Returns the base key without any modifiers applied, or `None` if it cannot be determined.
 fn get_key_without_modifiers(input: &winit::event::KeyEvent) -> Option<String> {

--- a/crates/warpui/src/windowing/winit/event_loop/key_events_tests.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/key_events_tests.rs
@@ -1,5 +1,6 @@
-use super::get_input_key;
-use winit::keyboard::{Key::Character, SmolStr};
+use super::{get_input_key, text_fallback_event_for_unconverted_key};
+use winit::event::ElementState;
+use winit::keyboard::{Key::Character, ModifiersState, SmolStr};
 
 #[test]
 fn test_get_input_key() {
@@ -47,4 +48,101 @@ fn test_get_input_key() {
             }
         }
     }
+}
+
+#[test]
+fn text_fallback_emits_typed_characters_for_unmodified_text() {
+    let event = text_fallback_event_for_unconverted_key(
+        Some("mobile".to_string()),
+        ElementState::Pressed,
+        ModifiersState::empty(),
+        false,
+    );
+
+    match event.expect("text input should produce an event") {
+        crate::Event::TypedCharacters { chars } => assert_eq!("mobile", chars),
+        unexpected => panic!("expected typed characters, got {unexpected:?}"),
+    }
+}
+
+#[test]
+fn text_fallback_maps_enter_to_key_down() {
+    let event = text_fallback_event_for_unconverted_key(
+        Some("\r".to_string()),
+        ElementState::Pressed,
+        ModifiersState::empty(),
+        false,
+    );
+
+    match event.expect("enter should produce a key event") {
+        crate::Event::KeyDown {
+            keystroke, chars, ..
+        } => {
+            assert_eq!("enter", keystroke.key);
+            assert_eq!("\r", chars);
+        }
+        unexpected => panic!("expected key down, got {unexpected:?}"),
+    }
+}
+
+#[test]
+fn text_fallback_preserves_control_key_chars() {
+    for (input, expected_key) in [
+        ("\u{8}", "backspace"),
+        ("\u{7f}", "delete"),
+        ("\u{1b}", "escape"),
+    ] {
+        let event = text_fallback_event_for_unconverted_key(
+            Some(input.to_string()),
+            ElementState::Pressed,
+            ModifiersState::empty(),
+            false,
+        );
+
+        match event.expect("control key should produce a key event") {
+            crate::Event::KeyDown {
+                keystroke, chars, ..
+            } => {
+                assert_eq!(expected_key, keystroke.key);
+                assert_eq!(input, chars);
+            }
+            unexpected => panic!("expected key down, got {unexpected:?}"),
+        }
+    }
+}
+
+#[test]
+fn text_fallback_ignores_shortcuts() {
+    let event = text_fallback_event_for_unconverted_key(
+        Some("v".to_string()),
+        ElementState::Pressed,
+        ModifiersState::CONTROL,
+        false,
+    );
+
+    assert!(event.is_none());
+}
+
+#[test]
+fn text_fallback_ignores_synthetic_events() {
+    let event = text_fallback_event_for_unconverted_key(
+        Some("a".to_string()),
+        ElementState::Pressed,
+        ModifiersState::empty(),
+        true,
+    );
+
+    assert!(event.is_none());
+}
+
+#[test]
+fn text_fallback_ignores_key_releases() {
+    let event = text_fallback_event_for_unconverted_key(
+        Some("a".to_string()),
+        ElementState::Released,
+        ModifiersState::empty(),
+        false,
+    );
+
+    assert!(event.is_none());
 }

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -50,7 +50,7 @@ use super::CustomEvent;
 #[cfg(windows)]
 use super::windows::{add_network_connection_listener, WindowsNetworkConnectionPoint};
 
-use self::key_events::convert_keyboard_input_event;
+use self::key_events::{convert_keyboard_input_event, text_fallback_event_for_unconverted_key};
 
 /// This is the time duration beyond which clicks get treated as separate single clicks instead of
 /// double-click, triple-click, etc.
@@ -1306,8 +1306,19 @@ impl EventLoop {
                 }
 
                 let event_text = event.text.as_ref().map(|text| text.to_string());
-                let warp_ui_event =
-                    convert_keyboard_input_event(event, window_state, is_synthetic)?;
+                let event_state = event.state;
+                let modifiers = window_state.modifiers;
+                let Some(warp_ui_event) =
+                    convert_keyboard_input_event(event, window_state, is_synthetic)
+                else {
+                    return text_fallback_event_for_unconverted_key(
+                        event_text,
+                        event_state,
+                        modifiers,
+                        is_synthetic,
+                    )
+                    .map(ConvertedEvent::Event);
+                };
                 Some(ConvertedEvent::KeyDownWithTypedCharacters {
                     chars: event_text,
                     event: warp_ui_event,


### PR DESCRIPTION
  ## Description
  Fixes text-only keyboard input being dropped when winit cannot convert a `KeyboardInput` event into a Warp `Keystroke`.

  Some remote-control or virtual keyboard paths can provide text through `event.text` while leaving the logical/physical key information unusable for Warp's normal key conversion. Previously, those events were discarded before `TypedCharacters` could be emitted, so mobile keyboards used through remote-control apps could fail to type into OpenWarp.

  This change adds a narrow fallback for unconverted key-down events that:
  - emits `TypedCharacters` when text is present and no shortcut modifiers are active
  - preserves fallback control characters for backspace, delete, and escape
  - ignores release events, synthetic events, and shortcut-modified input to avoid changing existing keybinding behavior

  ## Testing
  - `~\.cargo\bin\cargo.exe test -p warpui text_fallback --lib`
  - `~\.cargo\bin\cargo.exe check -p warpui`

  Added focused unit tests for:
  - plain text fallback
  - enter/newline fallback
  - backspace/delete/escape control-character fallback
  - shortcut modifier filtering
  - synthetic event filtering
  - key-release filtering

  ## Server API dependencies
  No server API dependencies.

  - [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-
  introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
  - [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?
  pvs=4#04da1e6a493542d68b3e998c7d339640)?
    - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
  - [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
    - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-
  add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

  ## Agent Mode
  - [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

  ## Changelog Entries for Stable

  CHANGELOG-BUG-FIX: Fixed an issue where text-only keyboard input from remote-control or virtual keyboards could be ignored.