### PR TITLE
Fix requested command output wait semantics

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -306,7 +306,10 @@ impl ShellCommandExecutor {
                 drop(model);
 
                 ActionExecution::new_async(
-                    self.action_result_future(block_selector.clone(), ActionResultDelay::Default),
+                    self.action_result_future(
+                        block_selector.clone(),
+                        action_result_delay_for_requested_command(*wait_until_completion),
+                    ),
                     move |result, ctx| {
                         // Remove the senders from the maps.
                         if let Some(handle) = handle.upgrade(ctx) {
@@ -576,41 +579,52 @@ impl ShellCommandExecutor {
         }
 
         async move {
-            // If we support long-running commands, set up a timeout after which we'll
-            // treat the command as long-running and give the agent a snapshot of the
-            // current state.  Otherwise, we'll wait indefinitely for the command to
-            // finish executing.
-            let mut timeout = match delay {
+            pin!(block_metadata_received_rx);
+            pin!(force_refresh_rx);
+
+            let timeout_duration = match delay {
+                ActionResultDelay::UntilCompletion => None,
                 ActionResultDelay::Duration(duration) => {
                     // Enforce a maximum allowed delay that the agent may request, never waiting longer than MAX_AGENT_DELAY_DURATION.
                     // If the requested duration exceeds this cap, we'll still behave as if the agent may expect a running command,
                     // so there's no need to signal preemption (the agent already anticipates an incomplete command state).
-                    Timer::after(duration.min(Self::MAX_AGENT_DELAY_DURATION))
+                    Some(duration.min(Self::MAX_AGENT_DELAY_DURATION))
                 }
                 ActionResultDelay::OnCompletion { timeout } => {
-                    Timer::after(timeout.min(Self::MAX_AGENT_DELAY_DURATION))
+                    Some(timeout.min(Self::MAX_AGENT_DELAY_DURATION))
                 }
-                ActionResultDelay::Default => Timer::after(Self::MAX_WAIT_DURATION),
-            }
-            .fuse();
+                ActionResultDelay::Default => Some(Self::MAX_WAIT_DURATION),
+            };
 
-            pin!(block_metadata_received_rx);
-            pin!(force_refresh_rx);
-
-            let wake_reason = select! {
-                val = block_metadata_received_rx => match val {
-                    Ok(_) => WakeReason::BlockFinished,
-                    Err(_) => return ActionResult::Cancelled,
-                },
-                val = force_refresh_rx => match val {
-                    // User asked the agent to check now; fall through to the snapshot
-                    // code path below. Treated as a preemption (snapshot arrives before
-                    // the agent's own timer would have fired).
-                    Ok(_) => WakeReason::ForceRefresh,
-                    // Sender was dropped (e.g. because the executor is being torn down).
-                    Err(_) => return ActionResult::Cancelled,
-                },
-                _ = timeout => WakeReason::Timeout,
+            let wake_reason = if let Some(timeout_duration) = timeout_duration {
+                let timeout = Timer::after(timeout_duration).fuse();
+                pin!(timeout);
+                select! {
+                    val = block_metadata_received_rx => match val {
+                        Ok(_) => WakeReason::BlockFinished,
+                        Err(_) => return ActionResult::Cancelled,
+                    },
+                    val = force_refresh_rx => match val {
+                        // User asked the agent to check now; fall through to the snapshot
+                        // code path below. Treated as a preemption (snapshot arrives before
+                        // the agent's own timer would have fired).
+                        Ok(_) => WakeReason::ForceRefresh,
+                        // Sender was dropped (e.g. because the executor is being torn down).
+                        Err(_) => return ActionResult::Cancelled,
+                    },
+                    _ = timeout => WakeReason::Timeout,
+                }
+            } else {
+                select! {
+                    val = block_metadata_received_rx => match val {
+                        Ok(_) => WakeReason::BlockFinished,
+                        Err(_) => return ActionResult::Cancelled,
+                    },
+                    val = force_refresh_rx => match val {
+                        Ok(_) => WakeReason::ForceRefresh,
+                        Err(_) => return ActionResult::Cancelled,
+                    },
+                }
             };
 
             // Mark the snapshot as preempted if woken early, allowing the server to distinguish
@@ -727,6 +741,7 @@ impl ShellCommandExecutor {
 /// `effective_read_shell_command_delay`)。
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum ActionResultDelay {
+    UntilCompletion,
     Default,
     Duration(Duration),
     OnCompletion { timeout: Duration },
@@ -741,6 +756,14 @@ impl ActionResultDelay {
             },
             None => Self::Default,
         }
+    }
+}
+
+fn action_result_delay_for_requested_command(wait_until_completion: bool) -> ActionResultDelay {
+    if wait_until_completion {
+        ActionResultDelay::UntilCompletion
+    } else {
+        ActionResultDelay::Default
     }
 }
 

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -114,3 +114,15 @@ fn preserves_explicit_or_non_interactive_read_delays() {
         ActionResultDelay::Default
     );
 }
+
+#[test]
+fn requested_command_wait_until_completion_does_not_use_snapshot_timeout() {
+    assert_eq!(
+        action_result_delay_for_requested_command(true),
+        ActionResultDelay::UntilCompletion
+    );
+    assert_eq!(
+        action_result_delay_for_requested_command(false),
+        ActionResultDelay::Default
+    );
+}


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
