### PR TITLE
feat(ai-assistant): right-align user messages in chat transcript

### DIFF
--- a/app/src/ai_assistant/transcript.rs
+++ b/app/src/ai_assistant/transcript.rs
@@ -582,6 +582,7 @@ impl Transcript {
             icon,
             bottom_right_element,
             appearance,
+            false,
         )
     }
 
@@ -602,7 +603,7 @@ impl Transcript {
         .with_height(16.)
         .with_width(16.)
         .finish();
-        self.render_message(dialogue, background_color, icon, None, appearance)
+        self.render_message(dialogue, background_color, icon, None, appearance, true)
     }
 
     /// Renders a single message (whether that be a user's prompt or assistant's answer).
@@ -613,6 +614,7 @@ impl Transcript {
         icon: Box<dyn Element>,
         bottom_right_element: Option<Box<dyn Element>>,
         appearance: &Appearance,
+        align_right: bool,
     ) -> Box<dyn Element> {
         let theme = appearance.theme();
         let inline_code_bg_color = appearance.theme().surface_3().into_solid();
@@ -740,22 +742,46 @@ impl Transcript {
             );
         }
 
-        let row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_child(
-                Container::new(icon)
-                    .with_margin_right(12.)
-                    .with_margin_top(3.)
-                    .finish(),
-            )
-            .with_child(Shrinkable::new(1., Container::new(final_col.finish()).finish()).finish());
+        let icon_container = if align_right {
+            Container::new(icon)
+                .with_margin_left(12.)
+                .with_margin_top(3.)
+                .finish()
+        } else {
+            Container::new(icon)
+                .with_margin_right(12.)
+                .with_margin_top(3.)
+                .finish()
+        };
+
+        let row = if align_right {
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_child(
+                    Shrinkable::new(1., Container::new(final_col.finish()).finish()).finish(),
+                )
+                .with_child(icon_container)
+        } else {
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_child(icon_container)
+                .with_child(
+                    Shrinkable::new(1., Container::new(final_col.finish()).finish()).finish(),
+                )
+        };
+
+        let (padding_left, padding_right) = if align_right {
+            (20., PANEL_LEFT_MARGIN)
+        } else {
+            (PANEL_LEFT_MARGIN, 20.)
+        };
 
         Container::new(row.finish())
             .with_background_color(background_color)
-            .with_padding_left(PANEL_LEFT_MARGIN)
+            .with_padding_left(padding_left)
             .with_padding_top(16.)
             .with_padding_bottom(16.)
-            .with_padding_right(20.)
+            .with_padding_right(padding_right)
             .finish()
     }
 

--- a/app/src/ai_assistant/transcript.rs
+++ b/app/src/ai_assistant/transcript.rs
@@ -758,7 +758,13 @@ impl Transcript {
             Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_child(
-                    Expanded::new(1., Container::new(final_col.finish()).finish()).finish(),
+                    Expanded::new(
+                        1.,
+                        Align::new(Container::new(final_col.finish()).finish())
+                            .right()
+                            .finish(),
+                    )
+                    .finish(),
                 )
                 .with_child(icon_container)
         } else {

--- a/app/src/ai_assistant/transcript.rs
+++ b/app/src/ai_assistant/transcript.rs
@@ -12,7 +12,7 @@ use warpui::{
         Container, CornerRadius, CrossAxisAlignment, EventHandler, Fill, Flex,
         FormattedTextElement, HyperlinkUrl, Icon, MainAxisAlignment, MainAxisSize,
         MouseStateHandle, ParentAnchor, ParentElement, Radius, SavePosition, ScrollbarWidth,
-        Shrinkable, Text, Wrap,
+        Expanded, Shrinkable, Text, Wrap,
     },
     keymap::Keystroke,
     platform::Cursor,
@@ -758,7 +758,7 @@ impl Transcript {
             Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_child(
-                    Shrinkable::new(1., Container::new(final_col.finish()).finish()).finish(),
+                    Expanded::new(1., Container::new(final_col.finish()).finish()).finish(),
                 )
                 .with_child(icon_container)
         } else {


### PR DESCRIPTION
## 关联 Issue

Fixes #211

## 问题点（确定性描述）

`app/src/ai_assistant/transcript.rs:609` 中的 `render_message` 函数对用户消息和 AI 回复使用完全相同的左对齐布局（图标左侧、文本右侧），导致两者在视觉上无法区分。

具体代码（修改前，743-759 行）：
```rust
let row = Flex::row()
    .with_main_axis_size(MainAxisSize::Max)
    .with_child(
        Container::new(icon)
            .with_margin_right(12.)
            .with_margin_top(3.)
            .finish(),
    )
    .with_child(Shrinkable::new(1., Container::new(final_col.finish()).finish()).finish());

Container::new(row.finish())
    .with_background_color(background_color)
    .with_padding_left(PANEL_LEFT_MARGIN)  // 两种消息均左对齐
    ...
```

`render_user_prompt`（605 行）和 `render_assistant_answer`（579 行）都调用了同一个 `render_message`，没有任何对齐区分。

## 复现证据

- `transcript.rs:605`：`render_user_prompt` → `self.render_message(dialogue, background_color, icon, None, appearance)`
- `transcript.rs:579-585`：`render_assistant_answer` → 同一 `render_message`，传入相同结构的参数
- `transcript.rs:743-751`：唯一的行排列逻辑，无条件将图标置于左侧

## 规模声明

| 指标 | 值 |
|---|---|
| 修改文件数 | **1**（`app/src/ai_assistant/transcript.rs`） |
| 修改行数 | **+38 / -12**（净增 26 行） |
| 影响面（外部调用方） | **0**（`render_message` / `render_user_prompt` / `render_assistant_answer` 均为私有方法） |

属于小修复范围（1 文件，≤ 50 行，无公开 API 变更）。

## 修改文件清单

| 文件 | 行号范围 | 改动说明 |
|---|---|---|
| `app/src/ai_assistant/transcript.rs` | 609-617 | `render_message` 新增 `align_right: bool` 参数 |
| `app/src/ai_assistant/transcript.rs` | 745-785 | 行布局分支：`align_right=true` 时文本在前、图标在右、左右内边距互换 |
| `app/src/ai_assistant/transcript.rs` | 606 | `render_user_prompt` 调用传入 `true` |
| `app/src/ai_assistant/transcript.rs` | 585 | `render_assistant_answer` 调用传入 `false` |

## 验证

```
$ rustfmt --check app/src/ai_assistant/transcript.rs
# 仅在第 49 行存在一处预存在的空行差异（与本 PR 无关），
# 本次修改所在的 742 行以后区域无 rustfmt 差异。

$ cargo check -p warp
# 构建失败原因：环境中未安装 protoc（warp_multi_agent_api 的构建依赖）。
# 已确认此错误在本 PR 修改前同样存在（git stash 后复现），与本次变更无关。
```

## 影响面

- `render_message`：私有方法，仅在 `transcript.rs` 内 2 处被调用，已全部更新。
- `Transcript` 结构体的现有测试（`transcript_tests.rs`）仅覆盖代码块导航逻辑，不涉及渲染，不受影响。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCe5YAgbx4bn1JkYTL67Xw)_