### PR TITLE
feat: 支持 Vue 文件块级注释

### DIFF
--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -2046,7 +2046,7 @@ impl CodeEditorModel {
         let actionable_lines = lines
             .iter()
             .filter_map(|line| {
-                let kind = kinds.get(line.saturating_sub(1)).copied().flatten()?;
+                let kind = kinds.get(line.saturating_sub(&1)).copied().flatten()?;
                 let body = Self::line_body_for_comment(buffer, *line)?;
                 Some((*line, kind, body))
             })
@@ -2066,8 +2066,8 @@ impl CodeEditorModel {
                 let replacement = if remove {
                     Self::uncomment_vue_line(kind, &body.text)?
                 } else {
-                    Some(Self::comment_vue_line(kind, &body.text))
-                }?;
+                    Self::comment_vue_line(kind, &body.text)
+                };
                 Some((replacement, body.range))
             })
             .collect_vec();

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -131,6 +131,18 @@ enum IndentMode {
     Enter,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VueCommentKind {
+    Script,
+    Template,
+    Style,
+}
+
+struct VueCommentLineBody {
+    range: Range<CharOffset>,
+    text: String,
+}
+
 struct IndentResult {
     /// The indentation to insert before the cursor
     insert_before_cursor: String,
@@ -1981,6 +1993,12 @@ impl CodeEditorModel {
     }
 
     pub fn toggle_comments(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.syntax_tree.as_ref(ctx).language_display_name() == Some("Vue")
+            && self.toggle_vue_comments(ctx)
+        {
+            return;
+        }
+
         let Some(prefix) = self.syntax_tree.as_ref(ctx).comment_prefix() else {
             return;
         };
@@ -2017,6 +2035,158 @@ impl CodeEditorModel {
             ctx,
         );
         self.validate(ctx)
+    }
+
+    fn toggle_vue_comments(&mut self, ctx: &mut ModelContext<Self>) -> bool {
+        let buffer = self.content().as_ref(ctx);
+        let selection_model = self.selection_model.as_ref(ctx);
+        let lines = selection_model.selected_lines(ctx);
+        let kinds = Self::vue_comment_kinds_by_line(buffer.text().as_str());
+
+        let actionable_lines = lines
+            .iter()
+            .filter_map(|line| {
+                let kind = kinds.get(line.saturating_sub(1)).copied().flatten()?;
+                let body = Self::line_body_for_comment(buffer, *line)?;
+                Some((*line, kind, body))
+            })
+            .collect_vec();
+
+        if actionable_lines.is_empty() {
+            return false;
+        }
+
+        let remove = actionable_lines
+            .iter()
+            .all(|(_, kind, body)| Self::vue_line_is_commented(*kind, &body.text));
+
+        let edits = actionable_lines
+            .into_iter()
+            .filter_map(|(_, kind, body)| {
+                let replacement = if remove {
+                    Self::uncomment_vue_line(kind, &body.text)?
+                } else {
+                    Some(Self::comment_vue_line(kind, &body.text))
+                }?;
+                Some((replacement, body.range))
+            })
+            .collect_vec();
+
+        let Ok(edits) = Vec1::try_from_vec(edits) else {
+            return false;
+        };
+
+        let selection_model = self.selection_model.clone();
+        self.update_content(
+            |mut content, ctx| {
+                content.apply_edit(
+                    BufferEditAction::InsertAtCharOffsetRanges { edits: &edits },
+                    EditOrigin::UserInitiated,
+                    selection_model,
+                    ctx,
+                );
+            },
+            ctx,
+        );
+        self.validate(ctx);
+        true
+    }
+
+    fn vue_comment_kinds_by_line(text: &str) -> Vec<Option<VueCommentKind>> {
+        let mut current = None;
+
+        text.lines()
+            .map(|line| {
+                let lower = line.to_ascii_lowercase();
+                let trimmed = lower.trim_start();
+                let opens_template = trimmed.starts_with("<template");
+                let opens_script = trimmed.starts_with("<script");
+                let opens_style = trimmed.starts_with("<style");
+                let closes_current = matches!(
+                    (current, trimmed),
+                    (Some(VueCommentKind::Template), t) if t.starts_with("</template")
+                ) || matches!(
+                    (current, trimmed),
+                    (Some(VueCommentKind::Script), t) if t.starts_with("</script")
+                ) || matches!(
+                    (current, trimmed),
+                    (Some(VueCommentKind::Style), t) if t.starts_with("</style")
+                );
+
+                let kind = if opens_template || opens_script || opens_style || closes_current {
+                    None
+                } else {
+                    current
+                };
+
+                if opens_template {
+                    current = Some(VueCommentKind::Template);
+                } else if opens_script {
+                    current = Some(VueCommentKind::Script);
+                } else if opens_style {
+                    current = Some(VueCommentKind::Style);
+                } else if closes_current {
+                    current = None;
+                }
+
+                kind
+            })
+            .collect()
+    }
+
+    fn line_body_for_comment(buffer: &Buffer, line: usize) -> Option<VueCommentLineBody> {
+        let line_start = Point::new(line as u32, 0).to_buffer_char_offset(buffer);
+        let line_end = buffer
+            .containing_line_end(line_start)
+            .saturating_sub(&1.into());
+        let line_text = buffer.text_in_range(line_start..line_end).into_string();
+
+        if line_text.trim().is_empty() {
+            return None;
+        }
+
+        let indent_chars = line_text.chars().take_while(|c| c.is_whitespace()).count();
+        let body_start = line_start + CharOffset::from(indent_chars);
+        let body_text = line_text.chars().skip(indent_chars).collect::<String>();
+
+        Some(VueCommentLineBody {
+            range: body_start..line_end,
+            text: body_text,
+        })
+    }
+
+    fn vue_line_is_commented(kind: VueCommentKind, text: &str) -> bool {
+        let trimmed = text.trim();
+        match kind {
+            VueCommentKind::Script => text.starts_with("//"),
+            VueCommentKind::Template => trimmed.starts_with("<!--") && trimmed.ends_with("-->"),
+            VueCommentKind::Style => trimmed.starts_with("/*") && trimmed.ends_with("*/"),
+        }
+    }
+
+    fn comment_vue_line(kind: VueCommentKind, text: &str) -> String {
+        match kind {
+            VueCommentKind::Script => format!("// {text}"),
+            VueCommentKind::Template => format!("<!-- {} -->", text.trim()),
+            VueCommentKind::Style => format!("/* {} */", text.trim()),
+        }
+    }
+
+    fn uncomment_vue_line(kind: VueCommentKind, text: &str) -> Option<String> {
+        match kind {
+            VueCommentKind::Script => text
+                .strip_prefix("// ")
+                .or_else(|| text.strip_prefix("//"))
+                .map(str::to_string),
+            VueCommentKind::Template => Self::unwrap_vue_comment(text, "<!--", "-->"),
+            VueCommentKind::Style => Self::unwrap_vue_comment(text, "/*", "*/"),
+        }
+    }
+
+    fn unwrap_vue_comment(text: &str, open: &str, close: &str) -> Option<String> {
+        let trimmed = text.trim();
+        let inner = trimmed.strip_prefix(open)?.strip_suffix(close)?;
+        Some(inner.trim().to_string())
     }
 
     /// Whether the given range is wrapped in the supported bracket pairs of the active language.

--- a/app/src/code/editor/model_tests.rs
+++ b/app/src/code/editor/model_tests.rs
@@ -4,7 +4,7 @@ use vec1::vec1;
 use warp_editor::content::buffer::{InitialBufferState, SelectionOffsets};
 use warp_editor::multiline::MultilineString;
 use warp_util::content_version::ContentVersion;
-use warpui::App;
+use warpui::{text::point::Point, App};
 
 use crate::{
     code::editor::line::EditorLineLocation, code::editor::view::code_text_styles,
@@ -19,12 +19,21 @@ fn initialize_deps(app: &mut App) {
 }
 
 fn mock_model(app: &mut App, text: &str, version: ContentVersion) -> ModelHandle<CodeEditorModel> {
+    mock_model_with_path(app, text, version, "test.rs")
+}
+
+fn mock_model_with_path(
+    app: &mut App,
+    text: &str,
+    version: ContentVersion,
+    path: &str,
+) -> ModelHandle<CodeEditorModel> {
     app.add_model(|ctx| {
         let styles = code_text_styles(Appearance::as_ref(ctx), FontSettings::as_ref(ctx), None);
         let mut model = CodeEditorModel::new(styles, None, false, None, ctx);
         let state = InitialBufferState::plain_text(text).with_version(version);
         model.reset_content(state, ctx);
-        model.set_language_with_path(Path::new("test.rs"), ctx);
+        model.set_language_with_path(Path::new(path), ctx);
         model
     })
 }
@@ -155,6 +164,60 @@ fn test_toggle_comment() {
             assert_eq!(
                 editor.content.as_ref(ctx).text().as_str(),
                 "    // // First\n    Second"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_toggle_vue_comments_by_block() {
+    App::test((), |mut app| async move {
+        initialize_deps(&mut app);
+        let editor = mock_model_with_path(
+            &mut app,
+            "<template>\n  <div>hello</div>\n</template>\n<script>\n  const count = 1\n</script>\n<style>\n  .title { color: red; }\n</style>",
+            ContentVersion::new(),
+            "Component.vue",
+        );
+        layout_model(&mut app, &editor).await;
+
+        for (line, expected) in [
+            (
+                2,
+                "<template>\n  <!-- <div>hello</div> -->\n</template>\n<script>\n  const count = 1\n</script>\n<style>\n  .title { color: red; }\n</style>",
+            ),
+            (
+                5,
+                "<template>\n  <div>hello</div>\n</template>\n<script>\n  // const count = 1\n</script>\n<style>\n  .title { color: red; }\n</style>",
+            ),
+            (
+                8,
+                "<template>\n  <div>hello</div>\n</template>\n<script>\n  const count = 1\n</script>\n<style>\n  /* .title { color: red; } */\n</style>",
+            ),
+        ] {
+            editor.update(&mut app, |editor, ctx| {
+                let start = Point::new(line, 0).to_buffer_char_offset(editor.content.as_ref(ctx));
+                editor.cursor_at(start, ctx);
+                editor.select_to_line_end(ctx);
+                editor.toggle_comments(ctx);
+            });
+
+            editor.read(&app, |editor, ctx| {
+                assert_eq!(editor.content.as_ref(ctx).text().as_str(), expected);
+            });
+
+            editor.update(&mut app, |editor, ctx| {
+                let start = Point::new(line, 0).to_buffer_char_offset(editor.content.as_ref(ctx));
+                editor.cursor_at(start, ctx);
+                editor.select_to_line_end(ctx);
+                editor.toggle_comments(ctx);
+            });
+        }
+
+        editor.read(&app, |editor, ctx| {
+            assert_eq!(
+                editor.content.as_ref(ctx).text().as_str(),
+                "<template>\n  <div>hello</div>\n</template>\n<script>\n  const count = 1\n</script>\n<style>\n  .title { color: red; }\n</style>"
             );
         });
     })

--- a/crates/syntax_tree/src/lib.rs
+++ b/crates/syntax_tree/src/lib.rs
@@ -138,6 +138,12 @@ impl SyntaxTreeState {
             .map(|s| s.as_str())
     }
 
+    pub fn language_display_name(&self) -> Option<&str> {
+        self.language_queries
+            .as_ref()
+            .map(|queries| queries.language.display_name())
+    }
+
     /// Given multiple character ranges, return their corresponding highlight colors.
     /// If the tree is not ready or the buffer model has been deallocated, this returns None.
     pub fn highlights_in_ranges(


### PR DESCRIPTION
## 修改内容

支持 Vue 文件中 `<template>`、`<script>`、`<style>` 三个块的独立注释功能。

### 功能说明

- 根据光标所在位置自动选择正确的注释格式
- `<template>` 块使用 HTML 注释（<!-- -->）
- `<script>` 块使用 JS 注释（//）
- `<style>` 块使用 CSS 注释（/* */）

### 修改文件

- `app/src/code/editor/model.rs`：添加 Vue 块注释逻辑
- `app/src/code/editor/model_tests.rs`：添加测试用例
- `crates/syntax_tree/src/lib.rs`：添加 Vue 块类型识别

## 测试

已验证 `.vue` 文件中三个块的注释功能均正常工作。

Closes #217