### PR TITLE
fix(build): graceful degradation when Windows icon path is missing

### DIFF
--- a/app/build.rs
+++ b/app/build.rs
@@ -378,7 +378,16 @@ fn embed_resource_file(target_dir: &Path) {
         .join("no-padding")
         .join("icon.ico");
 
-    fs::copy(icon_path, target_dir.join("icon.ico"))
+    if !icon_path.exists() {
+        println!(
+            "cargo:warning=Icon not found at {} (CARGO_BIN_NAME={bin_name}): \
+             skipping Windows resource embed. \
+             Set CARGO_BIN_NAME or add channels/{bin_name}/icon/no-padding/icon.ico",
+            icon_path.display()
+        );
+        return;
+    }
+    fs::copy(&icon_path, target_dir.join("icon.ico"))
         .unwrap_or_else(|err| panic!("Could not copy icon: {err:#}"));
 
     let resource_file_path = target_dir.join("resource.rc");


### PR DESCRIPTION
## 关联 Issue

Fixes #146

## 问题点（确定性描述）

**根因**：`app/build.rs:381-382`

```rust
fs::copy(icon_path, target_dir.join("icon.ico"))
    .unwrap_or_else(|err| panic!("Could not copy icon: {err:#}"));
```

`embed_resource_file` 在构建 `icon_path = channels/<bin_name>/icon/no-padding/icon.ico` 后直接调用 `fs::copy`，不检查路径是否存在。当 `CARGO_BIN_NAME` 未设置时 fallback 为 `"oss"`，目前因为 `app/channels/oss/icon/no-padding/icon.ico` 恰好存在而正常工作；但若未来任何人修改 fallback 字符串或调整 channel 目录结构，构建会立即 panic，而报错仅指向 `fs::copy` 底层 I/O 错误，不包含"应该设置什么 env var"或"缺少哪个目录"的诊断信息。

## 复现证据

- `app/build.rs:367`：`let bin_name = env::var("CARGO_BIN_NAME").unwrap_or("oss".to_owned());`
- `app/build.rs:375-379`：icon_path 硬绑定到 `channels/<bin_name>/icon/no-padding/icon.ico`
- `app/build.rs:381-382`：`fs::copy` 失败时 `panic!("Could not copy icon: {err:#}")`
- `app/build.rs:136-137`：整个函数仅在 `#[cfg(windows)]` 下调用，1 处调用点

## 修复方案

在 `fs::copy` 前插入 `icon_path.exists()` 检查。图标缺失时改为：
1. 打印 `cargo:warning=...`，包含实际路径、当前 `CARGO_BIN_NAME` 值以及修复指引
2. `return` 跳过整个 embed_resource 流程

本地 dev 构建不需要嵌入图标资源，跳过不影响功能；CI 正式流水线均会显式设置 `CARGO_BIN_NAME`，icon 存在，走原有路径，无行为变化。

## 规模声明

- 修改文件数：**1**（`app/build.rs`）
- 修改行数：**+9 / -1 = 10 行净变动**（远低于 50 行红线）
- 影响面 grep 命中：**1**（`app/build.rs:137`，`#[cfg(windows)]` 隔离）

属于小修复范围。

## 修改文件清单

| 文件 | 行号范围 | 改动说明 |
|------|----------|----------|
| `app/build.rs` | 381-391 | 在 `fs::copy` 前插入 `icon_path.exists()` 守卫；缺失时 `cargo:warning` + `return` |

## 验证

```
rustfmt --check app/build.rs   → exit 0（格式检查通过）
git diff --name-only HEAD~1    → app/build.rs（仅此一文件）
```

（`embed_resource_file` 为 `#[cfg(windows)]`，Linux CI 环境下函数不参与编译，不影响现有测试。）

## 影响面

- 调用方：`app/build.rs:136-137`（唯一，`#[cfg(windows)]` 隔离）
- Windows 正式构建（`CARGO_BIN_NAME` 已设置，`channels/oss/icon/no-padding/icon.ico` 存在）：行为不变
- Windows 本地 `cargo build`（`CARGO_BIN_NAME` 未设置，`oss` 目录现存）：行为不变（icon 存在，正常走 embed 路径）
- 未来若 fallback 或 channel 目录变化导致 icon 缺失：由 panic 改为 `cargo:warning`，构建继续，不中断开发流程

---
_Generated by [Claude Code](https://claude.ai/code/session_01DM9gskgPG85yZBdW7vvF7F)_