### PR TITLE
fix(windows): remove STARTF_USESTDHANDLES that causes CreateProcessW to fail with 0x80070057

### DIFF
--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -26,7 +26,7 @@ use windows::Win32::System::Console::{COORD, HPCON};
 use windows::Win32::System::Threading::{
     CreateProcessW, WaitForSingleObject, CREATE_BREAKAWAY_FROM_JOB, CREATE_UNICODE_ENVIRONMENT,
     EXTENDED_STARTUPINFO_PRESENT, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
+    STARTUPINFOEXW, STARTUPINFOW,
 };
 
 use crate::terminal::local_tty::windows::proc_thread_attribute_list::ProcThreadAttributeList;
@@ -143,7 +143,6 @@ pub(super) fn spawn(
     // The default zeros the memory.
     let mut startup_info = STARTUPINFOEXW::default();
     startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
-    startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
 
     let mut attrs = unsafe {
         ProcThreadAttributeList::new()


### PR DESCRIPTION
## 관련 Issue

Fixes #214

---

## 문제점 (확정적 설명)

**근인**: `app/src/terminal/local_tty/windows/mod.rs:146`

```rust
// 수정 전 (버그 있음)
startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
```

Windows 공식 문서(`STARTUPINFO.dwFlags`)는 명시적으로 규정합니다:

> "If this flag (`STARTF_USESTDHANDLES`) is specified when calling one of the process creation functions, the handles **must be inheritable** and the function's **bInheritHandles parameter must be set to TRUE**."

그런데 코드에서:
- `STARTF_USESTDHANDLES` 플래그 설정 (구 `:146`)
- `CreateProcessW` 호출 시 `bInheritHandles = false` 전달 (`:192`)
- `hStdInput`, `hStdOutput`, `hStdError`는 모두 기본값 `null`/`0`

이 조합이 Windows API 계약을 직접 위반하여 `CreateProcessW`가 `ERROR_INVALID_PARAMETER (0x80070057)`를 반환합니다.

ConPTY 모델에서는 모든 터미널 I/O가 `STARTUPINFOEX`의 thread attribute list에 있는 pseudoconsole 핸들을 통해 처리되므로 `STARTF_USESTDHANDLES`는 필요하지 않으며 설정해서는 안 됩니다.

---

## 복현 증거

`app/src/terminal/local_tty/windows/mod.rs`:
- `:101-106` — `CreateShellProcessFailed` 에러 정의 (에러 메시지 `"Failed to create shell process {detail}: {error:#}"`)
- `:144-146` — 버그 위치: `STARTF_USESTDHANDLES` 설정
- `:186-208` — `CreateProcessW` 호출, `bInheritHandles = false`
- `:205-208` — 실패 시 `PtySpawnError::CreateShellProcessFailed` 반환

에러 코드 `0x80070057` = `ERROR_INVALID_PARAMETER` = Windows API 파라미터 오류로, 이슈 보고의 "参数错误。(0x80070057)"와 정확히 일치합니다.

---

## 규모 선언

| 항목 | 값 |
|------|-----|
| 수정 파일 수 | 1 |
| 수정 행 수 | 2줄 삭제 |
| 영향면 grep 명중 수 | 2 (동일 파일 내 import + 사용) |
| 공개 API 변경 | 없음 |
| 의존성 변경 | 없음 |

---

## 수정 파일 목록

| 파일 | 변경 내용 |
|------|-----------|
| `app/src/terminal/local_tty/windows/mod.rs:29` | import에서 `STARTF_USESTDHANDLES,` 제거 |
| `app/src/terminal/local_tty/windows/mod.rs:146` | `startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;` 제거 |

---

## 검증

`cargo check` 실행 시, 빌드 환경에 `protoc`가 설치되지 않아 `warp_multi_agent_api` proto 컴파일 단계에서 실패하나, 이는 이 PR 이전에도 동일하게 발생하는 기존 환경 문제임을 `git stash` 기반으로 확인했습니다. 변경 대상 파일(`windows/mod.rs`)은 Windows 전용 조건부 컴파일 모듈로, 수정 내용은 단순 2행 삭제로 새로운 컴파일 오류를 추가하지 않습니다.

---

## 영향면

`STARTF_USESTDHANDLES`는 해당 파일의 2곳(`import`, `dwFlags 할당`)에서만 사용되며 다른 파일에서 참조되지 않습니다. ConPTY pseudoconsole 설정 로직(`ProcThreadAttributeList`, `set_pty_connection`)에는 변경 없음.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJMrPK3cNkNse442FB3W9A)_