### PR TITLE
feat(agent-settings): CLI 智能体设置页 + 标题栏快速启动栏

### DIFF
--- a/app/i18n/en/warp.ftl
+++ b/app/i18n/en/warp.ftl
@@ -1030,6 +1030,13 @@ settings-ai-auto-open-rich-input = Auto open Rich Input when a coding agent sess
 settings-ai-auto-dismiss-rich-input = Auto dismiss Rich Input after prompt submission
 settings-ai-toolbar-commands-label = Commands that enable the toolbar
 settings-ai-toolbar-commands-description = Add regex patterns to show the coding agent toolbar for matching commands.
+settings-ai-per-agent-section = Installed agents
+settings-ai-per-agent-scanning = Looking for installed agents...
+settings-ai-per-agent-empty = No installed CLI agents found.
+settings-ai-per-agent-agent-col = Agent
+settings-ai-per-agent-toolbar-col = Toolbar
+settings-ai-per-agent-tab-menu-col = Tab menu
+settings-ai-per-agent-titlebar-col = Title bar
 settings-ai-coding-agent-other = Other
 settings-ai-coding-agent-select-header = Select coding agent
 

--- a/app/i18n/ja/warp.ftl
+++ b/app/i18n/ja/warp.ftl
@@ -966,6 +966,13 @@ settings-ai-auto-open-rich-input = コーディングエージェントのセッ
 settings-ai-auto-dismiss-rich-input = プロンプト送信後に Rich Input を自動で閉じる
 settings-ai-toolbar-commands-label = ツールバーを有効化するコマンド
 settings-ai-toolbar-commands-description = マッチするコマンドでコーディングエージェントツールバーを表示する正規表現を追加します。
+settings-ai-per-agent-section = インストール済みエージェント
+settings-ai-per-agent-scanning = インストール済みエージェントを検索しています...
+settings-ai-per-agent-empty = インストール済み CLI エージェントが見つかりません。
+settings-ai-per-agent-agent-col = エージェント
+settings-ai-per-agent-toolbar-col = ツールバー
+settings-ai-per-agent-tab-menu-col = タブメニュー
+settings-ai-per-agent-titlebar-col = タイトルバー
 settings-ai-coding-agent-other = その他
 settings-ai-coding-agent-select-header = コーディングエージェントを選択
 

--- a/app/i18n/zh-CN/warp.ftl
+++ b/app/i18n/zh-CN/warp.ftl
@@ -1013,6 +1013,13 @@ settings-ai-auto-open-rich-input = 编码智能体会话启动时自动打开富
 settings-ai-auto-dismiss-rich-input = 提交提示后自动关闭富输入
 settings-ai-toolbar-commands-label = 启用工具栏的命令
 settings-ai-toolbar-commands-description = 添加正则表达式，匹配的命令将显示编码智能体工具栏。
+settings-ai-per-agent-section = 已安装的智能体
+settings-ai-per-agent-scanning = 正在查找已安装的智能体...
+settings-ai-per-agent-empty = 未找到已安装的 CLI 智能体。
+settings-ai-per-agent-agent-col = 智能体
+settings-ai-per-agent-toolbar-col = 工具栏
+settings-ai-per-agent-tab-menu-col = 新标签页
+settings-ai-per-agent-titlebar-col = 标题栏
 settings-ai-coding-agent-other = 其他
 settings-ai-coding-agent-select-header = 选择编码智能体
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1494,8 +1494,8 @@ fn initialize_app(
 
     timer.mark_interval_end("SUBSYSTEM_INITS_DONE");
 
-    // 后台检测系统安装的 CLI agent，不阻塞 UI
-    crate::terminal::CLIAgent::refresh_install_cache();
+    // 注册 CLI agent 安装状态 model（后台异步扫描 PATH，完成后自动同步 per-agent 设置）
+    ctx.add_singleton_model(crate::terminal::cli_agent::CLIAgentInstallModel::new);
 
     let display_count = ctx.windows().display_count();
     ctx.add_singleton_model(|_| DisplayCount(display_count));

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1128,6 +1128,48 @@ impl settings_value::SettingsValue for BYOPLastUsedReasoningMap {
     }
 }
 
