### PR TITLE
fix(cli-agent): Windows 启动时检测已安装 agent 不再弹出命令行窗口

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -6,7 +6,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
-use std::process::Command;
 use std::sync::{Arc, LazyLock, RwLock};
 
 use ai::skills::SkillProvider;
@@ -600,27 +599,37 @@ impl CLIAgent {
 
     /// 同步检测系统是否安装了此 agent。后台线程专用。
     fn is_installed_blocking(&self) -> bool {
-        let check_cmd = |cmd: &str| -> bool {
-            #[cfg(unix)]
-            let (shell, arg) = ("which", cmd);
-            #[cfg(windows)]
-            let (shell, arg) = ("where", cmd);
-            Command::new(shell)
-                .arg(arg)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .output()
-                .is_ok_and(|o| o.status.success())
-        };
         match self {
             CLIAgent::Unknown => false,
             // `agent` 太泛化，Cursor CLI 用 cursor-agent 检测
-            CLIAgent::CursorCli => check_cmd("cursor-agent"),
+            CLIAgent::CursorCli => is_on_path("cursor-agent"),
             // DeepSeek 同时检查主命令和别名
-            CLIAgent::DeepSeek => check_cmd("deepseek") || check_cmd("deepseek-tui"),
-            other => check_cmd(other.command_prefix()),
+            CLIAgent::DeepSeek => is_on_path("deepseek") || is_on_path("deepseek-tui"),
+            other => is_on_path(other.command_prefix()),
         }
     }
+}
+
+/// 内联 PATH 搜索，零进程、零闪窗。
+#[cfg(unix)]
+fn is_on_path(cmd: &str) -> bool {
+    let Ok(path_var) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path_var).any(|dir| dir.join(cmd).is_file())
+}
+
+#[cfg(windows)]
+fn is_on_path(cmd: &str) -> bool {
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT".into());
+    let Ok(path_var) = std::env::var("PATH") else {
+        return false;
+    };
+    let exts: Vec<&str> = pathext.split(';').collect();
+    std::env::split_paths(&path_var).any(|dir| {
+        exts.iter()
+            .any(|ext| dir.join(format!("{}{}", cmd, ext)).is_file())
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 问题

PR #200 新增了 CLI Agent 已安装检测功能，通过 `where` 命令逐个检测 13 个 agent。Windows 上每次 spawn `where` 都会短暂显示一个命令行窗口，启动时闪现十多次。

## 修复

将外部命令检测改为内联 PATH 搜索，零进程、零闪窗：

- **Unix**：`std::env::split_paths` 直接迭代 PATH 查找文件名
- **Windows**：追加 PATHEXT 动态读取，逐后缀匹配 `.exe` / `.cmd` / `.bat`

删除了对 `std::process::Command` 的依赖，性能更快且无外部依赖。

## 改动

`app/src/terminal/cli_agent.rs` — `is_installed_blocking()` 替换 `where`/`which` 命令为 `is_on_path()` 纯 Rust 实现。