### PR TITLE
fix(windows): prevent drag_window on maximized window to fix stuck move/resize (#220)

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1672,10 +1672,15 @@ impl EventLoop {
                     // Double-clicking the titlebar does maximize/restore.
                     if click_count >= 2 {
                         window.toggle_maximized();
-                    } else if window_state.last_touch_purpose.is_none() {
+                    } else if window_state.last_touch_purpose.is_none()
+                        && !winit_window.is_maximized()
+                    {
                         // Single-click drag moves the window. Skip for touch events as
                         // drag_window doesn't work properly with touch input on Windows.
                         // We won't receive MouseInput::Released after drag_window.
+                        // Also skip when maximized: calling drag_window on a maximized window
+                        // corrupts OS window state on Windows, causing the window to become
+                        // unable to move or resize after restore. See: issue #220
                         match winit_window.drag_window() {
                             Ok(_) => window_state.current_mouse_button_pressed = None,
                             Err(err) => log::error!("error dragging window: {err:?}"),

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1130,6 +1130,14 @@ impl Window {
             .unwrap_or(false)
     }
 
+    pub fn is_maximized(&self) -> bool {
+        self.inner
+            .borrow()
+            .as_ref()
+            .map(|inner| inner.window.is_maximized())
+            .unwrap_or(false)
+    }
+
     /// Requests user attention. If the window is in focus, this is a noop.
     pub fn request_user_attention(&self) {
         // Determine which level of user attention urgency to request from the OS.


### PR DESCRIPTION
## 関連 Issue

Fixes #220

## 問題点（確定性）

**根因**：`crates/warpui/src/windowing/winit/event_loop/mod.rs:1679`

ダブルクリックで最大化 → 復元する際、**第1クリック（click_count=1）** が最大化中のウィンドウに対して `drag_window()` を呼ぶ。

```rust
// 修正前 (event_loop/mod.rs:1675)
} else if window_state.last_touch_purpose.is_none() {
    match winit_window.drag_window() {   // ← 最大化中でも無条件に呼ばれる
```

Windows 上でこれは `WM_NCLBUTTONDOWN+HTCAPTION` を OS に送り、ウィンドウ移動ループを起動する。最大化ウィンドウに対してこの操作を行うと OS の内部ウィンドウ状態が変化し、その後 `toggle_maximized()` で復元しても move/resize 操作が機能しなくなる。

## 复現証拠

- `event_loop/mod.rs:1675-1682`：`drag_window()` に最大化チェックがない
- `window.rs:1039-1048`：リサイズ側は既に `is_maximized()` でガード済み（非対称）

```rust
// window.rs:1039-1048 — リサイズ側の既存ガード
let drag_resize_direction = if inner.window.is_maximized() {
    None   // 最大化中はリサイズ禁止 ← drag_window() にはこれがなかった
} else { ... }
```

## 規模声明

| 指標 | 値 |
|---|---|
| 変更ファイル数 | 2 |
| 変更行数 | +14 / -1 |
| 影響面 `drag_window` 呼び出し箇所 | 1件のみ |
| 公開 API 変更 | なし |

## 変更ファイル一覧

| ファイル | 行 | 変更内容 |
|---|---|---|
| `crates/warpui/src/windowing/winit/window.rs` | 1132-1139 | `pub fn is_maximized()` を追加（`is_decorated()` と同パターン） |
| `crates/warpui/src/windowing/winit/event_loop/mod.rs` | 1675-1676 | `drag_window()` 呼び出し条件に `&& !winit_window.is_maximized()` を追加 |

## 検証

```
cargo check -p warpui  →  Finished (no errors)
cargo test  -p warpui  →  test result: ok. 47 passed; 0 failed
```

## 影響面

- **修正後の動作**：最大化中のタイトルバーへの単一クリックは `drag_window()` を呼ばなくなる（最大化ウィンドウは移動できないため、これが正しい動作）
- **ダブルクリックによる最大化/復元**：変更なし（`click_count >= 2` 分岐は影響なし）
- **通常状態のドラッグ/リサイズ**：変更なし
- **macOS/Linux**：`is_maximized()` は winit の共通 API であり、他プラットフォームでも安全

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKBFbj8WY5aMddPFxQvXD7)_