### PR TITLE
feat: 添加 Vue 文件 injection 高亮支持（JS/CSS/TS）

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -228,6 +228,8 @@ pub struct Language {
     pub grammar: ParserGrammar,
     /// Query for syntax highlighting.
     pub highlight_query: Query,
+    /// Query for language injections (e.g., JS/CSS in Vue files).
+    pub injections_query: Option<Query>,
     /// Query for auto indent.
     pub indents_query: Option<Query>,
     /// Unit for each indent action.
@@ -331,6 +333,16 @@ fn get_arborium_highlight_query(lang: &str) -> Option<&str> {
     }
 }
 
+/// Get the bundled injections query from arborium for a given language.
+/// This enables embedded language highlighting (e.g., JS/CSS in Vue files).
+fn get_arborium_injections_query(lang: &str) -> Option<&str> {
+    match lang {
+        "vue" => Some(arborium::lang_vue::INJECTIONS_QUERY),
+        // Add other languages with injections support here as needed
+        _ => None,
+    }
+}
+
 fn load_language(lang: &str) -> Option<Language> {
     let arborium_name = to_arborium_name(lang);
     let grammar = arborium::get_language(arborium_name)?;
@@ -354,6 +366,10 @@ fn load_language(lang: &str) -> Option<Language> {
     let highlight_query = Query::new(&grammar, highlight_query_str)
         .expect("arborium highlight query should be valid");
 
+    // Load injections query for embedded language support (e.g., JS/CSS in Vue)
+    let injections_query = get_arborium_injections_query(lang)
+        .and_then(|query_str| Query::new(&grammar, query_str).ok());
+
     let indents_query_path = [lang, "indents.scm"].join("\\");
     let indents_query = load_query(&indents_query_path, &grammar);
 
@@ -362,6 +378,7 @@ fn load_language(lang: &str) -> Option<Language> {
 
     Some(Language {
         highlight_query,
+        injections_query,
         indents_query,
         grammar,
         indent_unit,

--- a/crates/syntax_tree/src/lib.rs
+++ b/crates/syntax_tree/src/lib.rs
@@ -13,7 +13,7 @@ use parking_lot::Mutex;
 use arborium::tree_sitter::{InputEdit, Parser, Tree};
 use futures::stream::AbortHandle;
 use queries::{
-    highlight_query::HighlightQuery,
+    highlight_query::{HighlightQuery, InjectionHighlightQuery},
     indent_query::{indentation_delta, IndentDelta},
 };
 use rangemap::{RangeMap, RangeSet};
@@ -43,6 +43,8 @@ pub enum DecorationStateEvent {
 struct LanguageQueries {
     language: Arc<Language>,
     syntax_query: HighlightQuery,
+    /// Highlight queries for injected languages (e.g., JavaScript, CSS for Vue)
+    injection_queries: HashMap<String, InjectionHighlightQuery>,
 }
 
 /// Single-entry cache for highlight queries.
@@ -109,9 +111,29 @@ impl SyntaxTreeState {
     }
 
     pub fn set_language(&mut self, language: Arc<Language>) {
+        let mut injection_queries = HashMap::new();
+
+        if language.injections_query.is_some() {
+            // 中文注释：这里按 Vue injections.scm 里会出现的语言集合预热查询，避免渲染时重复查表。
+            for injection_language in ["javascript", "typescript", "jsx", "tsx", "css", "scss"] {
+                if let Some(injected_language) = languages::language_by_name(injection_language) {
+                    let highlight_query =
+                        HighlightQuery::new(&injected_language.highlight_query, self.color_map);
+                    injection_queries.insert(
+                        injection_language.to_string(),
+                        InjectionHighlightQuery {
+                            language: injected_language,
+                            highlight_query,
+                        },
+                    );
+                }
+            }
+        }
+
         self.language_queries = Some(LanguageQueries {
             syntax_query: HighlightQuery::new(&language.highlight_query, self.color_map),
             language,
+            injection_queries,
         });
     }
 
@@ -182,6 +204,25 @@ impl SyntaxTreeState {
             // Merge the highlights into the combined map
             for (highlight_range, color) in highlights.iter() {
                 combined_highlights.insert(highlight_range.clone(), *color);
+            }
+
+            // Process injections for embedded languages (e.g., JS/CSS in Vue)
+            if let Some(injections_query) = &language_queries.language.injections_query {
+                if !language_queries.injection_queries.is_empty() {
+                    let injection_highlights =
+                        language_queries.syntax_query.get_injection_highlights(
+                            range.clone(),
+                            injections_query,
+                            &language_queries.injection_queries,
+                            buffer.as_ref(ctx),
+                            tree,
+                        );
+
+                    // Merge injection highlights (these override main highlights)
+                    for (highlight_range, color) in injection_highlights.iter() {
+                        combined_highlights.insert(highlight_range.clone(), *color);
+                    }
+                }
             }
         }
 

--- a/crates/syntax_tree/src/queries/highlight_query.rs
+++ b/crates/syntax_tree/src/queries/highlight_query.rs
@@ -1,6 +1,6 @@
-use std::{iter, ops::Range};
+use std::{cell::RefCell, collections::HashMap, iter, ops::Range, sync::Arc};
 
-use arborium::tree_sitter::{Node, Query, QueryCursor, TextProvider, Tree};
+use arborium::tree_sitter::{Node, Parser, Query, QueryCursor, TextProvider, Tree};
 use rangemap::RangeMap;
 use streaming_iterator::StreamingIterator;
 use string_offset::{ByteOffset, CharOffset};
@@ -9,6 +9,10 @@ use warp_editor::content::{
     text::Bytes,
 };
 use warpui::color::ColorU;
+
+thread_local! {
+    static INJECTION_PARSER: RefCell<Parser> = RefCell::new(Parser::new());
+}
 
 /// Color mapping from parsed syntax token name to its corresponding highlighting color.
 #[derive(Clone, Copy)]
@@ -26,6 +30,11 @@ pub struct ColorMap {
 /// Query for retrieving syntax highlighting information on the tokens.
 pub struct HighlightQuery {
     highlight_map: Vec<Option<ColorU>>,
+}
+
+pub struct InjectionHighlightQuery {
+    pub language: Arc<languages::Language>,
+    pub highlight_query: HighlightQuery,
 }
 
 impl HighlightQuery {
@@ -77,6 +86,180 @@ impl HighlightQuery {
 
         range_map
     }
+
+    /// Process language injections and return highlights for injected regions.
+    /// This handles embedded languages like JavaScript/CSS in Vue files.
+    pub fn get_injection_highlights(
+        &self,
+        range: Range<CharOffset>,
+        injections_query: &Query,
+        injection_highlight_queries: &HashMap<String, InjectionHighlightQuery>,
+        buffer: &Buffer,
+        tree: &Tree,
+    ) -> RangeMap<CharOffset, ColorU> {
+        let mut range_map = RangeMap::new();
+
+        let mut cursor = QueryCursor::new();
+        let byte_start = range.start.to_buffer_byte_offset(buffer).as_usize();
+        let byte_end = range.end.to_buffer_byte_offset(buffer).as_usize();
+        cursor.set_byte_range(byte_start..byte_end);
+
+        let injection_content_idx = injections_query
+            .capture_names()
+            .iter()
+            .position(|name| *name == "injection.content")
+            .map(|idx| idx as u32);
+        let injection_language_idx = injections_query
+            .capture_names()
+            .iter()
+            .position(|name| *name == "injection.language")
+            .map(|idx| idx as u32);
+
+        let mut matches = cursor.matches(injections_query, tree.root_node(), TextBuffer(buffer));
+
+        while let Some(query_match) = matches.next() {
+            // 中文注释：优先读取 query 的 #set! 属性，这是注入语言的权威来源。
+            // Source: arborium-highlight-2.18.0/src/tree_sitter.rs
+            let mut lang_name = injections_query
+                .property_settings(query_match.pattern_index)
+                .iter()
+                .find(|prop| prop.key.as_ref() == "injection.language")
+                .and_then(|prop| prop.value.as_deref())
+                .map(str::to_owned);
+            let mut content_node: Option<Node> = None;
+
+            for cap in query_match.captures {
+                if Some(cap.index) == injection_content_idx {
+                    content_node = Some(cap.node);
+                } else if Some(cap.index) == injection_language_idx && lang_name.is_none() {
+                    let bytes = collect_buffer_bytes(
+                        buffer,
+                        ByteOffset::from(cap.node.start_byte()),
+                        ByteOffset::from(cap.node.end_byte()),
+                    );
+                    if let Ok(value) = std::str::from_utf8(&bytes) {
+                        if !value.is_empty() {
+                            lang_name = Some(value.to_string());
+                        }
+                    }
+                }
+            }
+
+            if let (Some(node), Some(lang_name)) = (content_node, lang_name) {
+                let normalized_lang = normalize_injection_language_name(&lang_name);
+
+                if let Some(injection_query) = injection_highlight_queries.get(normalized_lang) {
+                    let content_range = node.byte_range();
+                    let local_start = byte_start.saturating_sub(content_range.start);
+                    let local_end = byte_end
+                        .min(content_range.end)
+                        .saturating_sub(content_range.start);
+
+                    if local_start < local_end {
+                        let source = collect_buffer_bytes(
+                            buffer,
+                            ByteOffset::from(content_range.start),
+                            ByteOffset::from(content_range.end),
+                        );
+
+                        // 中文注释：注入片段必须先按目标语言单独建树，再把高亮偏移回原文件。
+                        let highlights = injection_query
+                            .highlight_query
+                            .get_highlighted_chunks_for_injection(
+                                local_start..local_end,
+                                &injection_query.language,
+                                &source,
+                                content_range.start,
+                                buffer,
+                            );
+
+                        for (highlight_range, color) in highlights.iter() {
+                            range_map.insert(highlight_range.clone(), *color);
+                        }
+                    }
+                }
+            }
+        }
+
+        range_map
+    }
+
+    fn get_highlighted_chunks_for_injection(
+        &self,
+        local_byte_range: Range<usize>,
+        language: &languages::Language,
+        source: &[u8],
+        base_byte_offset: usize,
+        buffer: &Buffer,
+    ) -> RangeMap<CharOffset, ColorU> {
+        INJECTION_PARSER.with(|parser| {
+            let mut parser = parser.borrow_mut();
+            parser
+                .set_language(&language.grammar)
+                .expect("注入语言语法应当兼容 parser");
+
+            let Some(tree) = parser.parse(source, None) else {
+                return RangeMap::new();
+            };
+
+            let mut range_map = RangeMap::new();
+            let mut cursor = QueryCursor::new();
+            cursor.set_byte_range(local_byte_range);
+            let mut captures = cursor.captures(
+                &language.highlight_query,
+                tree.root_node(),
+                TextSlice(source),
+            );
+
+            while let Some(matches) = captures.next() {
+                for cap in matches.0.captures {
+                    let insertion_range = cap.node.byte_range();
+                    let color = self
+                        .highlight_map
+                        .get(cap.index as usize)
+                        .and_then(|inner| *inner);
+
+                    if let Some(color) = color {
+                        let global_start =
+                            injection_byte_to_buffer_byte(base_byte_offset, insertion_range.start);
+                        let global_end =
+                            injection_byte_to_buffer_byte(base_byte_offset, insertion_range.end);
+                        let char_start =
+                            ByteOffset::from(global_start).to_buffer_char_offset(buffer);
+                        let char_end = ByteOffset::from(global_end).to_buffer_char_offset(buffer);
+                        if char_start < char_end {
+                            range_map.insert(char_start..char_end, color);
+                        }
+                    }
+                }
+            }
+
+            range_map
+        })
+    }
+}
+
+fn injection_byte_to_buffer_byte(base_byte_offset: usize, local_byte_offset: usize) -> usize {
+    // 中文注释：注入片段来自已解析的 Vue tree-sitter 节点，映射回 Buffer 时需要抵消
+    // Buffer/TreeSitter 边界上的 1-byte 偏移，避免 token 首字符漏高亮。
+    base_byte_offset + local_byte_offset.saturating_sub(1)
+}
+
+fn normalize_injection_language_name(name: &str) -> &str {
+    match name {
+        "js" => "javascript",
+        "ts" => "typescript",
+        "less" | "postcss" => "scss",
+        other => other,
+    }
+}
+
+fn collect_buffer_bytes(buffer: &Buffer, start: ByteOffset, end: ByteOffset) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for chunk in buffer.bytes_in_range(start, end) {
+        bytes.extend_from_slice(chunk);
+    }
+    bytes
 }
 
 fn convert_capture_name_to_color(name: &str, color_map: &ColorMap) -> Option<ColorU> {


### PR DESCRIPTION
 ## 修改内容

  - 在 Language 结构体中添加 injections_query 字段
  - 加载 arborium 的 Vue INJECTIONS_QUERY
  - 实现 injection 高亮处理逻辑
  - 支持 <script>、<script lang=ts>、<style> 等标签内的代码高亮

  ## 支持的标签

  - `<script>` - JavaScript 高亮
  - `<script lang="ts">` - TypeScript 高亮
  - `<script lang="tsx/jsx">` - TSX/JSX 高亮
  - `<style>` - CSS 高亮
  - `<style lang="scss">` - SCSS 高亮

  ## 测试

  已验证 `.vue` 文件中的 `<script>` 和 `<style>` 标签内代码能正确高亮显示。

  Closes #217