### PR TITLE
fix(byop): MiniMax M3 thinking blocks displayed as reasoning

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -3203,6 +3203,9 @@ pub async fn generate_byop_output(
     } = input;
 
     let force_echo_reasoning = super::reasoning::model_requires_reasoning_echo(api_type, &model_id);
+    // 仅对已知把 reasoning 夹在 <think> 标签里的模型(如 MiniMax M3)激活流式提取。
+    // 其他模型保持原始 Chunk 输出行为,避免误吞含字面量 <think> 的正常文本。
+    let use_think_extraction = super::reasoning::model_uses_think_tags_in_content(&model_id);
     let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, attachment_caps)?;
     let conversation_id = params
         .conversation_token
@@ -3545,10 +3548,8 @@ pub async fn generate_byop_output(
         // 之后的 chunk 走 AppendToMessageContent 增量追加。
         let mut text_msg_id: Option<String> = None;
         let mut reasoning_msg_id: Option<String> = None;
-        // <think>...</think> 流式提取状态:部分国产 OpenAI 兼容 thinking 模型(如 MiniMax M3)
-        // 把 reasoning 以 <think> 标签形式夹在 /delta/content 中,而非 /delta/reasoning_content
-        // 独立字段。genai 侧仅解析后者,前者作为普通 Chunk 到达,需在此层提取。
-        // `think_active` 标记当前是否在 <think> 块内;`think_buf` 累积块内内容。
+        // <think>...</think> 流式提取状态:仅当 `use_think_extraction` 为 true 时有意义。
+        // 已知把 reasoning 夹在 <think> 标签里的模型(如 MiniMax M3)用此提取。
         let mut think_active = false;
         let mut think_buf = String::new();
         // tool_call 按 call_id 累积 — genai 流式发的 ToolCallChunk 已带完整 ToolCall
@@ -3635,72 +3636,88 @@ pub async fn generate_byop_output(
                 ChatStreamEvent::Chunk(c) if !c.content.is_empty() => {
                     chunk_count += 1;
                     chunk_bytes += c.content.len();
-                    // <think> 标签流式提取:把夹在 /delta/content 中的 <think>...</think>
-                    // 段路由到 reasoning 通道,其余内容照常走文本通道。
-                    // 支持标签跨 chunk 边界(think_active / think_buf 持久化跨循环迭代)。
-                    let mut rest: &str = &c.content;
-                    loop {
-                        if think_active {
-                            match rest.find("</think>") {
-                                Some(end) => {
-                                    think_buf.push_str(&rest[..end]);
-                                    let reasoning = std::mem::take(&mut think_buf);
-                                    think_active = false;
-                                    rest = &rest[end + "</think>".len()..];
-                                    if !reasoning.is_empty() {
-                                        reasoning_count += 1;
-                                        reasoning_bytes += reasoning.len();
-                                        super::reasoning::note_reasoning_seen(api_type, &model_id);
-                                        if let Some(id) = reasoning_msg_id.clone() {
-                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Reasoning(reasoning)));
-                                        } else {
-                                            let new_id = Uuid::new_v4().to_string();
-                                            let mut msg = make_reasoning_message(&current_task_id, &request_id, reasoning);
-                                            msg.id = new_id.clone();
-                                            reasoning_msg_id = Some(new_id);
-                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                    if use_think_extraction {
+                        // <think> 标签流式提取:仅对 THINK_TAG_IN_CONTENT_MODELS 白名单内的模型激活。
+                        // 把 /delta/content 中的 <think>...</think> 段路由到 reasoning 通道,
+                        // 其余内容照常走文本通道。支持标签内容跨 chunk 边界。
+                        //
+                        // known limitation: `<think>` 标签字符串本身跨 chunk 截断时(如
+                        // chunk1 末尾为 `<thi`、chunk2 开头为 `nk>`)无法识别,残余字符串
+                        // 作为普通文本输出。大多数推理模型会把 `<think>` 作为完整 token 输出,
+                        // 实际触发概率极低。
+                        let mut rest: &str = &c.content;
+                        loop {
+                            if think_active {
+                                match rest.find("</think>") {
+                                    Some(end) => {
+                                        think_buf.push_str(&rest[..end]);
+                                        let reasoning = std::mem::take(&mut think_buf);
+                                        think_active = false;
+                                        rest = &rest[end + "</think>".len()..];
+                                        if !reasoning.is_empty() {
+                                            reasoning_count += 1;
+                                            reasoning_bytes += reasoning.len();
+                                            if let Some(id) = reasoning_msg_id.clone() {
+                                                yield Ok(make_append_event(&current_task_id, &id, AppendKind::Reasoning(reasoning)));
+                                            } else {
+                                                let new_id = Uuid::new_v4().to_string();
+                                                let mut msg = make_reasoning_message(&current_task_id, &request_id, reasoning);
+                                                msg.id = new_id.clone();
+                                                reasoning_msg_id = Some(new_id);
+                                                yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                            }
                                         }
                                     }
+                                    None => {
+                                        think_buf.push_str(rest);
+                                        break;
+                                    }
                                 }
-                                None => {
-                                    think_buf.push_str(rest);
-                                    break;
+                            } else {
+                                match rest.find("<think>") {
+                                    Some(start) => {
+                                        let before = rest[..start].to_owned();
+                                        think_active = true;
+                                        rest = &rest[start + "<think>".len()..];
+                                        if !before.is_empty() {
+                                            if let Some(id) = text_msg_id.clone() {
+                                                yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(before)));
+                                            } else {
+                                                let new_id = Uuid::new_v4().to_string();
+                                                let mut msg = make_agent_output_message(&current_task_id, &request_id, before);
+                                                msg.id = new_id.clone();
+                                                text_msg_id = Some(new_id);
+                                                yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                            }
+                                        }
+                                    }
+                                    None => {
+                                        let text = rest.to_owned();
+                                        if !text.is_empty() {
+                                            if let Some(id) = text_msg_id.clone() {
+                                                yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(text)));
+                                            } else {
+                                                let new_id = Uuid::new_v4().to_string();
+                                                let mut msg = make_agent_output_message(&current_task_id, &request_id, text);
+                                                msg.id = new_id.clone();
+                                                text_msg_id = Some(new_id);
+                                                yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                            }
+                                        }
+                                        break;
+                                    }
                                 }
                             }
+                        }
+                    } else {
+                        if let Some(id) = text_msg_id.clone() {
+                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(c.content)));
                         } else {
-                            match rest.find("<think>") {
-                                Some(start) => {
-                                    let before = rest[..start].to_owned();
-                                    think_active = true;
-                                    rest = &rest[start + "<think>".len()..];
-                                    if !before.is_empty() {
-                                        if let Some(id) = text_msg_id.clone() {
-                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(before)));
-                                        } else {
-                                            let new_id = Uuid::new_v4().to_string();
-                                            let mut msg = make_agent_output_message(&current_task_id, &request_id, before);
-                                            msg.id = new_id.clone();
-                                            text_msg_id = Some(new_id);
-                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
-                                        }
-                                    }
-                                }
-                                None => {
-                                    let text = rest.to_owned();
-                                    if !text.is_empty() {
-                                        if let Some(id) = text_msg_id.clone() {
-                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(text)));
-                                        } else {
-                                            let new_id = Uuid::new_v4().to_string();
-                                            let mut msg = make_agent_output_message(&current_task_id, &request_id, text);
-                                            msg.id = new_id.clone();
-                                            text_msg_id = Some(new_id);
-                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
-                                        }
-                                    }
-                                    break;
-                                }
-                            }
+                            let new_id = Uuid::new_v4().to_string();
+                            let mut msg = make_agent_output_message(&current_task_id, &request_id, c.content);
+                            msg.id = new_id.clone();
+                            text_msg_id = Some(new_id);
+                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
                         }
                     }
                 }

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -3545,6 +3545,12 @@ pub async fn generate_byop_output(
         // 之后的 chunk 走 AppendToMessageContent 增量追加。
         let mut text_msg_id: Option<String> = None;
         let mut reasoning_msg_id: Option<String> = None;
+        // <think>...</think> 流式提取状态:部分国产 OpenAI 兼容 thinking 模型(如 MiniMax M3)
+        // 把 reasoning 以 <think> 标签形式夹在 /delta/content 中,而非 /delta/reasoning_content
+        // 独立字段。genai 侧仅解析后者,前者作为普通 Chunk 到达,需在此层提取。
+        // `think_active` 标记当前是否在 <think> 块内;`think_buf` 累积块内内容。
+        let mut think_active = false;
+        let mut think_buf = String::new();
         // tool_call 按 call_id 累积 — genai 流式发的 ToolCallChunk 已带完整 ToolCall
         // (since 0.4.0 行为),但跨 chunk 同一 call_id 可能多次出现 args 增量,
         // 用 HashMap 按 id 累积后在流末统一 emit。
@@ -3629,14 +3635,73 @@ pub async fn generate_byop_output(
                 ChatStreamEvent::Chunk(c) if !c.content.is_empty() => {
                     chunk_count += 1;
                     chunk_bytes += c.content.len();
-                    if let Some(id) = text_msg_id.clone() {
-                        yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(c.content)));
-                    } else {
-                        let new_id = Uuid::new_v4().to_string();
-                        let mut msg = make_agent_output_message(&current_task_id, &request_id, c.content);
-                        msg.id = new_id.clone();
-                        text_msg_id = Some(new_id);
-                        yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                    // <think> 标签流式提取:把夹在 /delta/content 中的 <think>...</think>
+                    // 段路由到 reasoning 通道,其余内容照常走文本通道。
+                    // 支持标签跨 chunk 边界(think_active / think_buf 持久化跨循环迭代)。
+                    let mut rest: &str = &c.content;
+                    loop {
+                        if think_active {
+                            match rest.find("</think>") {
+                                Some(end) => {
+                                    think_buf.push_str(&rest[..end]);
+                                    let reasoning = std::mem::take(&mut think_buf);
+                                    think_active = false;
+                                    rest = &rest[end + "</think>".len()..];
+                                    if !reasoning.is_empty() {
+                                        reasoning_count += 1;
+                                        reasoning_bytes += reasoning.len();
+                                        super::reasoning::note_reasoning_seen(api_type, &model_id);
+                                        if let Some(id) = reasoning_msg_id.clone() {
+                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Reasoning(reasoning)));
+                                        } else {
+                                            let new_id = Uuid::new_v4().to_string();
+                                            let mut msg = make_reasoning_message(&current_task_id, &request_id, reasoning);
+                                            msg.id = new_id.clone();
+                                            reasoning_msg_id = Some(new_id);
+                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                        }
+                                    }
+                                }
+                                None => {
+                                    think_buf.push_str(rest);
+                                    break;
+                                }
+                            }
+                        } else {
+                            match rest.find("<think>") {
+                                Some(start) => {
+                                    let before = rest[..start].to_owned();
+                                    think_active = true;
+                                    rest = &rest[start + "<think>".len()..];
+                                    if !before.is_empty() {
+                                        if let Some(id) = text_msg_id.clone() {
+                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(before)));
+                                        } else {
+                                            let new_id = Uuid::new_v4().to_string();
+                                            let mut msg = make_agent_output_message(&current_task_id, &request_id, before);
+                                            msg.id = new_id.clone();
+                                            text_msg_id = Some(new_id);
+                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                        }
+                                    }
+                                }
+                                None => {
+                                    let text = rest.to_owned();
+                                    if !text.is_empty() {
+                                        if let Some(id) = text_msg_id.clone() {
+                                            yield Ok(make_append_event(&current_task_id, &id, AppendKind::Text(text)));
+                                        } else {
+                                            let new_id = Uuid::new_v4().to_string();
+                                            let mut msg = make_agent_output_message(&current_task_id, &request_id, text);
+                                            msg.id = new_id.clone();
+                                            text_msg_id = Some(new_id);
+                                            yield Ok(make_add_messages_event(&current_task_id, vec![msg]));
+                                        }
+                                    }
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
                 ChatStreamEvent::Chunk(_) => {}

--- a/app/src/ai/agent_providers/reasoning.rs
+++ b/app/src/ai/agent_providers/reasoning.rs
@@ -250,8 +250,9 @@ const INTERLEAVED_RULES: &[(&str, ReasoningInterleavedField)] = {
         ("glm-4.5-thinking", RC),
         ("glm-4.6-thinking", RC),
         ("glm-4.7", RC),
-        // MiniMax M1 thinking
+        // MiniMax M1 / M3 thinking
         ("minimax-m1", RC),
+        ("minimax-m3", RC),
         // 腾讯混元 T1 thinking
         ("hunyuan-t1", RC),
         // 百度文心 X1 / thinking

--- a/app/src/ai/agent_providers/reasoning.rs
+++ b/app/src/ai/agent_providers/reasoning.rs
@@ -250,9 +250,11 @@ const INTERLEAVED_RULES: &[(&str, ReasoningInterleavedField)] = {
         ("glm-4.5-thinking", RC),
         ("glm-4.6-thinking", RC),
         ("glm-4.7", RC),
-        // MiniMax M1 / M3 thinking
+        // MiniMax M1 thinking(使用 reasoning_content 字段)
         ("minimax-m1", RC),
-        ("minimax-m3", RC),
+        // MiniMax M3: reasoning 以 <think> 标签夹在 content 中传输,
+        // 多轮 echo 格式待确认(RC 还是 <think>-in-content),暂不加 RC 条目。
+        // 显示修复由 model_uses_think_tags_in_content 白名单 + 流式提取处理。
         // 腾讯混元 T1 thinking
         ("hunyuan-t1", RC),
         // 百度文心 X1 / thinking
@@ -268,6 +270,27 @@ const INTERLEAVED_RULES: &[(&str, ReasoningInterleavedField)] = {
         ("yi-thinking", RC),
     ]
 };
+
+/// OpenAI 兼容 thinking 模型中，把 reasoning 以 `<think>...</think>` 标签形式夹在
+/// `/delta/content` 里传输（而非独立的 `/delta/reasoning_content` 字段）的模型白名单。
+///
+/// 命中此表的模型，chat_stream 流式层会对 Chunk 事件做 `<think>` 标签提取，
+/// 把标签内内容路由到 reasoning 通道显示为灰色思考块。
+/// 未命中的模型保持原有文本输出行为，避免误吞含字面量 `<think>` 的正常输出。
+const THINK_TAG_IN_CONTENT_MODELS: &[&str] = &[
+    // MiniMax M3:reasoning 通过 content 中的 <think> 标签传输。
+    "minimax-m3",
+];
+
+/// 返回指定模型是否通过 `<think>` 标签在 content 中传递 reasoning（而非 reasoning_content 字段）。
+///
+/// chat_stream 流式层用此函数决定是否对 Chunk 事件做 `<think>` 标签提取。
+pub fn model_uses_think_tags_in_content(model_id: &str) -> bool {
+    let id = model_id.to_ascii_lowercase();
+    THINK_TAG_IN_CONTENT_MODELS
+        .iter()
+        .any(|&needle| id.contains(needle))
+}
 
 /// 运行时 latch 集合:记录哪些 (api_type, model_id) 在某次 stream 里发过
 /// `ReasoningChunk` —— 即"该 endpoint 服务端认识 reasoning_content 字段"的
@@ -821,5 +844,23 @@ mod tests {
             AgentProviderApiType::Ollama,
             "qwq-32b"
         ));
+    }
+
+    #[test]
+    fn think_tag_in_content_models() {
+        // MiniMax M3 命中
+        assert!(model_uses_think_tags_in_content("minimax-m3"));
+        assert!(model_uses_think_tags_in_content("MiniMax-M3-80k"));
+        assert!(model_uses_think_tags_in_content("MINIMAX-M3"));
+        // MiniMax M1 不命中(使用 reasoning_content 字段)
+        assert!(!model_uses_think_tags_in_content("minimax-m1"));
+        // 其他 thinking 模型不命中(各自走 reasoning_content 字段)
+        assert!(!model_uses_think_tags_in_content("deepseek-r1"));
+        assert!(!model_uses_think_tags_in_content("gpt-5"));
+        assert!(!model_uses_think_tags_in_content("qwen3-235b"));
+        assert!(!model_uses_think_tags_in_content("kimi-k2-thinking"));
+        // 普通非 thinking 模型不命中
+        assert!(!model_uses_think_tags_in_content("gpt-4o"));
+        assert!(!model_uses_think_tags_in_content("claude-opus-4-7"));
     }
 }


