### PR TITLE
fix(resizable): SSH sidebar resize 時に tree item の ghost drag が誤起動する問題を修正

### DIFF
--- a/crates/warpui_core/src/elements/resizable.rs
+++ b/crates/warpui_core/src/elements/resizable.rs
@@ -441,10 +441,6 @@ impl Element for Resizable {
         let child_handled = self.child.dispatch_event(event, ctx, app);
 
         match event.raw_event() {
-            crate::Event::LeftMouseDown { .. } => {
-                // Not on the dragbar — already dispatched to child above.
-            }
-
             crate::Event::LeftMouseUp { .. } => {
                 // If a mouse-up occurs, take the view out of resizing mode
                 if self.state().is_resizing() {

--- a/crates/warpui_core/src/elements/resizable.rs
+++ b/crates/warpui_core/src/elements/resizable.rs
@@ -422,20 +422,27 @@ impl Element for Resizable {
         ctx: &mut EventContext,
         app: &AppContext,
     ) -> bool {
+        // Intercept LeftMouseDown on the dragbar before dispatching to children.
+        // Without this, child Draggable elements (e.g. SSH tree rows that stretch to the
+        // full panel width) would also activate on the same click, causing ghost-drag
+        // artifacts while the sidebar resize appears not to work (issue #203).
+        if let crate::Event::LeftMouseDown { position, .. } = event.raw_event() {
+            if self
+                .dragbar
+                .bounds
+                .is_some_and(|bounds| bounds.contains_point(*position))
+            {
+                self.state().begin_resizing(*position);
+                dispatch_callback(self.resize_handler.as_mut(), ctx, app);
+                return true;
+            }
+        }
+
         let child_handled = self.child.dispatch_event(event, ctx, app);
 
         match event.raw_event() {
-            crate::Event::LeftMouseDown { position, .. } => {
-                // If a mouse-down on the dragbar element occurred, put the view into resizing mode
-                if self
-                    .dragbar
-                    .bounds
-                    .is_some_and(|bounds| bounds.contains_point(*position))
-                {
-                    self.state().begin_resizing(*position);
-                    dispatch_callback(self.resize_handler.as_mut(), ctx, app);
-                    return true;
-                }
+            crate::Event::LeftMouseDown { .. } => {
+                // Not on the dragbar — already dispatched to child above.
             }
 
             crate::Event::LeftMouseUp { .. } => {


### PR DESCRIPTION
## 関連 Issue

Fixes #203

---

## 問題点（確定的記述）

**根因**: `crates/warpui_core/src/elements/resizable.rs:425`（修正前）

```rust
// 修正前 — LeftMouseDown を常に child へ先行 dispatch してから dragbar をチェック
let child_handled = self.child.dispatch_event(event, ctx, app);  // ← 先に子へ
match event.raw_event() {
    LeftMouseDown { position, .. } => {
        if dragbar.contains_point(position) {
            self.state().begin_resizing(*position);  // ← 子が処理済みでも Resizable も開始
```

SSH Manager panel の tree row は `CrossAxisAlignment::Stretch` により panel 全幅に伸張され、各行の `Draggable` 要素のヒット領域が panel 右端の 5px dragbar と重複する。`LeftMouseDown` を子へ先行 dispatch する現行の実装では、ユーザーが dragbar をクリックした際に SSH tree row の `Draggable` も同時にアクティベートされる。

## 複現証拠

| ファイル:行 | 証拠 |
|-------------|------|
| `app/src/ssh_manager/panel.rs:1358` | `with_cross_axis_alignment(CrossAxisAlignment::Stretch)` → tree rows が panel 全幅に伸張 |
| `app/src/ssh_manager/panel.rs:1540` | `Draggable::new(drag_state, hoverable)` → 全幅ヒット領域の Draggable |
| `crates/warpui_core/src/elements/resizable.rs:19` | `DRAGBAR_WIDTH = 5.0` — dragbar と Draggable が重複 |
| `crates/warpui_core/src/elements/drag/draggable.rs:22` | `DEFAULT_DRAG_THRESHOLD = 5.0` — 5px ドラッグで即 Dragging 状態に遷移 |

**発生するイベントシーケンス（修正前）**:
1. dragbar（右端 5px）で `LeftMouseDown` → child dispatch → SSH tree row の `Draggable` が `WaitingToDrag` に遷移
2. `Resizable` も `begin_resizing` を呼び出す（両方が同時に所有権を持つ）
3. 5px 以上ドラッグ → `Draggable` が `Dragging` 状態に遷移、ghost item が cursor を追随
4. ユーザーには「要素が動いたが sidebar/divider は動いていない」ように見える

## 規模宣言

| 指標 | 値 |
|------|----|
| 変更ファイル数 | 1 |
| 変更行数 | 18 insertions, 11 deletions |
| `Resizable` 使用箇所 | 7 箇所（left_panel, right_panel, ai_assistant, code_review 等）|
| API 変更 | なし |

## 修改ファイル清单

| ファイル | 行範囲 | 変更内容 |
|----------|--------|----------|
| `crates/warpui_core/src/elements/resizable.rs` | 419-497 | `LeftMouseDown` の dragbar チェックを `self.child.dispatch_event()` の前置処理として移動。dragbar 上のクリックは child へ dispatch せずリサイズのみを開始する |

```rust
// 修正後
if let crate::Event::LeftMouseDown { position, .. } = event.raw_event() {
    if self.dragbar.bounds.is_some_and(|bounds| bounds.contains_point(*position)) {
        self.state().begin_resizing(*position);  // child より先に処理
        dispatch_callback(self.resize_handler.as_mut(), ctx, app);
        return true;  // child へは dispatch しない
    }
}
let child_handled = self.child.dispatch_event(event, ctx, app);
```

## 検証

```
cargo check -p warpui_core  → Finished (no errors)
cargo test -p warpui_core   → test result: ok. 271 passed; 0 failed
```

## 影響面

`Resizable` を使用する全パネルで dragbar クリック時に子 Draggable が起動しなくなる。**これは正しい挙動**（resize handle は resize 専用の hit area であり、その下の要素を起動すべきではない）。DrivePanel、ProjectExplorer 等の file tree drag-and-drop は panel の内側領域で動作するため影響なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_011qq75Uyw33TGZh2edAdiNb)_