### PR TITLE
feat(workspace): 新建标签页菜单增加已安装 Coding Agent 快速启动条目

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1493,6 +1493,9 @@ fn initialize_app(
 
     timer.mark_interval_end("SUBSYSTEM_INITS_DONE");
 
+    // 后台检测系统安装的 CLI agent，不阻塞 UI
+    crate::terminal::CLIAgent::refresh_install_cache();
+
     let display_count = ctx.windows().display_count();
     ctx.add_singleton_model(|_| DisplayCount(display_count));
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -6,6 +6,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
+use std::process::Command;
+use std::sync::{Arc, LazyLock, RwLock};
 
 use ai::skills::SkillProvider;
 use enum_iterator::Sequence;
@@ -563,6 +565,60 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::DeepSeek => CLIAgentType::DeepSeek,
             CLIAgent::Antigravity => CLIAgentType::Antigravity,
             CLIAgent::Unknown => CLIAgentType::Unknown,
+        }
+    }
+}
+
+/// CLI agent 安装状态缓存。应用启动时后台线程填充一次。
+static AGENT_INSTALL_CACHE: LazyLock<Arc<RwLock<Option<HashMap<CLIAgent, bool>>>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(None)));
+
+impl CLIAgent {
+    /// 非阻塞读取缓存。缓存未就绪时返回 false，菜单中不展示该 agent。
+    pub fn is_installed(&self) -> bool {
+        AGENT_INSTALL_CACHE
+            .read()
+            .ok()
+            .and_then(|c| c.as_ref().map(|m| m.get(self).copied().unwrap_or(false)))
+            .unwrap_or(false)
+    }
+
+    /// 后台刷新全部 agent 的安装状态，不阻塞 UI。
+    /// 仅在应用启动时调用一次。
+    pub fn refresh_install_cache() {
+        let cache = AGENT_INSTALL_CACHE.clone();
+        std::thread::spawn(move || {
+            let results: HashMap<CLIAgent, bool> = enum_iterator::all::<CLIAgent>()
+                .filter(|a| !matches!(a, CLIAgent::Unknown))
+                .map(|a| (a, a.is_installed_blocking()))
+                .collect();
+            if let Ok(mut guard) = cache.write() {
+                *guard = Some(results);
+            }
+        });
+    }
+
+    /// 同步检测系统是否安装了此 agent。后台线程专用。
+    fn is_installed_blocking(&self) -> bool {
+        let check_cmd = |cmd: &str| -> bool {
+            #[cfg(unix)]
+            let (shell, arg) = ("which", cmd);
+            #[cfg(windows)]
+            let (shell, arg) = ("where", cmd);
+            Command::new(shell)
+                .arg(arg)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .output()
+                .is_ok_and(|o| o.status.success())
+        };
+        match self {
+            CLIAgent::Unknown => false,
+            // `agent` 太泛化，Cursor CLI 用 cursor-agent 检测
+            CLIAgent::CursorCli => check_cmd("cursor-agent"),
+            // DeepSeek 同时检查主命令和别名
+            CLIAgent::DeepSeek => check_cmd("deepseek") || check_cmd("deepseek-tui"),
+            other => check_cmd(other.command_prefix()),
         }
     }
 }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -21,6 +21,7 @@ use crate::settings_view::{SettingsAction as SettingsTabAction, SettingsSection}
 use crate::tab::{NewSessionMenuItem, SelectedTabColor};
 use crate::tab_configs::TabConfig;
 use crate::terminal::available_shells::AvailableShell;
