### PR TITLE
fix(ai): cancel_execution 关闭 50ms 窗口期 sender 泄漏并删除不可靠兜底

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased]
 
-- **AI / BYOP**:port opencode `applyCaching`,启用 prompt caching;`write_to_long_running_shell_command` 在 line 模式下拒绝嵌入 LF;BYOP LRC monitor fallback 改走 silent subtask
+- **AI / BYOP**:port opencode `applyCaching`,启用 prompt caching;`write_to_long_running_shell_command` 在 line 模式下拒绝嵌入 LF;BYOP LRC monitor fallback 改走 silent subtask;`cancel_execution` 50ms 窗口内 sender 泄漏修复(#134 follow-up,#137)
 - **云端剥离 Phase 1–2**:增加 `cloud-disabled` channel 谓词;清理 billing/pricing、referral/reward、cloud sharing dialog UI;退订 RTC UpdateManager;退役 notebook/folder sync queue
 - **平台**:修复 Spotlight/Finder/Launchpad 启动 macOS 时的 panic;`run_shell_command` stdout 兜底回退至 command grid
 - **基建**:`.gitattributes` 强制 LF;新增 stale bot 与 Claude Code GitHub workflow

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -687,25 +687,13 @@ impl ShellCommandExecutor {
         self.block_finished_senders.remove(&requested_selector);
         self.force_refresh_senders.remove(&requested_selector);
 
-        // 其他路径(ReadShellCommandOutput / WriteToLongRunningShellCommand 等)以
-        // active block id 为 selector,仅在 block 确实 long-running 时才可能在 map 里有
-        // sender。这里保留 long-running 守卫作为防御。
-        let terminal_model = self.terminal_model.lock();
-        let active_block = terminal_model.block_list().active_block();
-        if !active_block.is_active_and_long_running() {
-            return;
-        }
-        // active_block 就是上面已处理的 RequestedCommand 时跳过,避免重复 remove。
-        if active_block
-            .requested_command_action_id()
-            .is_some_and(|requested_command_id| requested_command_id == id)
-        {
-            return;
-        }
-        let selector = BlockSelector::Id(active_block.id().clone());
-        drop(terminal_model);
-        self.block_finished_senders.remove(&selector);
-        self.force_refresh_senders.remove(&selector);
+        // 不再用 `BlockSelector::Id(active_block.id())` 做兜底清理。WriteToLRC /
+        // ReadShellCommandOutput / TransferShellCommandControlToUser 的 sender key 来
+        // 自 action 参数中的 block_id 或创建时的 active_block,与 cancel 时刻的
+        // active_block 不存在可靠对应:若用户在 action 派生后切换了 active block,
+        // 旧的 active-block 兜底就匹配不上;若没切换,清理也只是"偶发正确"。它们的
+        // sender 由各自 on_complete 回调在 future 自然结束时清理;如需即时清理需引入
+        // action_id → BlockSelector 反向索引,属于本 issue 之外的独立改动。
     }
 
     /// Force any in-flight poll for the given long-running command block to resolve

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -678,20 +678,32 @@ impl ShellCommandExecutor {
     }
 
     pub(super) fn cancel_execution(&mut self, id: &AIAgentActionId, _ctx: &mut ModelContext<Self>) {
+        // RequestedCommand 路径以 action id 为 selector,无条件清理。
+        // 不能依赖 `is_active_and_long_running()` 守卫:命令派生后 ~50ms
+        // (LONG_RUNNING_COMMAND_DURATION_MS) 窗口内守卫为 false,会导致 senders 残留,
+        // 进而让 detached future 挂到命令真正结束才退出(对 wait_until_completion=true
+        // 即 ActionResultDelay::UntilCompletion 的影响尤其大)。
+        let requested_selector = BlockSelector::RequestedCommandId(id.clone());
+        self.block_finished_senders.remove(&requested_selector);
+        self.force_refresh_senders.remove(&requested_selector);
+
+        // 其他路径(ReadShellCommandOutput / WriteToLongRunningShellCommand 等)以
+        // active block id 为 selector,仅在 block 确实 long-running 时才可能在 map 里有
+        // sender。这里保留 long-running 守卫作为防御。
         let terminal_model = self.terminal_model.lock();
         let active_block = terminal_model.block_list().active_block();
         if !active_block.is_active_and_long_running() {
             return;
         }
-
-        let selector = if active_block
+        // active_block 就是上面已处理的 RequestedCommand 时跳过,避免重复 remove。
+        if active_block
             .requested_command_action_id()
             .is_some_and(|requested_command_id| requested_command_id == id)
         {
-            BlockSelector::RequestedCommandId(id.clone())
-        } else {
-            BlockSelector::Id(active_block.id().clone())
-        };
+            return;
+        }
+        let selector = BlockSelector::Id(active_block.id().clone());
+        drop(terminal_model);
         self.block_finished_senders.remove(&selector);
         self.force_refresh_senders.remove(&selector);
     }


### PR DESCRIPTION
Closes #137

## Summary

- `cancel_execution` 的 RequestedCommand 路径不再依赖 `is_active_and_long_running()` 守卫,改为无条件按 `BlockSelector::RequestedCommandId(id)` 清理 `block_finished_senders` / `force_refresh_senders`,关闭命令派生后 ~50ms 窗口期内的 sender 泄漏。
- 删除旧的 `BlockSelector::Id(active_block.id())` 兜底清理路径 — 该路径对 `WriteToLRC` / `ReadShellCommandOutput` / `TransferShellCommandControlToUser` 的 sender key 与 cancel 时刻的 `active_block` 不存在可靠对应,是"偶发正确"的脆弱语义。
- 删除后这三类 action 的 sender 由各自 `on_complete` 回调在 future 自然结束时清理,与旧路径在多数场景下的行为一致(旧路径对它们多数时候本就是 no-op)。
- `cancel_execution` 不再需要锁 `terminal_model`,符合持锁最小化(AGENTS.md §5.3)。
- CHANGELOG `[Unreleased]` 追加一行记录。

## Plan

1. RequestedCommand 路径无条件清理 — 验证:`cargo check` 绿。
2. 删除 active_block-id 兜底路径,加注释说明根因和扩展方向 — 验证:`cargo check` 无 dead code warning。
3. 既有 5 个 `shell_command_tests` 测试不退化 — 验证:`cargo nextest run`。

## Verification

| 命令 | 结果 |
|---|---|
| `cargo check -p warp` | ✅ 2m26s,0 errors / 0 warnings |
| `cargo nextest run -p warp 'ai::blocklist::action_model::execute::shell_command'` | ✅ 5/5 passed |
| 两轮 code review | ✅ APPROVED |

## 背景与影响

详见 #137。PR #134 把 `wait_until_completion=true` 改为 `ActionResultDelay::UntilCompletion`(无超时)之后,该泄漏的影响时长被放大:detached future 会挂到命令真正结束才退出。本 PR 修复该泄漏并顺手清理了一处长期存在的脆弱语义。

## 非目标

- 不引入 `action_id → BlockSelector` 反向索引(这是 `WriteToLRC` / `Read` / `Transfer` 即时 cancel 清理的根本方案,但属于结构性改动,留作独立 issue)。
- 不改 `cancel_running_async_action` 和 `is_active_and_long_running` 的语义。
- 不引入 task abort handle 存储。