### PR TITLE
fix(zsh): reset bracketed-paste widget to prevent URL character escaping on command submit

### DIFF
--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -366,6 +366,16 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       bindkey -r '\ew'
       bindkey '\ew' warp_change_prompt_modes_to_warp_prompt
 
+      # Reset the bracketed-paste ZLE widget to the built-in default (.bracketed-paste).
+      # Plugins like bracketed-paste-magic (e.g. from Oh My Zsh) override this widget to
+      # escape URL-adjacent characters such as ')'. Since Warp submits commands via bracketed
+      # paste sequences, these plugins incorrectly mutate command text on submission — for
+      # example, turning `(echo "https://example.com")` into `(echo "https://example.com"\)`,
+      # which causes ZSH to enter a continuation prompt instead of executing the command.
+      # Since Warp manages all editing via its own input layer (not ZSH ZLE), resetting this
+      # widget has no user-visible impact.
+      zle -A .bracketed-paste bracketed-paste 2>/dev/null || true
+
       local escaped_pwd
       if [ -n "${WSL_DISTRO_NAME:-}" ]; then
         # In WSL, avoid symlinks b/c on Windows `std::fs` is unable to resolve symlink inside WSL containers.

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -366,14 +366,14 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       bindkey -r '\ew'
       bindkey '\ew' warp_change_prompt_modes_to_warp_prompt
 
-      # Reset the bracketed-paste ZLE widget to the built-in default (.bracketed-paste).
-      # Plugins like bracketed-paste-magic (e.g. from Oh My Zsh) override this widget to
-      # escape URL-adjacent characters such as ')'. Since Warp submits commands via bracketed
-      # paste sequences, these plugins incorrectly mutate command text on submission — for
-      # example, turning `(echo "https://example.com")` into `(echo "https://example.com"\)`,
-      # which causes ZSH to enter a continuation prompt instead of executing the command.
-      # Since Warp manages all editing via its own input layer (not ZSH ZLE), resetting this
-      # widget has no user-visible impact.
+      # 将 bracketed-paste ZLE widget 重置为内置默认值（.bracketed-paste）。
+      # bracketed-paste-magic 等插件（如 Oh My Zsh 中的同名插件）会覆盖此 widget，
+      # 对紧跟在 URL 之后的 ')' 等字符进行转义。由于 Warp 提交命令时使用 bracketed
+      # paste 序列，这类插件会在提交时错误地修改命令文本——例如将
+      # `(echo "https://example.com")` 变为 `(echo "https://example.com"\)`，
+      # 导致 ZSH 进入续行提示而非直接执行命令。
+      # 由于 Warp 通过自身输入层（而非 ZSH ZLE）管理所有编辑操作，重置此 widget
+      # 对用户不会产生任何可见影响。
       zle -A .bracketed-paste bracketed-paste 2>/dev/null || true
 
       local escaped_pwd


### PR DESCRIPTION
## Summary

Fixes #163 — typing `(echo "https://google.com")` and pressing Enter produces `(echo "https://google.com"\)` and a `subsh>` continuation prompt.

- **Root cause**: ZSH plugins like `bracketed-paste-magic` (commonly loaded via Oh My Zsh) override the `bracketed-paste` ZLE widget to escape URL-adjacent special characters such as `)`. Warp submits every command to ZSH via bracketed paste sequences (`\e[200~…\e[201~`), so these plugins silently mutate the submitted command — converting `(echo "https://google.com")` into `(echo "https://example.com"\)`. ZSH then sees an unclosed subshell and enters continuation mode (`subsh>`).

- **Why "Only in Warp"**: In a conventional terminal the user's keystrokes are processed character-by-character through ZSH ZLE; `bracketed-paste-magic` only activates for actual paste events (`\e[200~…`). Warp wraps *all* command submissions in a bracketed paste sequence, so every submission triggers the magic processing.

- **Why "Only when URL is last argument"**: `bracketed-paste-magic` escapes `)` only when it directly follows a URL-like pattern with no intervening text. `(echo "https://google.com" "ok")` has `"ok"` between the URL and `)`, so the `)` is not flagged.

- **Fix**: Inside `warp_precmd` (which runs before every prompt, after the user's rcfiles — including any Oh My Zsh setup — have been sourced), reset the `bracketed-paste` widget to ZSH's built-in `.bracketed-paste`. This undoes whatever any plugin may have installed and runs on every prompt cycle, so it cannot be overridden for the duration of the Warp session. The change is guarded with `2>/dev/null || true` for forward compatibility.

  Precedent: Warp already resets `^P` (`kill-buffer`) and other ZLE bindings in `warp_precmd` for the same reason — "This won't have any user-impact because these shortcuts are only run in the context of the zsh line editor, which isn't displayed in Warp." The same reasoning applies here.

## Test plan

- [ ] Open a Warp terminal with Oh My Zsh and `bracketed-paste-magic` enabled
- [ ] Type `(echo "https://google.com")` and press Enter — command should execute and print `https://google.com`; no `subsh>` prompt
- [ ] Confirm `(echo "https://google.com" "ok")` still works (was unaffected before)
- [ ] Confirm normal clipboard paste inside Warp still works (Warp's paste goes through its own editor, not ZSH ZLE)
- [ ] Confirm the fix is a no-op on shells without `bracketed-paste-magic` (the `2>/dev/null || true` ensures no error)