### PR TITLE
🎨 style(theme): 提亮 WezTerm Classic 主题 UI 前景色

### DIFF
--- a/app/src/themes/default_themes.rs
+++ b/app/src/themes/default_themes.rs
@@ -719,7 +719,7 @@ pub(super) fn adeberry() -> WarpTheme {
 pub(super) fn wezterm_classic() -> WarpTheme {
     WarpTheme::new(
         Fill::Solid(ColorU::from_u32(0x000000FF)),
-        ColorU::from_u32(0xB3B3B3FF),
+        ColorU::from_u32(0xE0E0E0FF),
         Fill::Solid(ColorU::from_u32(0x52AD70FF)),
         None,
         Some(Details::Darker),


### PR DESCRIPTION
## 变更内容

将 WezTerm Classic 主题的前景色从 `#B3B3B3` 提亮至 `#E0E0E0`，改善深色背景下的可读性。

## 影响范围
- 仅影响选择 WezTerm Classic 主题时的 UI 前景色
- 不影响终端 ANSI 配色

## 测试
- [x] `cargo build -p warp` 编译通过