### PR TITLE
fix: expose skill_path in system prompt so read_skill works for global skills

### DIFF
--- a/app/src/ai/agent_providers/prompt_renderer.rs
+++ b/app/src/ai/agent_providers/prompt_renderer.rs
@@ -191,9 +191,11 @@ struct GitCtx {
 struct SkillCtx {
     name: String,
     description: String,
-    /// Absolute path to SKILL.md (or `@warp-skill:<id>` for bundled skills).
-    /// Exposed so the model can pass the correct value to `read_skill(skill_path=...)`.
-    path: String,
+    /// Absolute path to SKILL.md for filesystem skills; `None` for bundled skills.
+    /// Bundled skills are loaded via `AIAgentInput::InvokeSkill`, not `read_skill`,
+    /// so exposing `@warp-skill:<id>` here would mislead the model into calling a
+    /// path that always fails the BYOP `skill_by_reference` lookup.
+    path: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -300,10 +302,19 @@ fn collect_prompt_context(model_id: &str, ctx: &[AIAgentContext]) -> PromptConte
             }
             AIAgentContext::Skills { skills } => {
                 for s in skills {
+                    let path = match &s.reference {
+                        ai::skills::SkillReference::Path(p) => {
+                            Some(p.to_string_lossy().into_owned())
+                        }
+                        // Bundled skills load via InvokeSkill, not read_skill.
+                        // Omit skill_path to avoid guiding the model toward a
+                        // value that will always fail BYOP's skill_by_reference.
+                        ai::skills::SkillReference::BundledSkillId(_) => None,
+                    };
                     out.skills.push(SkillCtx {
                         name: s.name.clone(),
                         description: s.description.clone(),
-                        path: s.reference.to_string(),
+                        path,
                     });
                 }
             }
@@ -593,6 +604,41 @@ mod tests {
         assert!(
             out.contains(skill_path),
             "system prompt must expose the skill_path so the model can pass it to read_skill; got: {out}"
+        );
+    }
+
+    /// Issue #169 后续:bundled skill 的 BundledSkillId 变体在 BYOP 路径下不可通过
+    /// read_skill 加载(走 InvokeSkill),因此 system prompt 中不应输出 <skill_path>
+    /// 以避免模型使用必然失败的 @warp-skill:{id} 值。
+    #[test]
+    fn render_omits_skill_path_for_bundled_skill() {
+        use crate::ai::skills::SkillDescriptor;
+        use ai::skills::{SkillProvider, SkillReference, SkillScope};
+        use warp_core::ui::icons::Icon;
+
+        let skill = SkillDescriptor {
+            reference: SkillReference::BundledSkillId("find-skills".into()),
+            name: "find-skills".into(),
+            description: "Help discover and install new agent skills.".into(),
+            scope: SkillScope::Bundled,
+            provider: SkillProvider::Zap,
+            icon_override: Some(Icon::WarpLogoLight),
+        };
+        let ctx = vec![AIAgentContext::Skills {
+            skills: vec![skill],
+        }];
+        let out = render_system(&LLMId::from("byop:p:deepseek-chat"), &ctx, &[], false, &[]);
+        assert!(
+            out.contains("find-skills"),
+            "bundled skill name should still appear in prompt: {out}"
+        );
+        assert!(
+            !out.contains("@warp-skill:"),
+            "bundled skill must NOT emit <skill_path> to avoid misleading the model: {out}"
+        );
+        assert!(
+            !out.contains("<skill_path>"),
+            "no <skill_path> tag should be rendered for bundled skills: {out}"
         );
     }
 

--- a/app/src/ai/agent_providers/prompt_renderer.rs
+++ b/app/src/ai/agent_providers/prompt_renderer.rs
@@ -191,6 +191,9 @@ struct GitCtx {
 struct SkillCtx {
     name: String,
     description: String,
+    /// Absolute path to SKILL.md (or `@warp-skill:<id>` for bundled skills).
+    /// Exposed so the model can pass the correct value to `read_skill(skill_path=...)`.
+    path: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -300,6 +303,7 @@ fn collect_prompt_context(model_id: &str, ctx: &[AIAgentContext]) -> PromptConte
                     out.skills.push(SkillCtx {
                         name: s.name.clone(),
                         description: s.description.clone(),
+                        path: s.reference.to_string(),
                     });
                 }
             }
@@ -563,6 +567,32 @@ mod tests {
         assert!(
             !out.contains("Skills provide specialized instructions"),
             "{out}"
+        );
+    }
+
+    /// Issue #169 回归:系统 prompt 中的 skill 区块必须包含 skill_path(绝对路径),
+    /// 而非仅 name/description,否则模型无法正确调用 read_skill 工具。
+    #[test]
+    fn render_includes_skill_path_for_read_skill_tool() {
+        use crate::ai::skills::SkillDescriptor;
+        use ai::skills::{SkillProvider, SkillReference, SkillScope};
+
+        let skill_path = "/home/user/.agents/skills/open-browser-use/SKILL.md";
+        let skill = SkillDescriptor {
+            reference: SkillReference::Path(skill_path.into()),
+            name: "open-browser-use".into(),
+            description: "Automates Chrome browser operations.".into(),
+            scope: SkillScope::Project,
+            provider: SkillProvider::Agents,
+            icon_override: None,
+        };
+        let ctx = vec![AIAgentContext::Skills {
+            skills: vec![skill],
+        }];
+        let out = render_system(&LLMId::from("byop:p:deepseek-chat"), &ctx, &[], false, &[]);
+        assert!(
+            out.contains(skill_path),
+            "system prompt must expose the skill_path so the model can pass it to read_skill; got: {out}"
         );
     }
 

--- a/app/src/ai/agent_providers/prompts/partials/skills.j2
+++ b/app/src/ai/agent_providers/prompts/partials/skills.j2
@@ -5,6 +5,7 @@ Use the `read_skill` tool to load a skill when a task matches its description.
   <skill>
     <name>{{ s.name }}</name>
     <description>{{ s.description }}</description>
+    <skill_path>{{ s.path }}</skill_path>
   </skill>
 {%- endfor %}
 </available_skills>

--- a/app/src/ai/agent_providers/prompts/partials/skills.j2
+++ b/app/src/ai/agent_providers/prompts/partials/skills.j2
@@ -5,7 +5,7 @@ Use the `read_skill` tool to load a skill when a task matches its description.
   <skill>
     <name>{{ s.name }}</name>
     <description>{{ s.description }}</description>
-    <skill_path>{{ s.path }}</skill_path>
+    {%- if s.path %}<skill_path>{{ s.path }}</skill_path>{% endif %}
   </skill>
 {%- endfor %}
 </available_skills>

--- a/app/src/ai/agent_providers/prompts/tool_descriptions/read_skill.md
+++ b/app/src/ai/agent_providers/prompts/tool_descriptions/read_skill.md
@@ -2,4 +2,4 @@ Load a specialized skill when the task at hand matches one of the skills listed 
 
 Use this tool to inject the skill's instructions and resources into the current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc. in the same directory as the skill.
 
-The skill `name` must match one of the skills listed in your system prompt. If the system prompt does not currently list any skills, this tool is a no-op — do not call it.
+Set `skill_path` to the `<skill_path>` value shown for that skill in your system prompt. If the system prompt does not currently list any skills, this tool is a no-op — do not call it.


### PR DESCRIPTION
## 关联 Issue

Fixes #169

## 问题点（确定性描述）

**根因**：`prompt_renderer.rs:191-194` 中 `SkillCtx` 缺少 `path` 字段；`prompt_renderer.rs:298-305` 的 `collect_prompt_context` 在处理 `AIAgentContext::Skills` 时，将 `SkillDescriptor.reference`（含绝对路径）丢弃；`skills.j2:1-10` 模板仅渲染 `<name>` 和 `<description>`，无路径信息。

```rust
// 修复前 — path 字段缺失，reference 在转换时被丢弃
struct SkillCtx {
    name: String,
    description: String,    // ← 无 path
}

AIAgentContext::Skills { skills } => {
    for s in skills {
        out.skills.push(SkillCtx {
            name: s.name.clone(),
            description: s.description.clone(),  // ← s.reference 被丢弃
        });
    }
}
```

模型收到的 system prompt 仅包含技能名称和描述，无 SKILL.md 路径。调用 `read_skill` 时以名称代替路径（如 `skill_path: "open-browser-use"`），导致 `skill_by_reference(SkillReference::Path("open-browser-use"))` 在 `skills_by_path` HashMap 中找不到键（键为完整绝对路径），返回 `Skill not found: Path("open-browser-use")`。

## 复现证据

日志明确显示（来自 Issue #169）：
```
args={"skill_path":"find-skills"}
args={"skill_path":"open-browser-use"}

content={"message":"Skill not found: Path(\"find-skills\")","status":"error"}
content={"message":"Skill not found: Path(\"open-browser-use\")","status":"error"}
```

`skill_manager.rs:336-339`：
```rust
pub fn skill_by_reference(&self, reference: &SkillReference) -> Option<&ParsedSkill> {
    SkillReference::Path(path) => self.skills_by_path.get(path),  // ← 键为绝对路径
```

## 规模声明

- 修改文件数：**3**（≤ 3 ✓）
- 修改行数：**~9 行**（≤ 50 ✓）
- 无公共 API / 导出签名 / schema / 并发 / 鉴权变更
- 影响面 grep：`SkillCtx` 为文件内私有 struct，外部引用：**0**

## 修改文件清单

| 文件 | 行号 | 改动说明 |
|---|---|---|
| `app/src/ai/agent_providers/prompt_renderer.rs` | 191-199 | `SkillCtx` 加 `path: String` 字段 |
| `app/src/ai/agent_providers/prompt_renderer.rs` | 301 | `push(SkillCtx{...})` 补 `path: s.reference.to_string()` |
| `app/src/ai/agent_providers/prompt_renderer.rs` | 563-595 | 新增回归测试 `render_includes_skill_path_for_read_skill_tool` |
| `app/src/ai/agent_providers/prompts/partials/skills.j2` | 8 | 加 `<skill_path>{{ s.path }}</skill_path>` |
| `app/src/ai/agent_providers/prompts/tool_descriptions/read_skill.md` | 末行 | 修正描述，说明应使用系统提示中的 `<skill_path>` 值 |

修复后 system prompt 中技能区块变为：
```xml
<skill>
  <name>open-browser-use</name>
  <description>...</description>
  <skill_path>/home/user/.agents/skills/open-browser-use/SKILL.md</skill_path>
</skill>
```

模型据此调用 `read_skill(skill_path="/home/user/.agents/skills/open-browser-use/SKILL.md")`，`skill_by_reference` 命中缓存或走磁盘回退，正确返回技能内容。

## 验证

```
cargo test --manifest-path app/Cargo.toml prompt_renderer

running 18 tests
test ...pick_template_dispatches_by_model_family ... ok
test ...render_includes_skill_path_for_read_skill_tool ... ok  ← 新增回归测试
test ...render_omits_skills_block_when_empty ... ok
... (18 passed; 0 failed)
```

## 影响面

- `SkillCtx` 私有 struct，无外部调用方
- `skills.j2` 仅被 `prompt_renderer.rs::build_env` 内嵌，无其他引用
- 所有现存 18 个 `prompt_renderer` 测试仍通过

https://claude.ai/code/session_01BS8Q5nFjPjFNPP56WRYkxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS8Q5nFjPjFNPP56WRYkxa)_