### PR TITLE
fix: respect user multimodal overrides in BYOP attachment caps

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -381,13 +381,11 @@ fn flush_assistant_buffer(
 fn build_user_message_with_binaries(
     text: String,
     binaries: Vec<user_context::UserBinary>,
-    api_type: AgentProviderApiType,
-    model_id: &str,
+    caps: attachment_caps::AttachmentCaps,
 ) -> ChatMessage {
     if binaries.is_empty() {
         return ChatMessage::user(text);
     }
-    let caps = attachment_caps::caps_for(api_type, model_id);
 
     let mut parts: Vec<ContentPart> = Vec::with_capacity(1 + binaries.len());
     parts.push(ContentPart::Text(text));
@@ -421,8 +419,7 @@ fn build_user_message_with_binaries(
 
     if !error_replacements.is_empty() {
         log::info!(
-            "[byop] {} attachment(s) replaced with ERROR text — model {api_type:?}/{model_id} \
-             does not support: {error_replacements:?}",
+            "[byop] {} attachment(s) replaced with ERROR text — does not support: {error_replacements:?}",
             error_replacements.len()
         );
     }
@@ -1179,7 +1176,7 @@ fn build_chat_request(
     params: &RequestParams,
     force_echo_reasoning: bool,
     api_type: AgentProviderApiType,
-    model_id: &str,
+    attachment_caps: attachment_caps::AttachmentCaps,
 ) -> Result<ChatRequest, ConvertToAPITypeError> {
     let agent_ctx = latest_input_context(&params.input);
     let plan_mode = is_plan_mode_turn(&params.input);
@@ -1382,8 +1379,7 @@ fn build_chat_request(
                     messages.push(build_user_message_with_binaries(
                         history_text,
                         history_binaries,
-                        api_type,
-                        model_id,
+                        attachment_caps,
                     ));
                 }
             }
@@ -1559,8 +1555,7 @@ fn build_chat_request(
                 messages.push(build_user_message_with_binaries(
                     full_text,
                     user_attachments.binaries,
-                    api_type,
-                    model_id,
+                    attachment_caps,
                 ));
             }
             AIAgentInput::ActionResult { result, .. } => {
@@ -1601,8 +1596,7 @@ fn build_chat_request(
                     messages.push(build_user_message_with_binaries(
                         full_text,
                         user_attachments.binaries,
-                        api_type,
-                        model_id,
+                        attachment_caps,
                     ));
                 }
             }
@@ -3178,6 +3172,9 @@ pub struct ByopOutputInput {
     pub lrc_should_spawn_subagent: bool,
     pub context_window: Option<u32>,
     pub cancellation_rx: futures::channel::oneshot::Receiver<()>,
+    /// ユーザー設定 (image/pdf/audio の三態 Override) を反映済みの attachment caps。
+    /// `resolve_for_model` で計算され、UI 表示と runtime 動作を一致させる。
+    pub attachment_caps: attachment_caps::AttachmentCaps,
 }
 
 /// `task_id`: conversation 的 root task id(controller 端从 history model 取)。
@@ -3202,10 +3199,11 @@ pub async fn generate_byop_output(
         lrc_should_spawn_subagent,
         context_window,
         cancellation_rx: _cancellation_rx,
+        attachment_caps,
     } = input;
 
     let force_echo_reasoning = super::reasoning::model_requires_reasoning_echo(api_type, &model_id);
-    let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, &model_id)?;
+    let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, attachment_caps)?;
     let conversation_id = params
         .conversation_token
         .as_ref()
@@ -5811,7 +5809,7 @@ mod serializer_readiness_tests {
     }
 
     fn build_openai_request(params: &RequestParams) -> Result<ChatRequest, ConvertToAPITypeError> {
-        build_chat_request(params, false, AgentProviderApiType::OpenAi, "test-model")
+        build_chat_request(params, false, AgentProviderApiType::OpenAi, attachment_caps::AttachmentCaps::default())
     }
 
     fn assert_request_has_no_repair_placeholder(request: &ChatRequest) {

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -419,7 +419,7 @@ fn build_user_message_with_binaries(
 
     if !error_replacements.is_empty() {
         log::info!(
-            "[byop] {} attachment(s) replaced with ERROR text — does not support: {error_replacements:?}",
+            "[byop] {} attachment(s) replaced with ERROR text — caps={caps:?} does not support: {error_replacements:?}",
             error_replacements.len()
         );
     }

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -58,6 +58,9 @@ struct ByopDispatch {
     /// 选中模型的上下文窗口(tokens)。0/None ⇒ 用户未填且 catalog 也无,
     /// chat_stream 跳过 context_window_usage 计算,UI 维持 100% 占位。
     context_window: Option<u32>,
+    /// ユーザー設定 (image/pdf/audio 三態 Override) を反映済みの attachment caps。
+    /// `resolve_for_model` で計算。UI 表示と runtime 動作が同じ caps を参照する。
+    attachment_caps: crate::ai::agent_providers::attachment_caps::AttachmentCaps,
 }
 
 /// 标题生成专用的 BYOP 配置(可能与主 base 模型同 provider 也可能不同)。
@@ -122,6 +125,20 @@ fn byop_dispatch_info(
     };
 
     let reasoning_effort = llm_prefs.get_reasoning_effort(None, provider.api_type, &model_id);
+    let attachment_caps = provider
+        .models
+        .iter()
+        .find(|m| m.id == model_id)
+        .map(|m| {
+            crate::ai::agent_providers::attachment_caps::resolve_for_model(
+                &provider.id,
+                provider.api_type,
+                m,
+            )
+        })
+        .unwrap_or_else(|| {
+            crate::ai::agent_providers::attachment_caps::caps_for(provider.api_type, &model_id)
+        });
     Some(ByopDispatch {
         base_url: provider.base_url,
         api_key,
@@ -136,6 +153,7 @@ fn byop_dispatch_info(
         lrc_command_id: params.lrc_command_id.clone(),
         lrc_should_spawn_subagent: params.lrc_should_spawn_subagent,
         context_window,
+        attachment_caps,
     })
 }
 
@@ -269,6 +287,7 @@ impl ResponseStream {
                             lrc_should_spawn_subagent: byop.lrc_should_spawn_subagent,
                             context_window: byop.context_window,
                             cancellation_rx,
+                            attachment_caps: byop.attachment_caps,
                         },
                     )
                     .await
@@ -376,6 +395,7 @@ impl ResponseStream {
                             lrc_should_spawn_subagent: byop.lrc_should_spawn_subagent,
                             context_window: byop.context_window,
                             cancellation_rx,
+                            attachment_caps: byop.attachment_caps,
                         },
                     )
                     .await

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -137,6 +137,10 @@ fn byop_dispatch_info(
             )
         })
         .unwrap_or_else(|| {
+            log::warn!(
+                "[byop] model '{}' not found in provider.models — falling back to caps_for (user overrides ignored)",
+                model_id
+            );
             crate::ai::agent_providers::attachment_caps::caps_for(provider.api_type, &model_id)
         });
     Some(ByopDispatch {


### PR DESCRIPTION
## 関連 Issue

Fixes #193

## 問題点（確定）

`build_user_message_with_binaries` (`chat_stream.rs:390`) が `attachment_caps::caps_for(api_type, model_id)` を呼んでいた。この関数は `AgentProviderModel.image`/`.pdf`/`.audio` のユーザー設定 (`Option<bool>` 三態) を**完全に無視**する。

ユーザーが設定 UI で multimodal を有効化すると `model.image = Some(true)` がセットされるが、runtime path は `caps_for` 経由で `AttachmentCaps::default()` (全 false) を返し、画像の代わりに以下の ERROR テキストをモデルに渡していた：

```
ERROR: Cannot read "image.png" (this model does not support image input). Inform the user.
```

モデルはこの指示通りにユーザーへ「画像を解釈できない」と報告する。

Minimax M3 はなぜ特に影響を受けるか：API type `OpenAi` の substring fallback ルール (`gpt-4o` / `gpt-4.1` / `gpt-5` / `o1` / `o3` / `o4`) に一切マッチしないため、models.dev catalog miss 時は必ず `AttachmentCaps::default()` (text-only) になる。

`mod.rs:88-89` のコメント「chat_stream も同じ関数を使う」は**誤り**であり、UI (`resolve_for_model`) と runtime (`caps_for`) が別の関数を使っていたことが根本原因。

## 復元証拠

| ファイル:行 | 内容 |
|---|---|
| `chat_stream.rs:390` | `caps_for(api_type, model_id)` — ユーザー設定を無視 |
| `attachment_caps.rs:74-93` | `resolve_for_model` — `model.image.unwrap_or(inferred)` でユーザー設定を尊重 |
| `mod.rs:91` | UI 表示のみ `resolve_for_model` を使用 |
| `attachment_caps.rs:141-143` | OpenAi arm fallback: 既知モデル以外は `AttachmentCaps::default()` |

## 修正内容

`byop_dispatch_info`（`response_stream.rs`）で `resolve_for_model` を使って caps を計算し、`ByopDispatch` → `ByopOutputInput` → `build_chat_request` → `build_user_message_with_binaries` に伝達するよう変更。

`build_chat_request` から不要になった `model_id` パラメータも削除。

## 規模確認

| 指標 | 値 |
|---|---|
| 修改文件数 | 2 |
| 変更行数 | +32 / -14 = 46行 |
| 影響面 grep 命中数 | 5箇所（全て同一モジュール内） |
| 公開 API / schema 変更 | なし |
| 新規依存 | なし |

## 修改文件一覧

| ファイル | 行範囲 | 変更内容 |
|---|---|---|
| `app/src/ai/agent_providers/chat_stream.rs` | 381-388 | `build_user_message_with_binaries` シグネチャ: `api_type`+`model_id` → `caps: AttachmentCaps` |
| `app/src/ai/agent_providers/chat_stream.rs` | 1176-1181 | `build_chat_request` から `model_id` パラメータ削除、`attachment_caps` 追加 |
| `app/src/ai/agent_providers/chat_stream.rs` | 3173-3210 | `ByopOutputInput` に `attachment_caps` フィールド追加、デストラクチャ・転送 |
| `app/src/ai/blocklist/controller/response_stream.rs` | 58-61 | `ByopDispatch` に `attachment_caps` フィールド追加 |
| `app/src/ai/blocklist/controller/response_stream.rs` | 125-155 | `byop_dispatch_info` で `resolve_for_model` を使って caps 計算 |
| `app/src/ai/blocklist/controller/response_stream.rs` | 287, 395 | 両 `ByopOutputInput` 構築に `attachment_caps` を追加 |

## 検証

```
cargo check --manifest-path app/Cargo.toml
→ Finished `dev` profile [unoptimized + debuginfo] (警告なし)

cargo test --manifest-path app/Cargo.toml --lib ai::agent_providers::attachment_caps
→ test result: ok. 8 passed; 0 failed
```

## 影響範囲

- `build_user_message_with_binaries` の呼び出し元: `build_chat_request` 内の 3箇所のみ
- `ByopOutputInput` の構築元: `response_stream.rs` の 2箇所のみ
- 既存の `caps_for` / `caps_for_by_substring` の動作は変更なし
- models.dev catalog に登録済みモデルへの影響なし（catalog hit 時は `resolve_for_model` も同じ値を返す）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz4ftQUDN33mdZhhvCHfts)_