### PR TITLE
feat: enable structured markdown table rendering in AI blocklist

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -548,6 +548,7 @@ default = [
     "markdown_tables",
     "markdown_mermaid",
     "blocklist_markdown_images",
+    "blocklist_markdown_table_rendering",
     "pr_comments_slash_command",
     "pr_comments_v2",
     "pr_comments_skill",

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -95,7 +95,7 @@ use crate::{
         },
     },
     code::{editor::view::CodeEditorView, editor_management::CodeSource},
-    notebooks::editor::{markdown_table_appearance, rich_text_styles},
+    notebooks::editor::{rich_text_styles, MarkdownTableAppearance},
     settings_view::SettingsSection,
     terminal::{
         find::TerminalFindModel, safe_mode_settings::get_secret_obfuscation_mode,
@@ -2321,6 +2321,25 @@ fn visual_section_height(app: &AppContext) -> f32 {
 }
 
 const TABLE_BLOCK_CORNER_RADIUS: f32 = 8.0;
+
+fn ai_table_appearance(appearance: &Appearance) -> MarkdownTableAppearance {
+    let theme = appearance.theme();
+    MarkdownTableAppearance {
+        border_color: internal_colors::neutral_4(theme),
+        header_background: theme.surface_2().into_solid(),
+        cell_background: ColorU::transparent_black(),
+        alternate_row_background: Some(theme.surface_1().with_opacity(50).into_solid()),
+        text_color: internal_colors::text_sub(theme, theme.background()),
+        header_text_color: internal_colors::text_main(theme, theme.background()),
+        scrollbar_nonactive_thumb_color: theme.nonactive_ui_detail().into_solid(),
+        scrollbar_active_thumb_color: theme.active_ui_detail().into_solid(),
+        cell_padding: 8.,
+        outer_border: true,
+        column_dividers: true,
+        row_dividers: true,
+    }
+}
+
 fn render_table_section(
     table: &AgentOutputTable,
     table_handles: TableSectionHandles,
@@ -2340,7 +2359,7 @@ fn render_table_section(
     }
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    let table_appearance = markdown_table_appearance(appearance);
+    let table_appearance = ai_table_appearance(appearance);
     let notebook_styles = rich_text_styles(appearance, FontSettings::as_ref(app));
     let table_font_family = appearance.ai_font_family();
     let table_font_size = appearance.monospace_font_size();

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -750,7 +750,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 /// Features enabled for feature preview build users (e.g.: Friends of Zap).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
-    FeatureFlag::BlocklistMarkdownTableRendering,
     FeatureFlag::MarkdownTables,
     FeatureFlag::GitOperationsInCodeReview,
 ];
@@ -767,6 +766,7 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     // 否则只能看到 OS 的候选窗,Zap 会把 marked text 更新整体丢弃。
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     FeatureFlag::ImeMarkedText,
+    FeatureFlag::BlocklistMarkdownTableRendering,
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,


### PR DESCRIPTION
## Summary

Enable and optimize structured markdown table rendering in AI agent conversation mode.

## Changes

- Promote `BlocklistMarkdownTableRendering` from `PREVIEW_FLAGS` to `RELEASE_FLAGS` for all users
- Add `blocklist_markdown_table_rendering` to default Cargo features for local dev builds
- Create dedicated `ai_table_appearance()` with optimized visual styles:
  - Outer border and column dividers enabled
  - Header background color (surface_2)
  - Alternating row backgrounds (50% opacity)
  - Reduced cell padding (8px) for compact display in conversation context

## Testing

- `cargo check` passes
- All markdown table related tests pass (14 AI agent util tests + 2 editor tests)
- Local manual verification confirms tables render with structured visual styling