+/// Per-agent 设置：控制单个 CLI agent 的工具栏、标签页菜单和标题栏可见性。
+/// key 是 CLIAgent 序列化名（例如 "Claude", "Gemini"）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PerAgentSettings {
+    /// 是否在终端输入底部展示编码智能体工具栏。
+    #[serde(default = "default_true_bool")]
+    pub toolbar: bool,
+    /// 是否在新建标签页菜单中展示该 agent 的快速启动入口。
+    #[serde(default = "default_true_bool", alias = "tab_menu")]
+    pub tabmenu: bool,
+    /// 是否在标题栏右侧展示该 agent 的快捷启动按钮。
+    #[serde(default)]
+    pub titlebar: bool,
+}
+
+fn default_true_bool() -> bool {
+    true
+}
+
+impl PerAgentSettings {
+    /// 返回指定 agent 的默认值。titlebar 对 Claude/Codex/Gemini/Antigravity 默认开启。
+    pub fn default_for(agent: CLIAgent) -> Self {
+        let titlebar = matches!(
+            agent,
+            CLIAgent::Claude | CLIAgent::Codex | CLIAgent::Gemini | CLIAgent::Antigravity
+        );
+        Self { toolbar: true, tabmenu: true, titlebar }
+    }
+}
+
+impl Default for PerAgentSettings {
+    fn default() -> Self {
+        Self {
+            toolbar: true,
+            tabmenu: true,
+            titlebar: false,
+        }
+    }
+}
+
+impl settings_value::SettingsValue for PerAgentSettings {}
+
 define_settings_group!(AISettings, settings: [
     // 历史遗留设置。Zap 的 Zap 智能体现在固定开启,不要用这个字段判断启用状态。
     is_any_ai_enabled: IsAnyAIEnabled {
@@ -1910,6 +1952,29 @@ define_settings_group!(AISettings, settings: [
         max_table_depth: 1,
         description: "Per-(api_type, model) reasoning effort memory for BYOP picker.",
     }
+
+    // Per-agent 设置：控制单个 CLI agent 的工具栏和标签页菜单可见性。
+    // key 是 CLIAgent::to_serialized_name() 的结果。
+    cli_agent_per_agent_settings: CLIAgentPerAgentSettings {
+        type: HashMap<String, PerAgentSettings>,
+        default: HashMap::new(),
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "agents.third_party.per_agent",
+        max_table_depth: 1,
+        description: "Per-agent visibility settings for toolbar and tab menu.",
+    }
+
+    // 是否已完成至少一次 CLI agent 安装扫描。
+    // 首次打开第三方智能体设置页时,若该标记为 false 则自动触发一次同步。
+    cli_agent_scan_completed: CLIAgentScanCompleted {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Never,
+        private: true,
+    }
 ]);
 
 impl AISettings {
@@ -2344,6 +2409,131 @@ impl AISettings {
         report_if_error!(self
             .plugin_update_chip_dismissed_for_version_map
             .set_value(map, ctx));
+    }
+
+    // ── Per-agent settings ──
+
+    /// 查询某个 CLI agent 的工具栏是否启用。未在 per-agent 设置中出现时取 agent 默认值。
+    pub fn is_cli_agent_toolbar_enabled(&self, agent: CLIAgent) -> bool {
+        if matches!(agent, CLIAgent::Unknown) {
+            return true;
+        }
+        self.cli_agent_per_agent_settings
+            .get(agent.to_serialized_name().as_str())
+            .map(|s| s.toolbar)
+            .unwrap_or_else(|| PerAgentSettings::default_for(agent).toolbar)
+    }
+
+    /// 查询某个 CLI agent 是否在新建标签页菜单中显示。未在 per-agent 设置中出现时取 agent 默认值。
+    pub fn is_cli_agent_tab_menu_enabled(&self, agent: CLIAgent) -> bool {
+        if matches!(agent, CLIAgent::Unknown) {
+            return false;
+        }
+        self.cli_agent_per_agent_settings
+            .get(agent.to_serialized_name().as_str())
+            .map(|s| s.tabmenu)
+            .unwrap_or_else(|| PerAgentSettings::default_for(agent).tabmenu)
+    }
+
+    /// 查询某个 CLI agent 的标题栏按钮是否启用。未在 per-agent 设置中出现时取 agent 默认值。
+    pub fn is_cli_agent_titlebar_enabled(&self, agent: CLIAgent) -> bool {
+        if matches!(agent, CLIAgent::Unknown) {
+            return false;
+        }
+        self.cli_agent_per_agent_settings
+            .get(agent.to_serialized_name().as_str())
+            .map(|s| s.titlebar)
+            .unwrap_or_else(|| PerAgentSettings::default_for(agent).titlebar)
+    }
+
+    /// 设置单个 agent 的工具栏启用状态。
+    pub fn set_cli_agent_toolbar(
+        &mut self,
+        agent: CLIAgent,
+        enabled: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let key = agent.to_serialized_name();
+        let mut map = self.cli_agent_per_agent_settings.clone();
+        map.entry(key)
+            .and_modify(|s| s.toolbar = enabled)
+            .or_insert_with(|| PerAgentSettings { toolbar: enabled, ..PerAgentSettings::default_for(agent) });
+        report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
+    }
+
+    /// 设置单个 agent 的标签页菜单启用状态。
+    pub fn set_cli_agent_tab_menu(
+        &mut self,
+        agent: CLIAgent,
+        enabled: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let key = agent.to_serialized_name();
+        let mut map = self.cli_agent_per_agent_settings.clone();
+        map.entry(key)
+            .and_modify(|s| s.tabmenu = enabled)
+            .or_insert_with(|| PerAgentSettings { tabmenu: enabled, ..PerAgentSettings::default_for(agent) });
+        report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
+    }
+
+    /// 设置单个 agent 的标题栏按钮启用状态。
+    pub fn set_cli_agent_titlebar(
+        &mut self,
+        agent: CLIAgent,
+        enabled: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let key = agent.to_serialized_name();
+        let mut map = self.cli_agent_per_agent_settings.clone();
+        map.entry(key)
+            .and_modify(|s| s.titlebar = enabled)
+            .or_insert_with(|| PerAgentSettings { titlebar: enabled, ..PerAgentSettings::default_for(agent) });
+        report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
+    }
+
+    /// 根据安装扫描结果同步 per-agent 设置。
+    /// - 新检测到的 agent 写入默认值(toolbar=true, tabmenu=true)
+    /// - 已卸载的 agent 从设置中移除
+    /// - 标注扫描完成
+    pub fn sync_per_agent_from_scan(
+        &mut self,
+        installed: &HashMap<CLIAgent, bool>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let installed_agents: Vec<CLIAgent> = installed
+            .iter()
+            .filter(|(a, v)| **v && !matches!(a, CLIAgent::Unknown))
+            .map(|(a, _)| *a)
+            .collect();
+        let installed_names: std::collections::HashSet<String> = installed_agents
+            .iter()
+            .map(|a| a.to_serialized_name())
+            .collect();
+
+        let mut per_agent = self.cli_agent_per_agent_settings.clone();
+
+        for agent in &installed_agents {
+            per_agent
+                .entry(agent.to_serialized_name())
+                .or_insert_with(|| PerAgentSettings::default_for(*agent));
+        }
+
+        // 已卸载的 agent → 移除
+        per_agent.retain(|name, _| installed_names.contains(name.as_str()));
+
+        let changed = &per_agent != self.cli_agent_per_agent_settings.value();
+        if changed {
+            report_if_error!(self.cli_agent_per_agent_settings.set_value(per_agent, ctx));
+        }
+
+        if !*self.cli_agent_scan_completed.value() {
+            report_if_error!(self.cli_agent_scan_completed.set_value(true, ctx));
+        }
+    }
+
+    /// 返回是否已完成至少一次 CLI agent 安装扫描。
+    pub fn is_cli_agent_scan_completed(&self) -> bool {
+        *self.cli_agent_scan_completed.value()
     }
 }
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -31,6 +31,7 @@ use crate::settings::{
     VoiceInputEnabled,
 };
 use crate::terminal::session_settings::{SessionSettings, SessionSettingsChangedEvent};
+use crate::terminal::cli_agent::{CLIAgentInstallEvent, CLIAgentInstallModel};
 use crate::terminal::CLIAgent;
 use crate::view_components::{
     action_button::{ActionButton, ButtonSize, SecondaryTheme},
@@ -47,10 +48,13 @@ use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    Border, ChildView, ConstrainedBox, CornerRadius, CrossAxisAlignment, Dismiss, Expanded, Fill,
-    HyperlinkLens, MainAxisAlignment, MainAxisSize, MouseStateHandle, Radius, Shrinkable, Text,
+    Border, ChildView, ConstrainedBox, CornerRadius, CrossAxisAlignment, Dismiss, Empty, Expanded,
+    Fill, Hoverable, HyperlinkLens, MainAxisAlignment, MainAxisSize, MouseStateHandle, Radius, Shrinkable,
+    Text,
 };
 use warpui::fonts::{Properties, Weight};
+use warpui::platform::Cursor;
+use warpui::text_layout::TextAlignment;
 use warpui::id;
 use warpui::keymap::ContextPredicate;
 use warpui::ui_components::slider::SliderStateHandle;
@@ -931,6 +935,14 @@ impl AISettingsPageView {
         ctx.subscribe_to_model(&InputSettings::handle(ctx), |_, _, _, ctx| {
             ctx.notify();
         });
+
+        // CLI agent 安装扫描完成后刷新设置页（per-agent 表格出现）
+        ctx.subscribe_to_model(
+            &CLIAgentInstallModel::handle(ctx),
+            |_, _, CLIAgentInstallEvent::ScanComplete, ctx| {
+                ctx.notify();
+            },
+        );
 
         let current_permission =
             BlocklistAIPermissions::as_ref(ctx).active_permissions_profile(ctx, None);
@@ -2170,6 +2182,14 @@ impl Entity for AISettingsPageView {
     type Event = AISettingsPageEvent;
 }
 
+/// Per-agent 可见性维度。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PerAgentDimension {
+    Toolbar,
+    TabMenu,
+    Titlebar,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum AISettingsPageAction {
     OpenUrl(String),
@@ -2183,6 +2203,8 @@ pub enum AISettingsPageAction {
     ToggleAIInputAutoDetection,
     ToggleNLDInTerminal,
     ToggleCLIAgentToolbar,
+    /// 切换单个 CLI agent 的指定维度可见性。
+    ToggleCLIAgentPerAgent(CLIAgent, PerAgentDimension),
     ToggleUseAgentToolbar,
     ToggleVoiceInput,
     ToggleCanUseWarpCreditsWithByok,
@@ -2582,6 +2604,26 @@ impl TypedActionView for AISettingsPageView {
                         log::warn!("Failed to set value for CLI Agent Footer setting: {e:?}");
                     }
                 }
+                ctx.notify();
+            }
+            AISettingsPageAction::ToggleCLIAgentPerAgent(agent, dim) => {
+                let settings = AISettings::as_ref(ctx);
+                let current = match dim {
+                    PerAgentDimension::Toolbar => settings.is_cli_agent_toolbar_enabled(*agent),
+                    PerAgentDimension::TabMenu => settings.is_cli_agent_tab_menu_enabled(*agent),
+                    PerAgentDimension::Titlebar => settings.is_cli_agent_titlebar_enabled(*agent),
+                };
+                AISettings::handle(ctx).update(ctx, |settings, ctx| match dim {
+                    PerAgentDimension::Toolbar => {
+                        settings.set_cli_agent_toolbar(*agent, !current, ctx);
+                    }
+                    PerAgentDimension::TabMenu => {
+                        settings.set_cli_agent_tab_menu(*agent, !current, ctx);
+                    }
+                    PerAgentDimension::Titlebar => {
+                        settings.set_cli_agent_titlebar(*agent, !current, ctx);
+                    }
+                });
                 ctx.notify();
             }
             AISettingsPageAction::ToggleAutoToggleRichInput => {
@@ -5624,10 +5666,7 @@ impl AIFactWidget {
                 "{} ",
                 crate::t!("settings-ai-rules-description")
             )),
-            FormattedTextFragment::hyperlink(
-                crate::t!("settings-ai-learn-more"),
-                "",
-            ),
+            FormattedTextFragment::hyperlink(crate::t!("settings-ai-learn-more"), ""),
         ];
         let description = Container::new(
             FormattedTextElement::new(
@@ -5990,6 +6029,25 @@ pub(crate) fn cli_agent_settings_widget_id() -> &'static str {
     CLIAgentWidget::static_widget_id()
 }
 
+// ── Per-agent chip 布局常量 ──
+const CHIP_HEIGHT: f32 = 28.;
+const CHIP_HORIZONTAL_PADDING: f32 = 10.;
+const CHIP_CORNER_RADIUS: f32 = 4.;
+const CHIP_GAP: f32 = 8.;
+const CHIP_WIDTH: f32 = 92.;
+const CHIP_CHECK_ICON_SIZE: f32 = 12.;
+const CHIP_CHECK_ICON_GAP: f32 = 4.;
+const PER_AGENT_ACTIONS_WIDTH: f32 = CHIP_WIDTH * 3. + CHIP_GAP * 2.;
+const AGENT_ICON_SIZE: f32 = 16.;
+const AGENT_ICON_MARGIN_RIGHT: f32 = 8.;
+const ROW_HORIZONTAL_PADDING: f32 = 8.;
+const ROW_VERTICAL_PADDING: f32 = 6.;
+const ROW_CORNER_RADIUS: f32 = 4.;
+const ROW_GAP: f32 = 4.;
+const PER_AGENT_SECTION_MARGIN_TOP: f32 = 16.;
+const PER_AGENT_SECTION_MARGIN_BOTTOM: f32 = 8.;
+type PerAgentChipKey = (CLIAgent, PerAgentDimension);
+
 #[derive(Default)]
 struct CLIAgentWidget {
     cli_agent_footer_toggle: SwitchStateHandle,
@@ -5997,6 +6055,8 @@ struct CLIAgentWidget {
     auto_toggle_rich_input_info_tooltip: MouseStateHandle,
     auto_open_rich_input_on_cli_agent_start_toggle: SwitchStateHandle,
     auto_dismiss_rich_input_toggle: SwitchStateHandle,
+    /// Per-agent chip hover state, keyed by agent and visibility dimension.
+    per_agent_chip_states: RefCell<HashMap<PerAgentChipKey, MouseStateHandle>>,
 }
 
 impl SettingsWidget for CLIAgentWidget {
@@ -6068,6 +6128,13 @@ impl SettingsWidget for CLIAgentWidget {
                     .with_margin_right(styles::TOGGLE_WIDTH_MARGIN)
                     .finish(),
             );
+
+        column.add_child(self.render_per_agent_settings_section(
+            ai_settings,
+            is_footer_enabled,
+            appearance,
+            app,
+        ));
 
         if is_footer_enabled {
             use super::settings_page::AdditionalInfo;
@@ -6259,6 +6326,222 @@ impl SettingsWidget for CLIAgentWidget {
         }
 
         column.finish()
+    }
+}
+
+impl CLIAgentWidget {
+    fn render_per_agent_settings_section(
+        &self,
+        ai_settings: &AISettings,
+        is_footer_enabled: bool,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let ui_font_family = appearance.ui_font_family();
+        let install_model = CLIAgentInstallModel::as_ref(app);
+        let installed_agents: Vec<CLIAgent> = enum_iterator::all::<CLIAgent>()
+            .filter(|a| !matches!(a, CLIAgent::Unknown) && install_model.is_cli_agent_installed(*a))
+            .collect();
+
+        let mut column = Flex::column().with_child(
+            Container::new(
+                appearance
+                    .ui_builder()
+                    .span(crate::t!("settings-ai-per-agent-section"))
+                    .with_style(UiComponentStyles {
+                        font_size: Some(appearance.ui_font_body()),
+                        font_color: Some(styles::header_font_color(true, app).into()),
+                        ..Default::default()
+                    })
+                    .build()
+                    .finish(),
+            )
+            .with_margin_top(PER_AGENT_SECTION_MARGIN_TOP)
+            .with_margin_bottom(PER_AGENT_SECTION_MARGIN_BOTTOM)
+            .finish(),
+        );
+
+        if !install_model.is_scan_complete() {
+            column.add_child(render_ai_setting_description(
+                crate::t!("settings-ai-per-agent-scanning"),
+                true,
+                app,
+            ));
+            return column.finish();
+        }
+
+        if installed_agents.is_empty() {
+            column.add_child(render_ai_setting_description(
+                crate::t!("settings-ai-per-agent-empty"),
+                true,
+                app,
+            ));
+            return column.finish();
+        }
+
+        for agent in installed_agents {
+            let icon = agent
+                .icon()
+                .unwrap_or(crate::ui_components::icons::Icon::LayoutAlt01);
+            let agent_name_text = appearance
+                .ui_builder()
+                .wrappable_text(agent.display_name().to_string(), true)
+                .with_style(UiComponentStyles {
+                    font_color: Some(theme.foreground().into_solid()),
+                    font_family_id: Some(ui_font_family),
+                    font_size: Some(appearance.ui_font_size()),
+                    ..Default::default()
+                })
+                .build()
+                .finish();
+
+            let toolbar_chip = self.render_cli_agent_visibility_chip(
+                crate::t!("settings-ai-per-agent-toolbar-col").to_string(),
+                ai_settings.is_cli_agent_toolbar_enabled(agent),
+                is_footer_enabled,
+                agent,
+                PerAgentDimension::Toolbar,
+                appearance,
+            );
+            let tab_menu_chip = self.render_cli_agent_visibility_chip(
+                crate::t!("settings-ai-per-agent-tab-menu-col").to_string(),
+                ai_settings.is_cli_agent_tab_menu_enabled(agent),
+                true,
+                agent,
+                PerAgentDimension::TabMenu,
+                appearance,
+            );
+            let titlebar_chip = self.render_cli_agent_visibility_chip(
+                crate::t!("settings-ai-per-agent-titlebar-col").to_string(),
+                ai_settings.is_cli_agent_titlebar_enabled(agent),
+                true,
+                agent,
+                PerAgentDimension::Titlebar,
+                appearance,
+            );
+            let actions = ConstrainedBox::new(
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(CHIP_GAP)
+                    .with_children([toolbar_chip, tab_menu_chip, titlebar_chip])
+                    .finish(),
+            )
+            .with_width(PER_AGENT_ACTIONS_WIDTH)
+            .finish();
+
+            let row = Container::new(
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_children([
+                        Container::new(
+                            ConstrainedBox::new(icon.to_warpui_icon(theme.foreground()).finish())
+                                .with_width(AGENT_ICON_SIZE)
+                                .with_height(AGENT_ICON_SIZE)
+                                .finish(),
+                        )
+                        .with_margin_right(AGENT_ICON_MARGIN_RIGHT)
+                        .finish(),
+                        Expanded::new(1., agent_name_text).finish(),
+                        actions,
+                    ])
+                    .finish(),
+            )
+            .with_background(theme.surface_1())
+            .with_horizontal_padding(ROW_HORIZONTAL_PADDING)
+            .with_vertical_padding(ROW_VERTICAL_PADDING)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
+            .with_margin_bottom(ROW_GAP)
+            .finish();
+
+            column.add_child(row);
+        }
+
+        column.finish()
+    }
+
+    fn render_cli_agent_visibility_chip(
+        &self,
+        label: String,
+        is_enabled: bool,
+        is_clickable: bool,
+        agent: CLIAgent,
+        dimension: PerAgentDimension,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let background = if is_enabled {
+            internal_colors::accent_overlay_2(theme)
+        } else {
+            internal_colors::fg_overlay_1(theme)
+        };
+        let border_fill = if is_enabled {
+            Fill::Solid(theme.accent().into_solid())
+        } else {
+            Fill::Solid(pathfinder_color::ColorU::transparent_black())
+        };
+        let text_color = if is_enabled && is_clickable {
+            internal_colors::text_main(theme, theme.background().into_solid())
+        } else {
+            internal_colors::text_sub(theme, theme.background().into_solid())
+        };
+        let icon_color = warp_core::ui::theme::Fill::Solid(text_color);
+        let ui_font_family = appearance.ui_font_family();
+        let mouse = self
+            .per_agent_chip_states
+            .borrow_mut()
+            .entry((agent, dimension))
+            .or_insert_with(MouseStateHandle::default)
+            .clone();
+
+        let mut chip = Hoverable::new(mouse, move |_| {
+            let mut content = Flex::row()
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_main_axis_alignment(MainAxisAlignment::Center);
+            if is_enabled {
+                content.add_child(
+                    ConstrainedBox::new(Icon::Check.to_warpui_icon(icon_color).finish())
+                        .with_width(CHIP_CHECK_ICON_SIZE)
+                        .with_height(CHIP_CHECK_ICON_SIZE)
+                        .finish(),
+                );
+                content.add_child(
+                    ConstrainedBox::new(Empty::new().finish())
+                        .with_width(CHIP_CHECK_ICON_GAP)
+                        .finish(),
+                );
+            }
+            content.add_child(
+                FormattedTextElement::from_str(label.clone(), ui_font_family, 13.)
+                    .with_color(text_color)
+                    .with_weight(Weight::Normal)
+                    .with_alignment(TextAlignment::Center)
+                    .with_line_height_ratio(1.0)
+                    .finish(),
+            );
+
+            let container = Container::new(content.finish())
+                .with_horizontal_padding(CHIP_HORIZONTAL_PADDING)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(CHIP_CORNER_RADIUS)))
+                .with_background(background)
+                .with_border(Border::all(1.).with_border_fill(border_fill));
+
+            ConstrainedBox::new(container.finish())
+                .with_width(CHIP_WIDTH)
+                .with_height(CHIP_HEIGHT)
+                .finish()
+        });
+
+        if is_clickable {
+            chip = chip.with_cursor(Cursor::PointingHand).on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(AISettingsPageAction::ToggleCLIAgentPerAgent(
+                    agent, dimension,
+                ));
+            });
+        }
+
+        chip.finish()
     }
 }
 