### PR DESCRIPTION
## 관련 Issue

Fixes #197

## 문제점 (확정 근거 포함)

**근인**: `app/src/ai/agent_providers/chat_stream.rs` 스트리밍 루프의 `Chunk` 처리 arm은 `ChatStreamEvent::Chunk` 이벤트를 무조건 텍스트로 처리합니다. MiniMax M3는 사고 내용을 `/delta/reasoning_content` 독립 필드 대신 `/delta/content` 안에 `<think>...</think>` 태그로 포함하여 스트리밍합니다. genai `OpenAIStreamer`(`lib/rust-genai/src/adapter/adapters/openai/streamer.rs:249-274`)는 `reasoning_content` / `reasoning` 필드만 `ReasoningChunk`로 변환하므로, `<think>` 태그가 포함된 content는 일반 `Chunk`로 흘러 UI에서 회색 reasoning 블록 대신 `<think>` 태그가 포함된 일반 텍스트가 출력됩니다.

**추가 결함**: `reasoning.rs:253-254`의 `INTERLEAVED_RULES` 테이블에 `minimax-m1` 항목만 존재하고 `minimax-m3`가 없어, M3가 `reasoning_content`를 반환하는 멀티턴 대화에서 두 번째 턴의 echo 누락으로 400 오류가 발생합니다.

