### PR TITLE
test(autoupdate): 移除孤儿 linux_test.rs

### DIFF
--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -303,7 +303,3 @@ fn package_name(channel: Channel) -> &'static str {
         Channel::Oss => "zap-oss",
     }
 }
-
-#[cfg(test)]
-#[path = "linux_test.rs"]
-mod tests;

--- a/app/src/autoupdate/linux_test.rs
+++ b/app/src/autoupdate/linux_test.rs
@@ -1,7 +1,0 @@
-use super::*;
-
-#[test]
-fn test_repo_name() {
-    assert_eq!(repo_name(Channel::Dev), "warpdotdev-dev");
-    assert_eq!(repo_name(Channel::Stable), "warpdotdev");
-}


### PR DESCRIPTION
## 背景

`app/src/autoupdate/linux_test.rs` 是个**孤儿测试**:它测的 `repo_name()` 函数早已被 `4e3853fe`(*Remove OpenWarp upstream release update paths*)删除,导致 `cargo test -p warp` / `cargo check -p warp --tests` 一直编译失败:

```
error[E0425]: cannot find function `repo_name` in this scope
 --> app/src/autoupdate/linux_test.rs:5:16
  |
5 |     assert_eq!(repo_name(Channel::Dev), "warpdotdev-dev");
  |                ^^^^^^^^^ not found in this scope
```

历史上 `18f34efc`(*test(autoupdate): remove orphan linux_test.rs*)已经做过同样的清理,但被 `3d4eaa45`(revert PR #123)连带 revert 掉了。revert commit 的 message 明确写着:

> 该 PR 改的另一面(autoupdate/linux_test.rs 孤儿测试清理)随之回退,**如需保留请单独 cherry-pick 18f34efc**。

本 PR 就是重做那次 cherry-pick。由于此后 `Channel::Oss` 映射已被 rename-to-zap 改成 `"zap-oss"`,无法直接 `git cherry-pick 18f34efc`(会和 `package_name` 表里那一行冲突),采用等价的手工应用。

## 改动

- 删除 `app/src/autoupdate/linux_test.rs`
- 删除 `app/src/autoupdate/linux.rs` 末尾的 `#[cfg(test)] #[path = "linux_test.rs"] mod tests;` 声明

共 2 文件,11 行删除,0 行新增。

## 验证

本地执行 `cargo check -p warp --tests` 通过(之前在该项目上稳定失败于 `repo_name not found`)。

## 非目标

- 不重建 `repo_name` 函数(它属于已被移除的"OpenWarp upstream release update paths",当前 `linux.rs` 用 `package_name` 返回 `warp-terminal` / `zap-oss` 等,跟 Cloudsmith `warpdotdev` repo slug 无关)。
- 不补充新的测试覆盖(同模块原本就没有别的同步测试,该函数也已不存在)。

## 关联

- `4e3853fe` 删除 `repo_name`(本次清理的根源)
- `18f34efc` 上一次的等价清理(被 revert)
- `3d4eaa45` revert PR #123,导致孤儿测试回归