### PR TITLE
fix: inject user rules into next command suggestion system prompt

### DIFF
--- a/app/src/ai/agent_providers/active_ai/mod.rs
+++ b/app/src/ai/agent_providers/active_ai/mod.rs
@@ -379,6 +379,12 @@ pub mod next_command {
     use super::*;
     use warpui::{AppContext, EntityId};
 
+    #[derive(Debug, Serialize)]
+    struct UserRuleCtx {
+        name: Option<String>,
+        content: String,
+    }
+
     pub struct Input {
         pub recent_blocks: Vec<BlockSnippet>,
         /// 已在 client 端从历史 DB 选出的相似命令上下文(可选)。
@@ -388,6 +394,8 @@ pub mod next_command {
         pub prefix: Option<String>,
         /// 之前已 reject 的建议(避免重复)。
         pub rejected_suggestions: Vec<String>,
+        /// 用户在 设置 → Agents → Rules 中配置的全局规则快照。
+        pub user_rules: Vec<(Option<String>, String)>,
     }
 
     /// Pre-spawn:解 BYOP 配置(需要 `&AppContext`)。`None` ⇒ 静默 no-op。
@@ -398,7 +406,14 @@ pub mod next_command {
     /// In-spawn:用 cfg + Input 渲染 prompt 并发请求。
     /// 模板渲染不依赖 AppContext,可在 spawn 内同步调用。
     pub async fn run_with(cfg: OneshotConfig, input: Input) -> Option<String> {
-        let system = render("next_command_system.j2", context! {});
+        let user_rule_ctxs: Vec<UserRuleCtx> = input
+            .user_rules
+            .into_iter()
+            .map(|(name, content)| UserRuleCtx { name, content })
+            .collect();
+        let system = render("next_command_system.j2", context! {
+            user_rules => user_rule_ctxs,
+        });
         let user = render(
             "next_command_user.j2",
             context! {

--- a/app/src/ai/agent_providers/prompts/active_ai/next_command_system.j2
+++ b/app/src/ai/agent_providers/prompts/active_ai/next_command_system.j2
@@ -2,6 +2,17 @@ You predict the most likely next shell command a user will run, based on their r
 
 Return ONLY the command text — single line, no quotes, no markdown fences, no explanation, no leading prompt characters (`$`, `>`).
 
+{%- if user_rules %}
+# User rules
+The user has configured the following global rules. Follow them in all responses.
+{%- for rule in user_rules %}
+{%- if rule.name %}
+## {{ rule.name }}
+{%- endif %}
+{{ rule.content }}
+{%- endfor %}
+
+{%- endif %}
 Rules:
 - The command must be plausible to run as the user's NEXT step right now.
 - If a `prefix` is given, the command MUST start with that exact prefix (byte-for-byte).

--- a/app/src/ai/predict/next_command_model.rs
+++ b/app/src/ai/predict/next_command_model.rs
@@ -35,8 +35,10 @@ use super::generate_ai_input_suggestions::{
     GenerateAIInputSuggestionsRequest, GenerateAIInputSuggestionsResponseV2, NextCommandContext,
 };
 
+use crate::ai::agent::api::collect_user_rules;
 use crate::ai::agent_providers::active_ai::next_command as byop_next_command;
 use crate::ai::agent_providers::oneshot::OneshotConfig;
+use crate::cloud_object::model::persistence::ObjectStoreModel;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
@@ -56,6 +58,7 @@ const MAX_NUM_SIMILAR_HISTORY_CONTEXT: usize = 25;
 async fn byop_generate_input_suggestions(
     byop_cfg: Option<OneshotConfig>,
     request: &GenerateAIInputSuggestionsRequest,
+    user_rules: Vec<(Option<String>, String)>,
 ) -> Result<GenerateAIInputSuggestionsResponseV2, AIApiError> {
     let Some(cfg) = byop_cfg else {
         // Zap 已剥云,无 BYOP 配置时不再 fallback ServerApi —— 返回空响应,
@@ -77,6 +80,7 @@ async fn byop_generate_input_suggestions(
         system_context: request.system_context.clone(),
         prefix: request.prefix.clone(),
         rejected_suggestions: request.rejected_suggestions.clone(),
+        user_rules,
     };
     let suggestion = byop_next_command::run_with(cfg, input).await;
     match suggestion {
@@ -392,6 +396,12 @@ impl NextCommandModel {
         // BYOP cfg 必须在 spawn 前解出(spawn 内拿不到 &AppContext)。
         // 用 None terminal_view_id 走全局当前 active profile。
         let byop_cfg = byop_next_command::resolve(ctx, None);
+        // 全局 Rules 同样在 spawn 前解出,仅在 memory 功能启用时收集。
+        let user_rules = if AISettings::as_ref(ctx).is_memory_enabled(ctx) {
+            collect_user_rules(ObjectStoreModel::as_ref(ctx))
+        } else {
+            Vec::new()
+        };
 
         let completion_context = completer_data.completion_session_context(ctx);
         // This is only needed if we have a prefix.
@@ -513,7 +523,7 @@ impl NextCommandModel {
                     // For zero-state next command suggestions, return the result immediately.
                     let Some(prefix) = prefix else {
                         return (
-                            byop_generate_input_suggestions(byop_cfg.clone(), &request).await,
+                            byop_generate_input_suggestions(byop_cfg.clone(), &request, user_rules.clone()).await,
                             request,
                             true,
                             start_ts_ms,
@@ -594,7 +604,7 @@ impl NextCommandModel {
                     };
 
                     // Only if we have no commands from history and no completions, use the LLM to generate a partial suggestion.
-                    let response = byop_generate_input_suggestions(byop_cfg, &request).await;
+                    let response = byop_generate_input_suggestions(byop_cfg, &request, user_rules).await;
                     (
                         response,
                         request,

--- a/app/src/ai/predict/next_command_model.rs
+++ b/app/src/ai/predict/next_command_model.rs
@@ -396,7 +396,11 @@ impl NextCommandModel {
         // BYOP cfg 必须在 spawn 前解出(spawn 内拿不到 &AppContext)。
         // 用 None terminal_view_id 走全局当前 active profile。
         let byop_cfg = byop_next_command::resolve(ctx, None);
-        // 全局 Rules 同样在 spawn 前解出,仅在 memory 功能启用时收集。
+        // 全局 Rules 同样在 spawn 前解出(spawn 内拿不到 &AppContext)。
+        // gate 与 chat 路径(`api.rs::RequestParams::new`)保持一致:两者都用
+        // `is_memory_enabled` 作为上游统一门控,属于产品层设计决定,非防御性代码。
+        // `collect_user_rules` 只遍历 `ObjectStoreModel.objects_by_id`(纯内存 HashMap),
+        // 不触发任何 IO,与上方的 `byop_next_command::resolve` 开销同量级。
         let user_rules = if AISettings::as_ref(ctx).is_memory_enabled(ctx) {
             collect_user_rules(ObjectStoreModel::as_ref(ctx))
         } else {


### PR DESCRIPTION
## 関連 Issue

Fixes #225

## 問題点（確定的記述）

**根因**: `app/src/ai/agent_providers/active_ai/mod.rs:401`

```rust
let system = render("next_command_system.j2", context! {});  // 空コンテキスト
```

`next_command::run_with` が `next_command_system.j2` をレンダリングする際に空のコンテキストを渡していたため、Settings → Agents → Rules で設定したグローバルルール（例：「常に英語で回答する」）が次コマンド提案のシステムプロンプトに一切注入されなかった。AI agent chat では `collect_user_rules` + `render_system` 経由で `partials/user_rules.j2` が注入されているが、next command suggestion パスにだけこの経路が欠けていた。

## 復現証拠

- `app/src/ai/agent_providers/active_ai/mod.rs:401` — `context! {}` で空レンダリング
- `app/src/ai/predict/next_command_model.rs:74-80` — `byop_next_command::Input` に `user_rules` フィールドなし（修正前）
- 対照: `app/src/ai/agent_providers/prompt_renderer.rs:399-433` — chat では `user_rules: &[(Option<String>, String)]` を受け取り注入済み

## 規模宣言

- 変更ファイル数: **3**
- 変更行数: **39**（insertions）
- 影響面 grep 命中数: **1**（`byop_next_command::Input` の構築箇所）

## 修正ファイル清单

| ファイル | 内容 |
|---|---|
| `app/src/ai/agent_providers/prompts/active_ai/next_command_system.j2` | `{% if user_rules %}` ブロック追加（`partials/user_rules.j2` と同仕様） |
| `app/src/ai/agent_providers/active_ai/mod.rs` | `UserRuleCtx` 構造体追加、`Input` に `user_rules` フィールド追加、`run_with` でテンプレートコンテキストに渡す |
| `app/src/ai/predict/next_command_model.rs` | `collect_user_rules` / `ObjectStoreModel` インポート追加、スポーン前に `is_memory_enabled` 判定で user_rules 解決、`byop_generate_input_suggestions` に `user_rules` パラメータ追加 |

## 検証

```
cargo check -p warp
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.34s  ✅

cargo test -p warp --lib -- ai::predict::next_command_model
→ test result: ok. 8 passed; 0 failed  ✅

cargo test -p warp --lib -- ai::agent_providers::prompt_renderer
→ test result: ok. 21 passed; 0 failed  ✅
```

## 影響面

- `byop_next_command::Input` を構築するのは `next_command_model.rs:74` の 1 箇所のみ
- `is_memory_enabled = false` のユーザーは従来どおり空 rules → 動作変化なし
- 既存テストはすべてパス、テスト内容の変更なし

---
_Generated by [Claude Code](https://claude.ai/code/session_011gCwLS2f5RwvNbwwBXbrXu)_