### PR TITLE
test: add Antigravity CLI agent listener unit tests (follow-up to #133)

### DIFF
--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -420,6 +420,46 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_is_supported() {
+        assert!(is_agent_supported(&CLIAgent::Antigravity));
+    }
+
+    #[test]
+    fn antigravity_uses_default_handler_with_rich_status() {
+        assert!(agent_supports_rich_status(&CLIAgent::Antigravity));
+    }
+
+    #[test]
+    fn antigravity_default_handler_skips_session_start() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Antigravity,
+            event: CLIAgentEventType::SessionStart,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_none());
+    }
+
+    #[test]
+    fn antigravity_default_handler_forwards_stop() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Antigravity,
+            event: CLIAgentEventType::Stop,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_some());
+    }
+
+    #[test]
     fn deepseek_handler_supports_structured_rich_status() {
         assert!(agent_supports_rich_status(&CLIAgent::DeepSeek));
     }


### PR DESCRIPTION
## 概述

#133 的纯测试后续 PR。补全 `app/src/terminal/cli_agent_sessions/listener/mod.rs` 中 Antigravity 的对称单元测试 —— 现有 `auggie_*` / `pi_*` 各有 4 个测试,Antigravity 因为同样走 `DefaultSessionListener`,缺这一组就形成对称性空洞。

## 变更

新增 4 个测试,镜像 Auggie / Pi 的同名测试:

- `antigravity_is_supported` —— 锁住 `is_agent_supported` 返回 `true`
- `antigravity_uses_default_handler_with_rich_status` —— 锁住 `agent_supports_rich_status` 返回 `true`
- `antigravity_default_handler_skips_session_start` —— 锁住 `DefaultSessionListener` 吞掉 `SessionStart`
- `antigravity_default_handler_forwards_stop` —— 锁住 `DefaultSessionListener` 透传 `Stop`

## 为什么

任何未来重构如果不小心把 Antigravity 从 `is_agent_supported` 的 `matches!` 或 `create_handler` 的 `DefaultSessionListener` 分支里漏掉,这 4 个测试会立刻爆。零行为变更,只是补防御性测试。

## 验证

- `cargo check --bin warp-oss` —— 0 错误 0 警告
- `cargo nextest run -p warp -E 'test(/antigravity/)'` —— 4/4 passed

## 注

合并 #133 时 review 反馈指出这个对称性缺口,因为我无法直接推到 fork 的 PR 分支,所以拆成这个独立的小 PR。