@@ -6523,9 +6806,13 @@ impl AwsBedrockWidget {
                 ..Default::default()
             };
 
-            let label = Text::new_inline(label, appearance.ui_font_family(), appearance.ui_font_body())
-                .with_color(styles::header_font_color(is_enabled, app).into())
-                .finish();
+            let label = Text::new_inline(
+                label,
+                appearance.ui_font_family(),
+                appearance.ui_font_body(),
+            )
+            .with_color(styles::header_font_color(is_enabled, app).into())
+            .finish();
 
             let input = appearance
                 .ui_builder()
@@ -6568,16 +6855,24 @@ impl AwsBedrockWidget {
                 .with_cross_axis_alignment(CrossAxisAlignment::Start)
                 .with_spacing(4.)
                 .with_child(
-                    Text::new_inline(title_text, appearance.ui_font_family(), appearance.ui_font_body())
-                        .with_style(Properties::default().weight(Weight::Semibold))
-                        .with_color(title_color.into())
-                        .finish(),
+                    Text::new_inline(
+                        title_text,
+                        appearance.ui_font_family(),
+                        appearance.ui_font_body(),
+                    )
+                    .with_style(Properties::default().weight(Weight::Semibold))
+                    .with_color(title_color.into())
+                    .finish(),
                 )
                 .with_child(
-                    Text::new(detail_text, appearance.ui_font_family(), appearance.ui_font_body())
-                        .with_color(detail_color.into())
-                        .soft_wrap(true)
-                        .finish(),
+                    Text::new(
+                        detail_text,
+                        appearance.ui_font_family(),
+                        appearance.ui_font_body(),
+                    )
+                    .with_color(detail_color.into())
+                    .soft_wrap(true)
+                    .finish(),
                 );
 
             Container::new(

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -6,8 +6,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, LazyLock, RwLock};
-
 use ai::skills::SkillProvider;
 use enum_iterator::Sequence;
 use markdown_parser::parse_markdown;
@@ -16,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use warp_editor::content::{buffer::Buffer, markdown::MarkdownStyle};
 
-use warpui::{AppContext, SingletonEntity};
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 use crate::ai::agent::{AgentReviewCommentBatch, DiffSetHunk};
 use crate::ai::blocklist::CLAUDE_ORANGE;
@@ -568,45 +566,88 @@ impl From<CLIAgent> for CLIAgentType {
     }
 }
 