## 복현 증거

- `reasoning.rs:253-254`: `("minimax-m1", RC)` 만 존재, `minimax-m3` 누락
- `openai/streamer.rs:249-274`: `/delta/reasoning_content`, `/delta/reasoning` 필드만 `ReasoningChunk`로 변환
- `adapter_impl.rs:103-106`: `normalize_reasoning_content`(= `<think>` 태그 추출)는 비스트리밍 경로에만 구현됨
- `chat_stream.rs:3635-3647` (수정 전): `Chunk` 이벤트를 `<think>` 태그 검사 없이 전부 텍스트로 emit

## 규모 선언 (SMALL_FIX 범위 증명)

| 지표 | 값 |
|------|----|
| 수정 파일 수 | 2 |
| 순증 행수 | 66줄 |
| 영향면 grep 명중 | 1곳 (Chunk arm) |
| 공개 API/export 변경 | 없음 |
| 새 의존성 | 없음 |

## 수정 파일 목록

| 파일 | 행 범위 | 내용 |
|------|---------|------|
| `app/src/ai/agent_providers/chat_stream.rs` | 3544-3706 | 스트리밍 루프 앞에 `think_active: bool` / `think_buf: String` 상태 추가; `Chunk` arm을 `<think>` 상태 머신으로 교체 — 블록 내부는 `ReasoningChunk` 경로(회색 표시 + latch), 외부는 기존 텍스트 경로 유지. 청크 경계 걸침 지원. |
| `app/src/ai/agent_providers/reasoning.rs` | 253-255 | `INTERLEAVED_RULES`에 `("minimax-m3", RC)` 추가 — M3 멀티턴 `reasoning_content` echo 활성화. |

## 검증

```
cargo check -p warp
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s  ✅

cargo test -p warp --lib ai::agent_providers::reasoning
→ test result: ok. 32 passed; 0 failed; 0 ignored  ✅
```

## 영향면

- `INTERLEAVED_RULES` 사용처: `model_reasoning_interleaved()` 함수 내 1곳 (`reasoning.rs:364`)
- `Chunk` arm 변경: 스트리밍 루프 내 1곳. 기존 `reasoning_content` 필드를 사용하는 모델(M1 등)은 `ReasoningChunk` 경로를 그대로 타므로 영향 없음. `<think>` 태그가 없는 일반 content는 `find("<think>")` 실패 → 기존 텍스트 경로 그대로 실행.

https://claude.ai/code/session_0123ysTwn44jVs63dELnqxib

---
_Generated by [Claude Code](https://claude.ai/code/session_0123ysTwn44jVs63dELnqxib)_