+use crate::terminal::CLIAgent;
 use crate::terminal::view::inline_banner::ZeroStatePromptSuggestionType;
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::themes::theme_chooser::ThemeChooserMode;
@@ -157,6 +158,8 @@ pub enum WorkspaceAction {
     AddGetStartedTab,
     /// Add a new tab that immediately enters agent view with a new conversation.
     AddAgentTab,
+    /// Add a new terminal tab and launch a specific CLI agent.
+    AddSpecificAgentTab(CLIAgent),
     /// Add a new tab running a local Docker sandbox via `sbx`.
     AddDockerSandboxTab,
     OpenNewSessionMenu {
@@ -677,6 +680,7 @@ impl WorkspaceAction {
             | AddTabWithShell { .. }
             | AddGetStartedTab
             | AddAgentTab
+            | AddSpecificAgentTab(_)
             | AddDockerSandboxTab
             | AddWindow
             | AddWindowWithShell { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -102,6 +102,7 @@ use crate::ai::blocklist::FORK_PREFIX;
 #[cfg(not(target_family = "wasm"))]
 use crate::terminal::cli_agent_sessions::plugin_manager::{plugin_manager_for, PluginModalKind};
 use crate::terminal::cli_agent_sessions::{CLIAgentSessionsModel, CLIAgentSessionsModelEvent};
+use crate::terminal::CLIAgent;
 use crate::workspace::header_toolbar_editor::{HeaderToolbarEditorEvent, HeaderToolbarEditorModal};
 use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
 use crate::workspace::tab_settings::TabCloseButtonPosition;
@@ -3857,6 +3858,18 @@ impl Workspace {
         });
     }
 
+    /// 新建默认终端标签页，然后执行指定 CLI agent 的启动命令。
+    fn add_tab_with_specific_agent(&mut self, agent: CLIAgent, ctx: &mut ViewContext<Self>) {
+        self.add_terminal_tab(false, ctx);
+        self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+            if let Some(terminal_view) = pane_group.active_session_view(ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.execute_command_or_set_pending(agent.command_prefix(), ctx);
+                });
+            }
+        });
+    }
+
     fn toggle_ai_assistant_panel(&mut self, ctx: &mut ViewContext<Self>) {
         // Now that the user has interacted with the panel, we can close
         // the dialogue and mark it as dismissed.
@@ -5794,7 +5807,7 @@ impl Workspace {
     /// Builds the unified new-session menu items
     /// tab bar chevron and the vertical tab bar `+` button.
     ///
-    /// Order: Agent → Terminal (sidecar) → Ambient Agent → [tab configs] → separator → New worktree config (sidecar) → New tab config → separator → Reopen closed session.
+    /// Order: Terminal → User tab configs → separator → Agent → Coding Agents → separator → Docker → Worktree config → New tab config → separator → Reopen closed session.
     fn unified_new_session_menu_items(
         &self,
         ctx: &mut ViewContext<Self>,
@@ -5809,18 +5822,7 @@ impl Workspace {
         let reopen_closed_session_shortcut_label =
             keybinding_name_to_display_string("app:reopen_closed_session", ctx);
 
-        // 1. Agent (if AI enabled)
-        if is_any_ai_enabled {
-            let mut agent_item = MenuItemFields::new(crate::t!("workspace-new-session-agent"))
-                .with_on_select_action(WorkspaceAction::AddAgentTab)
-                .with_icon(icons::Icon::LayoutAlt01);
-            if effective_default == DefaultSessionMode::Agent {
-                agent_item = agent_item.with_key_shortcut_label(shortcut_label.clone());
-            }
-            menu_items.push(agent_item.into_item());
-        }
-
-        // 2. Terminal (+ individual shells on Windows)
+        // 1. Terminal (+ individual shells on Windows)
         {
             // On Windows, list the default terminal and each available shell as
             // individual top-level items (no submenu) so each gets a sidecar.
@@ -5878,24 +5880,10 @@ impl Workspace {
             }
         }
 
-        // 3. Local Docker Sandbox
-        if FeatureFlag::LocalDockerSandbox.is_enabled() {
-            let mut docker_item =
-                MenuItemFields::new(crate::t!("workspace-new-session-local-docker-sandbox"))
-                    .with_on_select_action(WorkspaceAction::AddDockerSandboxTab)
-                    .with_icon(icons::Icon::Docker);
-            if effective_default == DefaultSessionMode::DockerSandbox {
-                docker_item = docker_item.with_key_shortcut_label(shortcut_label.clone());
-            }
-            menu_items.push(docker_item.into_item());
-        }
-
-        // 4. User tab configs
+        // 2. User tab configs
         if FeatureFlag::TabConfigs.is_enabled() {
             let tab_configs = WarpConfig::as_ref(ctx).tab_configs().to_vec();
 
-            // Count occurrences of each config name so we can disambiguate
-            // duplicates in the menu (e.g. "My Tab Config", "My Tab Config (1)").
             let mut name_totals: HashMap<String, usize> = HashMap::new();
             for config in &tab_configs {
                 *name_totals.entry(config.name.clone()).or_default() += 1;
@@ -5937,7 +5925,60 @@ impl Workspace {
             }
         }
 
-        // 5. Separator + worktree config entry + new tab config
+        // 3. Separator — 仅在后面有 Agent 或 Coding Agent 时才显示
+        if is_any_ai_enabled {
+            menu_items.push(MenuItem::Separator);
+        }
+
+        // 4. Agent (if AI enabled)
+        if is_any_ai_enabled {
+            let mut agent_item = MenuItemFields::new(crate::t!("workspace-new-session-agent"))
+                .with_on_select_action(WorkspaceAction::AddAgentTab)
+                .with_icon(icons::Icon::LayoutAlt01);
+            if effective_default == DefaultSessionMode::Agent {
+                agent_item = agent_item.with_key_shortcut_label(shortcut_label.clone());
+            }
+            menu_items.push(agent_item.into_item());
+        }
+
+        // 5. Coding Agents — 仅已安装的出现在菜单中
+        let coding_agent_count = {
+            let start_len = menu_items.len();
+            for agent in enum_iterator::all::<CLIAgent>() {
+                if matches!(agent, CLIAgent::Unknown) {
+                    continue;
+                }
+                if !agent.is_installed() {
+                    continue;
+                }
+                let icon = agent.icon().unwrap_or(icons::Icon::LayoutAlt01);
+                let item = MenuItemFields::new(agent.display_name())
+                    .with_on_select_action(WorkspaceAction::AddSpecificAgentTab(agent))
+                    .with_icon(icon);
+                menu_items.push(item.into_item());
+            }
+            menu_items.len() - start_len
+        };
+
+        // 6. Separator — 仅当 coding agent 有内容且 Docker 启用时才显示
+        // TabConfigs 区域在 step 8 自带分隔线，无需这里重复
+        if coding_agent_count > 0 && FeatureFlag::LocalDockerSandbox.is_enabled() {
+            menu_items.push(MenuItem::Separator);
+        }
+
+        // 7. Local Docker Sandbox
+        if FeatureFlag::LocalDockerSandbox.is_enabled() {
+            let mut docker_item =
+                MenuItemFields::new(crate::t!("workspace-new-session-local-docker-sandbox"))
+                    .with_on_select_action(WorkspaceAction::AddDockerSandboxTab)
+                    .with_icon(icons::Icon::Docker);
+            if effective_default == DefaultSessionMode::DockerSandbox {
+                docker_item = docker_item.with_key_shortcut_label(shortcut_label.clone());
+            }
+            menu_items.push(docker_item.into_item());
+        }
+
+        // 8. Separator + worktree config entry + new tab config
         if FeatureFlag::TabConfigs.is_enabled() {
             menu_items.push(MenuItem::Separator);
             menu_items.push(
@@ -5946,7 +5987,6 @@ impl Workspace {
                     .into_item(),
             );
 
-            // 6. New tab config — V0: opens the TOML template.
             menu_items.push(
                 MenuItemFields::new(crate::t!("workspace-new-tab-config"))
                     .with_on_select_action(WorkspaceAction::SelectNewSessionMenuItem(
@@ -8328,6 +8368,11 @@ impl Workspace {
             Some(WorkspaceAction::AddDockerSandboxTab) => SidecarItemKind::BuiltIn {
                 name: label.to_string(),
                 default_mode: DefaultSessionMode::DockerSandbox,
+                shell: None,
+            },
+            Some(WorkspaceAction::AddSpecificAgentTab(agent)) => SidecarItemKind::BuiltIn {
+                name: agent.display_name().to_string(),
+                default_mode: DefaultSessionMode::Agent,
                 shell: None,
             },
             _ => {
@@ -18549,6 +18594,7 @@ impl TypedActionView for Workspace {
             }
             AddGetStartedTab => self.add_get_started_tab(ctx),
             AddAgentTab => self.add_terminal_tab_with_new_agent_view(ctx),
+            AddSpecificAgentTab(agent) => self.add_tab_with_specific_agent(*agent, ctx),
             AddDockerSandboxTab => self.add_docker_sandbox_tab(ctx),
             StartAgentOnboardingTutorial(tutorial) => {
                 self.start_agent_onboarding_tutorial(tutorial.clone(), ctx)


### PR DESCRIPTION
## 改动

在新建标签页菜单中增加 Coding Agent 快速启动条目，自动识别系统上已安装的 CLI agent 并展示对应图标，点击即可在新终端中启动。

### 具体变更

- **`cli_agent.rs`** — 新增 `is_installed()` 方法，`RwLock` 缓存 + 后台 `std::thread::spawn` 检测，启动时运行一次，菜单读取零阻塞
- **`action.rs`** — 新增 `WorkspaceAction::AddSpecificAgentTab(CLIAgent)`
- **`view.rs`** — 菜单重排（Terminal 优先），Agent 条目后追加已安装的 coding agent，点击执行 `command_prefix`
- **`lib.rs`** — 启动时触发 `refresh_install_cache()`

### 菜单顺序

```
Terminal → Tab Configs → ── → Agent → Claude Code → Gemini → ... → ── → Docker → Worktree → Reopen
```

### 检测方式

`which <command_prefix>` (Unix) / `where <command_prefix>` (Windows)，每个 agent 独立检测，仅已安装的出现在菜单中。

Closes #178

### 效果图

<img width="562" height="793" alt="image" src="https://github.com/user-attachments/assets/e9fc86f7-2bd1-4902-8d4f-1a22059f7df1" />

### 下一步：

1. 在设置界面 - 第三方智能体界面 增加菜单的自定义功能（有些安装了但是不想加进来的话，可以去掉）
2. 添加一个窗口右上角的智能体快捷启动按钮（但这个应该在单独PR中实现）
3. 把智能体会话历史加到智能体对话列表中