-/// CLI agent 安装状态缓存。应用启动时后台线程填充一次。
-static AGENT_INSTALL_CACHE: LazyLock<Arc<RwLock<Option<HashMap<CLIAgent, bool>>>>> =
-    LazyLock::new(|| Arc::new(RwLock::new(None)));
+// ── CLI Agent 安装状态 singleton model ──
+// 对齐 AntivirusInfo 模式:ctx.spawn 异步扫描 → 回调 emit 事件 → 订阅者自动刷新 UI
 
-impl CLIAgent {
-    /// 非阻塞读取缓存。缓存未就绪时返回 false，菜单中不展示该 agent。
-    pub fn is_installed(&self) -> bool {
-        AGENT_INSTALL_CACHE
-            .read()
-            .ok()
-            .and_then(|c| c.as_ref().map(|m| m.get(self).copied().unwrap_or(false)))
+/// CLI agent 安装扫描完成事件。
+pub enum CLIAgentInstallEvent {
+    /// 后台扫描完成，安装状态缓存已就绪。
+    ScanComplete,
+}
+
+/// Singleton model，跟踪 CLI agent 的安装状态。
+///
+/// 构造时通过 `ctx.spawn` 启动后台 PATH 扫描，扫描完成后 emit
+/// [`CLIAgentInstallEvent::ScanComplete`] 并自动同步 per-agent 设置。
+///
+/// 所有需要查询安装状态的 UI 代码应通过 `CLIAgentInstallModel::as_ref(ctx)`
+/// 读取，并订阅事件以在扫描完成后触发重绘。
+pub struct CLIAgentInstallModel {
+    /// None = 扫描尚未完成; Some = 已有结果。
+    cache: Option<HashMap<CLIAgent, bool>>,
+}
+
+impl CLIAgentInstallModel {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        ctx.spawn(
+            async move {
+                enum_iterator::all::<CLIAgent>()
+                    .filter(|a| !matches!(a, CLIAgent::Unknown))
+                    .map(|a| (a, cli_agent_is_on_path(a)))
+                    .collect::<HashMap<CLIAgent, bool>>()
+            },
+            Self::on_scan_complete,
+        );
+        Self { cache: None }
+    }
+
+    fn on_scan_complete(
+        &mut self,
+        results: HashMap<CLIAgent, bool>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.cache = Some(results.clone());
+
+        // 自动同步到 per-agent 设置
+        crate::settings::AISettings::handle(ctx).update(ctx, |settings, ctx| {
+            settings.sync_per_agent_from_scan(&results, ctx);
+        });
+
+        ctx.emit(CLIAgentInstallEvent::ScanComplete);
+    }
+
+    /// 查询某个 agent 是否已安装。扫描未完成时返回 false。
+    pub fn is_cli_agent_installed(&self, agent: CLIAgent) -> bool {
+        self.cache
+            .as_ref()
+            .map(|m| m.get(&agent).copied().unwrap_or(false))
             .unwrap_or(false)
     }
 
-    /// 后台刷新全部 agent 的安装状态，不阻塞 UI。
-    /// 仅在应用启动时调用一次。
-    pub fn refresh_install_cache() {
-        let cache = AGENT_INSTALL_CACHE.clone();
-        std::thread::spawn(move || {
-            let results: HashMap<CLIAgent, bool> = enum_iterator::all::<CLIAgent>()
-                .filter(|a| !matches!(a, CLIAgent::Unknown))
-                .map(|a| (a, a.is_installed_blocking()))
-                .collect();
-            if let Ok(mut guard) = cache.write() {
-                *guard = Some(results);
-            }
-        });
+    /// 扫描是否已完成。
+    pub fn is_scan_complete(&self) -> bool {
+        self.cache.is_some()
     }
 
-    /// 同步检测系统是否安装了此 agent。后台线程专用。
-    fn is_installed_blocking(&self) -> bool {
-        match self {
-            CLIAgent::Unknown => false,
-            // `agent` 太泛化，Cursor CLI 用 cursor-agent 检测
-            CLIAgent::CursorCli => is_on_path("cursor-agent"),
-            // DeepSeek 同时检查主命令和别名
-            CLIAgent::DeepSeek => is_on_path("deepseek") || is_on_path("deepseek-tui"),
-            other => is_on_path(other.command_prefix()),
-        }
+    /// 获取安装状态快照。扫描未完成时返回 None。
+    pub fn snapshot(&self) -> Option<HashMap<CLIAgent, bool>> {
+        self.cache.clone()
+    }
+}
+
+impl Entity for CLIAgentInstallModel {
+    type Event = CLIAgentInstallEvent;
+}
+
+impl SingletonEntity for CLIAgentInstallModel {}
+
+/// 同步 PATH 搜索，检测指定 agent 是否安装。仅供 `ctx.spawn` 异步任务内部使用。
+fn cli_agent_is_on_path(agent: CLIAgent) -> bool {
+    match agent {
+        CLIAgent::Unknown => false,
+        CLIAgent::CursorCli => is_on_path("cursor-agent"),
+        CLIAgent::DeepSeek => is_on_path("deepseek") || is_on_path("deepseek-tui"),
+        other => is_on_path(other.command_prefix()),
     }
 }
 

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -296,7 +296,7 @@ impl TerminalView {
             .map(|s| s.agent);
 
         // Check the appropriate setting based on whether this is a CLI agent command
-        if cli_agent.is_some() {
+        if let Some(agent) = cli_agent {
             // For CLI agent commands, only check the CLI agent footer setting.
             // This is independent of the global AI toggle so that users who
             // disable Zap AI still get the footer for third-party coding agents.
@@ -304,7 +304,11 @@ impl TerminalView {
                 return false;
             }
 
-            // If a CLIAgent is active, we always want to show the agent footer.
+            // Check per-agent toolbar setting; default is true if not configured.
+            if !ai_settings.is_cli_agent_toolbar_enabled(agent) {
+                return false;
+            }
+
             return true;
         }
 

--- a/app/src/workspace/util.rs
+++ b/app/src/workspace/util.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use warpui::{
     elements::MouseStateHandle, AppContext, EntityId, SingletonEntity, ViewContext, ViewHandle,
@@ -41,6 +44,8 @@ pub(super) struct WorkspaceMouseStates {
     pub(super) session_config_tab_config_chip_close: MouseStateHandle,
     pub(super) tools_panel_icon: MouseStateHandle,
     pub(super) title_bar_search_bar: MouseStateHandle,
+    /// Per-agent titlebar button hover states, keyed by CLIAgent serialized name.
+    pub(super) cli_agent_titlebar_button_states: RefCell<HashMap<String, MouseStateHandle>>,
     #[cfg(target_family = "wasm")]
     pub(super) warp_logo: MouseStateHandle,
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -102,6 +102,7 @@ use crate::ai::blocklist::FORK_PREFIX;
 #[cfg(not(target_family = "wasm"))]
 use crate::terminal::cli_agent_sessions::plugin_manager::{plugin_manager_for, PluginModalKind};
 use crate::terminal::cli_agent_sessions::{CLIAgentSessionsModel, CLIAgentSessionsModelEvent};
+use crate::terminal::cli_agent::{CLIAgentInstallEvent, CLIAgentInstallModel};
 use crate::terminal::CLIAgent;
 use crate::workspace::header_toolbar_editor::{HeaderToolbarEditorEvent, HeaderToolbarEditorModal};
 use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
@@ -2588,6 +2589,14 @@ impl Workspace {
         ctx.subscribe_to_model(&CLIAgentSessionsModel::handle(ctx), |me, _, event, ctx| {
             me.handle_cli_agent_sessions_event(event, ctx);
         });
+
+        // CLI agent 安装扫描完成后刷新 UI（新 tab 菜单、标题栏按钮等）
+        ctx.subscribe_to_model(
+            &CLIAgentInstallModel::handle(ctx),
+            |_, _, CLIAgentInstallEvent::ScanComplete, ctx| {
+                ctx.notify();
+            },
+        );
 
         ctx.subscribe_to_model(
             &SessionSettings::handle(ctx),
@@ -5960,14 +5969,20 @@ impl Workspace {
             menu_items.push(agent_item.into_item());
         }
 
-        // 5. Coding Agents — 仅已安装的出现在菜单中
+        // 5. Coding Agents — 仅已安装且 tab_menu 启用的出现在菜单中
         let coding_agent_count = {
             let start_len = menu_items.len();
+            let ai_settings = AISettings::as_ref(ctx);
+            let install_model = CLIAgentInstallModel::as_ref(ctx);
             for agent in enum_iterator::all::<CLIAgent>() {
                 if matches!(agent, CLIAgent::Unknown) {
                     continue;
                 }
-                if !agent.is_installed() {
+                if !install_model.is_cli_agent_installed(agent) {
+                    continue;
+                }
+                // 检查 per-agent tab_menu 设置
+                if !ai_settings.is_cli_agent_tab_menu_enabled(agent) {
                     continue;
                 }
                 let icon = agent.icon().unwrap_or(icons::Icon::LayoutAlt01);
@@ -16158,6 +16173,11 @@ impl Workspace {
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_main_axis_size(MainAxisSize::Min);
 
+            // 标题栏 agent 快捷启动按钮（垂直标签栏模式）
+            for button in self.render_cli_agent_titlebar_buttons(appearance, ctx) {
+                right_controls.add_child(button);
+            }
+
             self.add_configurable_right_side_tab_bar_controls(
                 &mut right_controls,
                 &config,
@@ -16297,6 +16317,11 @@ impl Workspace {
         // Placeholder to make sure the flex row expands across the entire width of the app.
         tab_bar.add_child(Shrinkable::new(0.5, Empty::new().finish()).finish());
 
+        // 标题栏 agent 快捷启动按钮（水平标签栏模式）
+        for button in self.render_cli_agent_titlebar_buttons(appearance, ctx) {
+            tab_bar.add_child(button);
+        }
+
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,
             &config,
@@ -16369,6 +16394,80 @@ impl Workspace {
             .with_margin_left(TAB_BAR_ICON_PADDING)
             .finish(),
         )
+    }
+
+    /// 渲染标题栏上已安装 CLI agent 的快捷启动按钮。
+    /// 只显示 per-agent 设置中 titlebar 标记为 true 的 agent。
+    fn render_cli_agent_titlebar_buttons(
+        &self,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Vec<Box<dyn Element>> {
+        let ai_settings = AISettings::as_ref(ctx);
+        let install_model = CLIAgentInstallModel::as_ref(ctx);
+        let mut buttons = Vec::new();
+
+        for agent in enum_iterator::all::<CLIAgent>() {
+            if matches!(agent, CLIAgent::Unknown) || !install_model.is_cli_agent_installed(agent) {
+                continue;
+            }
+            if !ai_settings.is_cli_agent_titlebar_enabled(agent) {
+                continue;
+            }
+
+            let agent_key = agent.to_serialized_name();
+            let mut states = self
+                .mouse_states
+                .cli_agent_titlebar_button_states
+                .borrow_mut();
+            let handle = states
+                .entry(agent_key.clone())
+                .or_insert_with(MouseStateHandle::default)
+                .clone();
+
+            let icon = agent.icon().unwrap_or(icons::Icon::LayoutAlt01);
+            let theme = appearance.theme();
+            let icon_color = theme.sub_text_color(theme.background());
+            let button = icon_button_with_color(
+                appearance,
+                icon,
+                false,
+                handle.clone(),
+                icon_color,
+            )
+            .with_hovered_styles(UiComponentStyles {
+                font_color: Some(icon_color.into()),
+                background: Some(theme.surface_2().into()),
+                ..UiComponentStyles::default()
+            })
+            .with_clicked_styles(UiComponentStyles {
+                font_color: Some(icon_color.into()),
+                background: Some(theme.background().into()),
+                ..UiComponentStyles::default()
+            })
+            // 图标缩小到 14×14：padding 从 4 增大到 5.0，按钮外框 24×24 不变
+            .with_style(UiComponentStyles::default()
+                .set_padding(Coords::uniform(5.0))
+            );
+
+            let agent_name = agent.display_name().to_string();
+            let button = button
+                .with_tooltip(
+                    self.render_tab_bar_icon_button_tooltip(appearance, agent_name, None),
+                )
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(WorkspaceAction::AddSpecificAgentTab(agent));
+                });
+
+            buttons.push(
+                Container::new(button.finish())
+                    .with_margin_left(TAB_BAR_ICON_PADDING)
+                    .finish(),
+            );
+        }
+
+        buttons
     }
 
     /// Renders the notifications mailbox button (extracted for reuse from


### PR DESCRIPTION
## 变更内容

<img width="2154" height="1464" alt="image" src="https://github.com/user-attachments/assets/2bc08825-b092-4f2c-a7e6-d2dce5a09d65" />


- 新增第三方 CLI 智能体的 per-agent 可见性设置，分别控制工具栏、新标签页菜单和标题栏快捷入口。
- 将 CLI agent 安装检测改为应用级 singleton model，启动后异步扫描 PATH，扫描完成后同步 per-agent 默认设置并刷新相关 UI。
- 设置页新增“Installed agents”区域，只展示本机已安装的 CLI agent，并用 chip 控制三个可见性维度。
- 新标签页菜单只展示已安装且启用 Tab menu 的 CLI agent。
- 标题栏增加已安装且启用 Title bar 的 CLI agent 快捷启动按钮，点击后直接打开对应 agent 标签页。

## 验证

- `cargo check` 通过。
- `git diff --check upstream/main..HEAD` 通过。
