### PR TITLE
fix(prompt): add language instruction to default.j2 for GLM and similar models

### DIFF
--- a/app/src/ai/agent_providers/prompts/system/default.j2
+++ b/app/src/ai/agent_providers/prompts/system/default.j2
@@ -3,6 +3,7 @@ You are the AI coding agent inside Zap, an AI Development Environment (ADE) that
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 # Tone and style
+When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise.
 You should be concise, direct, and to the point. When you run a non-trivial shell command, you should explain what the command does and why you are running it, to make sure the user understands what you are doing (this is especially important when you are running a command that will make changes to the user's system).
 Your responses can use GitHub-flavored markdown for formatting, and will be rendered using the CommonMark specification.
 Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like `run_shell_command` or code comments as means to communicate with the user during the session.


### PR DESCRIPTION
## 关联 Issue

Fixes #191

## 问题点（确定性描述）

`app/src/ai/agent_providers/prompts/system/default.j2:5`（`# Tone and style` 区块）缺少语言约束指令。

GLM5.1 通过 `pick_template()` (`prompt_renderer.rs:130-155`) 落入兜底分支，使用 `default.j2`：

```rust
// prompt_renderer.rs:155
"system/default.j2"   // ← glm 不命中任何具名分支
```

`default.j2` 无语言指令 → GLM5.1（中文优先模型）默认输出中文，无视用户的英文界面设置。

对照：`kimi.j2:17` 已有此指令：
```
When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise.
```

`default.j2` 是唯一缺失该行的系统 prompt 模板。

## 复现证据

- `app/src/ai/agent_providers/prompt_renderer.rs:130-155`：GLM5.1 → `system/default.j2`
- `app/src/ai/agent_providers/prompts/system/default.j2:1-99`：全文无语言指令
- `app/src/ai/agent_providers/prompts/system/kimi.j2:17`：已有语言指令（对照）

## 规模声明

- 修改文件数：**1**
- 修改行数：**1 行插入**
- 影响面 grep 命中数：0（模板以 `include_str!` 编译进二进制，无运行时调用方）
- 属于小修复范围 ✅

## 修改文件清单

| 文件 | 行号范围 | 改动说明 |
|------|----------|----------|
| `app/src/ai/agent_providers/prompts/system/default.j2` | 第 6 行（新增） | `# Tone and style` 首行插入语言指令 |

```diff
 # Tone and style
+When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise.
 You should be concise, direct, and to the point.
```

## 验证

`cargo test -p warp --lib ai::agent_providers::prompt_renderer::tests` — 本地环境缺少 `protoc`（proto 编译器未安装），导致 `warp_multi_agent_api` build script 无法运行；此为预存在环境问题，与本次模板改动无关。改动为纯文本插入，无 Jinja2 语法，模板解析不受影响。

## 影响面

- `default.j2` 被路由到的模型族：GLM、DeepSeek、Qwen、以及所有未命中具名分支的自定义模型
- `kimi.j2`、`anthropic.j2`、`gpt.j2`、`beast.j2`、`codex.j2`、`gemini.j2`、`trinity.j2` 均不受影响
- `app/src/ai/agent_providers/prompt_renderer.rs:394`（`render_system`）调用链不变

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDF4cEYHPvJqExfdtFBj5o)_