### PR TITLE
 build: 默认二进制标识改为 oss & AI 设置页拉取失败时跳过重建

### DIFF
--- a/app/build.rs
+++ b/app/build.rs
@@ -364,7 +364,7 @@ fn embed_resource_file(target_dir: &Path) {
     // 直接 `cargo build` 出来的 dev 二进制在任务管理器里会显示成 `Zap(N)`。
     // 上游官方流水线在调用前会显式 `export WARP_APP_NAME=...` 覆盖,不受影响。
     let app_name = env::var("WARP_APP_NAME").unwrap_or_else(|_| "Zap".to_owned());
-    let bin_name = env::var("CARGO_BIN_NAME").unwrap_or("local".to_owned());
+    let bin_name = env::var("CARGO_BIN_NAME").unwrap_or("oss".to_owned());
     // 以 `WARP_APP_PUBLISHER` 覆盖;默认与 installer / AUMID 一致为「Zap」。
     // 保持 installer `MyAppPublisher`、Cargo bundle metadata `copyright`、
     // 进程 AUMID `dev.zap.Zap` 三处全局对齐，避免 Windows Shell

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3361,11 +3361,9 @@ impl TypedActionView for AISettingsPageView {
                     let client = http_client::Client::new();
                     ctx.spawn(
                         async move { models_dev::fetch_and_cache(client).await },
-                        |view, result, ctx| {
-                            if let Err(e) = result {
-                                log::warn!("[models.dev] 拉取失败: {e}");
-                            }
-                            view.rebuild_current_page(ctx);
+                        |view, result, ctx| match result {
+                            Ok(()) => view.rebuild_current_page(ctx),
+                            Err(e) => log::warn!("[models.dev] 拉取失败: {e}"),
                         },
                     );
                 } else {
@@ -3377,11 +3375,9 @@ impl TypedActionView for AISettingsPageView {
                 let client = http_client::Client::new();
                 ctx.spawn(
                     async move { models_dev::fetch_and_cache(client).await },
-                    |view, result, ctx| {
-                        if let Err(e) = result {
-                            log::warn!("[models.dev] 刷新失败: {e}");
-                        }
-                        view.rebuild_current_page(ctx);
+                    |view, result, ctx| match result {
+                        Ok(()) => view.rebuild_current_page(ctx),
+                        Err(e) => log::warn!("[models.dev] 刷新失败: {e}"),
                     },
                 );
             }


### PR DESCRIPTION
## Summary

  两个独立的小改动合并在一个 PR 中：

  1. `app/build.rs` 中 `CARGO_BIN_NAME` 的 fallback 从 `"local"` 改为 `"oss"`。
     直接 `cargo build` 出来的 dev 二进制在 Windows 任务管理器里会显示为 `Zap(N)`，其中 `N` 取自
  `CARGO_BIN_NAME`。默认值 `"local"` 不符合开源版本的定位，改为 `"oss"` 与项目性质一致。上游官方流水线通过
  `WARP_APP_NAME` 环境变量覆盖，不受影响。

  2. `app/src/settings_view/ai_page.rs` 中 `models_dev::fetch_and_cache` 回调逻辑修正。
     之前无论拉取成功或失败都会调用 `rebuild_current_page`，失败时的重建没有意义（数据未更新）。改为仅在 `Ok`
  时重建页面，`Err` 时只打日志。

  ## Plan

  1. 将 `CARGO_BIN_NAME` 默认值从 `"local"` 改为 `"oss"`。 → verify: `cargo check` 通过。
  2. 将两处 `fetch_and_cache` 回调中的 `if let Err` 改为 `match Ok/Err` 分支，成功时才重建页面。 → verify: `cargo check`
   通过。

  ## Verification

  - `cargo check` → ✅

  ## Unresolved

  - 无。