### PR TITLE
feat(image-viewer): in-app viewer for local and remote images

### DIFF
--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -120,6 +120,10 @@ pub struct LeafSnapshot {
 pub enum LeafContents {
     Terminal(TerminalPaneSnapshot),
     Notebook(NotebookPaneSnapshot),
+    /// A read-only image viewer pane backed by a local file.
+    Image {
+        path: Option<PathBuf>,
+    },
     AIDocument(AIDocumentPaneSnapshot),
     Code(CodePaneSnapShot),
     EnvVarCollection(EnvVarCollectionPaneSnapshot),
@@ -169,6 +173,9 @@ impl LeafContents {
             LeafContents::SshServer { .. } => false,
             // SFTP 浏览器:远端文件系统依赖活跃 SSH 连接,pane 不可恢复。
             LeafContents::Sftp { .. } => false,
+            // Image viewer panes are intentionally not persisted: they render in-session but
+            // are not restored after restart.
+            LeafContents::Image { .. } => false,
             // 远端文件代码 pane:远端 buffer 依赖活跃 SSH 连接,`RemoteFileTree`
             // source 不可恢复(`is_restorable() == false`)。若写入持久化会留下
             // 一条 restore 阶段被跳过的孤儿 `Code` 行,导致整个 tab 丢失 ——

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -2204,14 +2204,23 @@ impl FileTreeView {
                     let path = metadata.path.to_local_path_lossy();
                     self.open_file(&path, None, ctx);
                 } else {
-                    // 远端文件:走 buffer-sync 协议打开。
+                    // 远端文件:图片走图片查看器,其余走 buffer-sync 协议打开。
                     #[cfg(feature = "local_tty")]
                     if let Some(host_id) = root_dir.remote_host_id.clone() {
                         let remote_path = crate::code::buffer_location::RemotePath::new(
                             host_id,
                             (*metadata.path).clone(),
                         );
-                        ctx.emit(FileTreeEvent::OpenRemoteFile { remote_path });
+                        // `is_supported_image_file` 接受 `impl AsRef<Path>`,而
+                        // `metadata.path` 是 `StandardizedPath`(无 `AsRef<Path>`)——
+                        // 转成本地 PathBuf 仅为取扩展名,远端语义无关。
+                        if crate::util::openable_file_type::is_supported_image_file(
+                            metadata.path.to_local_path_lossy(),
+                        ) {
+                            ctx.emit(FileTreeEvent::OpenRemoteImage { remote_path });
+                        } else {
+                            ctx.emit(FileTreeEvent::OpenRemoteFile { remote_path });
+                        }
                     }
                 }
             }
@@ -2852,6 +2861,11 @@ pub enum FileTreeEvent {
     /// 在远端文件树里点击一个文件时发出,请求以远端 buffer 方式打开它。
     #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
     OpenRemoteFile {
+        remote_path: crate::code::buffer_location::RemotePath,
+    },
+    /// 在远端文件树里点击一个图片文件时发出,请求以远端图片查看器打开它。
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    OpenRemoteImage {
         remote_path: crate::code::buffer_location::RemotePath,
     },
 }

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -146,6 +146,7 @@ impl TryFrom<PaneNodeSnapshot> for PaneTemplateType {
                 }),
                 // Currently, notebook panes cannot be saved in launch configurations.
                 LeafContents::Notebook(_)
+                | LeafContents::Image { .. }
                 | LeafContents::EnvVarCollection(_)
                 | LeafContents::Code(_)
                 | LeafContents::Workflow(_)

--- a/app/src/notebooks/image/mod.rs
+++ b/app/src/notebooks/image/mod.rs
@@ -1,0 +1,210 @@
+//! Read-only image viewer pane contents. Renders a local image fit-to-pane via the warpui
+//! `Image` element. Mirrors the markdown `FileNotebookView`, but without the rich-text editor,
+//! workflow, or link machinery — an image emits nothing and only needs to be displayed.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use warpui::{
+    accessibility::{AccessibilityContent, WarpA11yRole},
+    assets::asset_cache::AssetSource,
+    elements::{Align, CacheOption, DispatchEventResult, Empty, EventHandler, Image, Text},
+    AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+};
+
+use crate::{
+    appearance::Appearance,
+    pane_group::{focus_state::PaneFocusHandle, pane::view, BackingView, PaneConfiguration, PaneEvent},
+    terminal::model::session::Session,
+};
+
+/// View for a read-only image backed by a file.
+pub struct ImageViewerView {
+    /// The path of the open image, cached for the title and snapshot/restore.
+    path: Option<PathBuf>,
+    /// The asset source to render. `None` until an image has been opened.
+    source: Option<AssetSource>,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+    focus_handle: Option<PaneFocusHandle>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImageViewerEvent {
+    /// The image was opened; used to persist the pane for session restoration.
+    Opened,
+    Pane(PaneEvent),
+}
+
+impl From<PaneEvent> for ImageViewerEvent {
+    fn from(event: PaneEvent) -> Self {
+        ImageViewerEvent::Pane(event)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ImageViewerAction {
+    Focus,
+    Close,
+}
+
+impl ImageViewerView {
+    /// Create a new image viewer view, with no open image.
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        let pane_configuration = ctx.add_model(|_ctx| PaneConfiguration::new(""));
+        Self {
+            path: None,
+            source: None,
+            pane_configuration,
+            focus_handle: None,
+        }
+    }
+
+    /// Open a local image file, rendering it from disk via `AssetSource::LocalFile`.
+    pub fn open_local(
+        &mut self,
+        path: impl Into<PathBuf>,
+        _session: Option<Arc<Session>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let local_path = path.into();
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.set_title(Self::title_for(&local_path), ctx);
+        });
+        self.source = Some(AssetSource::LocalFile {
+            path: local_path.to_string_lossy().into_owned(),
+        });
+        self.path = Some(local_path);
+
+        ctx.notify();
+        // Persist the open image so the tab restores after restart.
+        ctx.emit(ImageViewerEvent::Opened);
+    }
+
+    /// The path to the currently-open image, if it is local.
+    pub fn local_path(&self) -> Option<PathBuf> {
+        self.path.clone()
+    }
+
+    pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    pub fn focus(&self, ctx: &mut ViewContext<Self>) {
+        if let Some(a11y_content) = self.accessibility_contents(ctx) {
+            ctx.emit_a11y_content(a11y_content);
+        }
+        ctx.focus_self();
+    }
+
+    fn title(&self) -> String {
+        self.path
+            .as_deref()
+            .map(Self::title_for)
+            .unwrap_or_else(|| "Untitled".to_string())
+    }
+
+    fn title_for(path: &Path) -> String {
+        path.file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string())
+    }
+}
+
+impl Entity for ImageViewerView {
+    type Event = ImageViewerEvent;
+}
+
+impl View for ImageViewerView {
+    fn ui_name() -> &'static str {
+        "ImageViewerView"
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        Some(AccessibilityContent::new_without_help(
+            format!("{} image", self.title()),
+            WarpA11yRole::TextRole,
+        ))
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+
+        let body: Box<dyn Element> = match &self.source {
+            Some(source) => {
+                // Model the Image-element usage on `ui_components/src/lightbox.rs`: contain to
+                // fit-to-pane (preserving aspect ratio), with a loading element shown until the
+                // bytes decode. The pane wraps us in a `Shrinkable`, so `contain` fills the pane.
+                let loading = Align::new(
+                    Text::new(
+                        crate::t!("notebook-file-loading", name = self.title()),
+                        appearance.ui_font_family(),
+                        appearance.ui_font_size(),
+                    )
+                    .with_color(appearance.theme().foreground().into_solid())
+                    .finish(),
+                )
+                .finish();
+
+                Image::new(source.clone(), CacheOption::Original)
+                    .contain()
+                    .before_load(loading)
+                    .finish()
+            }
+            None => Empty::new().finish(),
+        };
+
+        EventHandler::new(Align::new(body).finish())
+            .on_left_mouse_down(|ctx, _, _| {
+                ctx.dispatch_typed_action(ImageViewerAction::Focus);
+                DispatchEventResult::StopPropagation
+            })
+            .finish()
+    }
+}
+
+impl TypedActionView for ImageViewerView {
+    type Action = ImageViewerAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            ImageViewerAction::Focus => ctx.focus_self(),
+            ImageViewerAction::Close => ctx.emit(ImageViewerEvent::Pane(PaneEvent::Close)),
+        }
+    }
+}
+
+impl BackingView for ImageViewerView {
+    type PaneHeaderOverflowMenuAction = ImageViewerAction;
+    type CustomAction = ();
+    type AssociatedData = ();
+
+    fn handle_pane_header_overflow_menu_action(
+        &mut self,
+        action: &Self::PaneHeaderOverflowMenuAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.handle_action(action, ctx);
+    }
+
+    fn close(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(ImageViewerEvent::Pane(PaneEvent::Close));
+    }
+
+    fn focus_contents(&mut self, ctx: &mut ViewContext<Self>) {
+        self.focus(ctx);
+    }
+
+    fn render_header_content(
+        &self,
+        _ctx: &view::HeaderRenderContext<'_>,
+        _app: &AppContext,
+    ) -> view::HeaderContent {
+        view::HeaderContent::simple(self.title())
+    }
+
+    fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {
+        self.focus_handle = Some(focus_handle);
+    }
+}

--- a/app/src/notebooks/image/mod.rs
+++ b/app/src/notebooks/image/mod.rs
@@ -9,13 +9,15 @@ use std::{
 
 use warpui::{
     accessibility::{AccessibilityContent, WarpA11yRole},
-    assets::asset_cache::AssetSource,
+    assets::asset_cache::{AssetCache, AssetSource},
     elements::{Align, CacheOption, DispatchEventResult, Empty, EventHandler, Image, Text},
+    image_cache::ImageType,
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
 };
 
 use crate::{
     appearance::Appearance,
+    code::buffer_location::RemotePath,
     pane_group::{focus_state::PaneFocusHandle, pane::view, BackingView, PaneConfiguration, PaneEvent},
     terminal::model::session::Session,
 };
@@ -23,7 +25,14 @@ use crate::{
 /// View for a read-only image backed by a file.
 pub struct ImageViewerView {
     /// The path of the open image, cached for the title and snapshot/restore.
+    /// Only set for local images; remote images keep their name in `remote_name`.
     path: Option<PathBuf>,
+    /// Title for a remote image (its filename). `None` for local images, which
+    /// derive their title from `path`.
+    remote_name: Option<String>,
+    /// True while a remote image's bytes are being fetched, so `render` shows a
+    /// loading indicator before any `source` exists.
+    loading: bool,
     /// The asset source to render. `None` until an image has been opened.
     source: Option<AssetSource>,
     pane_configuration: ModelHandle<PaneConfiguration>,
@@ -55,6 +64,8 @@ impl ImageViewerView {
         let pane_configuration = ctx.add_model(|_ctx| PaneConfiguration::new(""));
         Self {
             path: None,
+            remote_name: None,
+            loading: false,
             source: None,
             pane_configuration,
             focus_handle: None,
@@ -82,6 +93,46 @@ impl ImageViewerView {
         ctx.emit(ImageViewerEvent::Opened);
     }
 
+    /// Set the title and loading state for a remote image whose bytes are still
+    /// being fetched, so the pane shows its filename and a spinner up front.
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    pub fn set_loading_remote(&mut self, remote_path: &RemotePath, ctx: &mut ViewContext<Self>) {
+        let name = remote_path.file_name().to_string();
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.set_title(name.clone(), ctx);
+        });
+        self.remote_name = Some(name);
+        self.loading = true;
+        ctx.notify();
+    }
+
+    /// Open a remote image from already-fetched bytes, rendering via
+    /// `AssetSource::Raw` (the same path the terminal uses for inline images).
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    pub fn open_remote(
+        &mut self,
+        remote_path: &RemotePath,
+        bytes: &[u8],
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let name = remote_path.file_name().to_string();
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.set_title(name.clone(), ctx);
+        });
+
+        // 用 host_id:path 作为稳定 asset id —— 同一远端图片复用缓存,不同主机/路径不碰撞。
+        let asset_id = format!("{}:{}", remote_path.host_id, remote_path.path.as_str());
+        AssetCache::handle(ctx).update(ctx, |cache, ctx| {
+            cache.insert_raw_asset_bytes::<ImageType>(asset_id.clone(), bytes, ctx);
+        });
+
+        self.remote_name = Some(name);
+        self.loading = false;
+        self.source = Some(AssetSource::Raw { id: asset_id });
+        ctx.notify();
+        ctx.emit(ImageViewerEvent::Opened);
+    }
+
     /// The path to the currently-open image, if it is local.
     pub fn local_path(&self) -> Option<PathBuf> {
         self.path.clone()
@@ -102,6 +153,7 @@ impl ImageViewerView {
         self.path
             .as_deref()
             .map(Self::title_for)
+            .or_else(|| self.remote_name.clone())
             .unwrap_or_else(|| "Untitled".to_string())
     }
 
@@ -131,27 +183,33 @@ impl View for ImageViewerView {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
 
+        // A loading indicator, shown while remote bytes are fetched (no `source` yet)
+        // and as the `Image` element's `before_load` placeholder while bytes decode.
+        let loading_element = || {
+            Align::new(
+                Text::new(
+                    crate::t!("notebook-file-loading", name = self.title()),
+                    appearance.ui_font_family(),
+                    appearance.ui_font_size(),
+                )
+                .with_color(appearance.theme().foreground().into_solid())
+                .finish(),
+            )
+            .finish()
+        };
+
         let body: Box<dyn Element> = match &self.source {
             Some(source) => {
                 // Model the Image-element usage on `ui_components/src/lightbox.rs`: contain to
                 // fit-to-pane (preserving aspect ratio), with a loading element shown until the
                 // bytes decode. The pane wraps us in a `Shrinkable`, so `contain` fills the pane.
-                let loading = Align::new(
-                    Text::new(
-                        crate::t!("notebook-file-loading", name = self.title()),
-                        appearance.ui_font_family(),
-                        appearance.ui_font_size(),
-                    )
-                    .with_color(appearance.theme().foreground().into_solid())
-                    .finish(),
-                )
-                .finish();
-
                 Image::new(source.clone(), CacheOption::Original)
                     .contain()
-                    .before_load(loading)
+                    .before_load(loading_element())
                     .finish()
             }
+            // 远端图片在抓取字节期间还没有 source —— 先显示 loading 占位。
+            None if self.loading => loading_element(),
             None => Empty::new().finish(),
         };
 

--- a/app/src/notebooks/mod.rs
+++ b/app/src/notebooks/mod.rs
@@ -2,6 +2,7 @@ pub mod active_notebook_data;
 mod context_menu;
 pub mod editor;
 pub mod file;
+pub mod image;
 pub mod link;
 pub mod manager;
 pub mod notebook;

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1816,6 +1816,13 @@ impl PaneGroup {
                     "SFTP pane should not have been persisted, as it cannot be restored"
                 ))
             }
+            LeafContents::Image { .. } => {
+                // Image viewer panes are intentionally not persisted (see
+                // `LeafContents::is_persisted`), so this should be unreachable.
+                Err(anyhow::anyhow!(
+                    "Image pane should not have been persisted, as it is not restorable"
+                ))
+            }
             LeafContents::GetStarted => {
                 if !FeatureFlag::GetStartedTab.is_enabled() {
                     Err(anyhow::anyhow!("GetStarted pane not supported"))

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -160,6 +160,7 @@ pub use pane::env_var_collection_pane::EnvVarCollectionPane;
 // Zap Wave 7-3:`EnvironmentManagementPane` 随 ambient-agent UI 子系统物理删。
 pub use pane::execution_profile_editor_pane::ExecutionProfileEditorPane;
 pub use pane::file_pane::FilePane;
+pub use pane::image_pane::ImagePane;
 pub use pane::notebook_pane::NotebookPane;
 pub use pane::settings_pane::SettingsPane;
 pub use pane::terminal_pane::TerminalPane;

--- a/app/src/pane_group/pane/image_pane.rs
+++ b/app/src/pane_group/pane/image_pane.rs
@@ -1,0 +1,144 @@
+use std::{path::PathBuf, sync::Arc};
+
+use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
+
+use crate::{
+    app_state::LeafContents,
+    notebooks::image::{ImageViewerEvent, ImageViewerView},
+    terminal::model::session::Session,
+    workspace::ActiveSession,
+};
+
+use super::{
+    view::PaneView, DetachType, PaneConfiguration, PaneContent, PaneGroup, PaneId, ShareableLink,
+    ShareableLinkError,
+};
+
+/// A read-only pane that displays a local image. Mirrors [`super::file_pane::FilePane`], but
+/// backs onto [`ImageViewerView`] and drops the workflow/link plumbing — images emit nothing.
+pub struct ImagePane {
+    view: ViewHandle<PaneView<ImageViewerView>>,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+}
+
+impl ImagePane {
+    fn from_view(image_view: ViewHandle<ImageViewerView>, ctx: &mut AppContext) -> Self {
+        let pane_configuration = image_view.as_ref(ctx).pane_configuration();
+
+        let view = ctx.add_typed_action_view(image_view.window_id(ctx), |ctx| {
+            let pane_id = PaneId::from_image_pane_ctx(ctx);
+            PaneView::new(pane_id, image_view, (), pane_configuration.clone(), ctx)
+        });
+
+        Self {
+            view,
+            pane_configuration,
+        }
+    }
+
+    /// Create a new image pane for the given path and optional target session. Follows the same
+    /// session-fallback behavior as [`super::file_pane::FilePane::new`]: a remote target session
+    /// leaves the pane empty, while a missing session waits for the next local one.
+    pub fn new<V: View>(
+        path: Option<PathBuf>,
+        target_session: Option<Arc<Session>>,
+        ctx: &mut ViewContext<V>,
+    ) -> Self {
+        let view = ctx.add_typed_action_view(move |ctx| {
+            let mut view = ImageViewerView::new(ctx);
+
+            if let Some(path) = path {
+                if let Some(target_session) = target_session {
+                    if target_session.is_local() {
+                        view.open_local(path, Some(target_session), ctx);
+                    }
+                } else {
+                    let session = ActiveSession::as_ref(ctx)
+                        .session(ctx.window_id())
+                        .filter(|session| session.is_local());
+                    view.open_local(path, session, ctx);
+                }
+            }
+
+            view
+        });
+        Self::from_view(view, ctx)
+    }
+
+    pub fn image_view(&self, ctx: &AppContext) -> ViewHandle<ImageViewerView> {
+        self.view.as_ref(ctx).child(ctx)
+    }
+}
+
+impl PaneContent for ImagePane {
+    fn id(&self) -> PaneId {
+        PaneId::from_image_pane_view(&self.view)
+    }
+
+    fn attach(
+        &self,
+        _group: &PaneGroup,
+        focus_handle: crate::pane_group::focus_state::PaneFocusHandle,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        self.view
+            .update(ctx, |view, ctx| view.set_focus_handle(focus_handle, ctx));
+
+        let pane_id = self.id();
+
+        ctx.subscribe_to_view(
+            &self.image_view(ctx),
+            move |pane_group, _, event, ctx| match event {
+                ImageViewerEvent::Opened => {
+                    ctx.emit(crate::pane_group::Event::AppStateChanged)
+                }
+                ImageViewerEvent::Pane(pane_event) => {
+                    pane_group.handle_pane_event(pane_id, pane_event, ctx)
+                }
+            },
+        );
+
+        ctx.subscribe_to_view(&self.view, move |group, _, event, ctx| {
+            group.handle_pane_view_event(pane_id, event, ctx);
+        });
+    }
+
+    fn detach(
+        &self,
+        _group: &PaneGroup,
+        _detach_type: DetachType,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        let image_view = self.image_view(ctx);
+        ctx.unsubscribe_to_view(&image_view);
+        ctx.unsubscribe_to_view(&self.view);
+    }
+
+    fn snapshot(&self, app: &AppContext) -> LeafContents {
+        let path = self.image_view(app).as_ref(app).local_path();
+        LeafContents::Image { path }
+    }
+
+    fn has_application_focus(&self, ctx: &mut ViewContext<PaneGroup>) -> bool {
+        self.view.is_self_or_child_focused(ctx)
+    }
+
+    fn focus(&self, ctx: &mut ViewContext<PaneGroup>) {
+        self.image_view(ctx).update(ctx, |view, ctx| view.focus(ctx));
+    }
+
+    fn shareable_link(
+        &self,
+        _ctx: &mut ViewContext<PaneGroup>,
+    ) -> Result<ShareableLink, ShareableLinkError> {
+        Ok(ShareableLink::Base)
+    }
+
+    fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    fn is_pane_being_dragged(&self, ctx: &AppContext) -> bool {
+        self.view.as_ref(ctx).is_being_dragged()
+    }
+}

--- a/app/src/pane_group/pane/image_pane.rs
+++ b/app/src/pane_group/pane/image_pane.rs
@@ -65,6 +65,22 @@ impl ImagePane {
         Self::from_view(view, ctx)
     }
 
+    /// Create an image pane for a remote image. The pane starts in a loading state
+    /// (showing a spinner with the remote filename); the caller fetches the bytes
+    /// asynchronously and fills them in via [`ImageViewerView::open_remote`].
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    pub fn new_remote<V: View>(
+        remote_path: crate::code::buffer_location::RemotePath,
+        ctx: &mut ViewContext<V>,
+    ) -> Self {
+        let view = ctx.add_typed_action_view(move |ctx| {
+            let mut view = ImageViewerView::new(ctx);
+            view.set_loading_remote(&remote_path, ctx);
+            view
+        });
+        Self::from_view(view, ctx)
+    }
+
     pub fn image_view(&self, ctx: &AppContext) -> ViewHandle<ImageViewerView> {
         self.view.as_ref(ctx).child(ctx)
     }

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -19,6 +19,7 @@ pub(super) mod execution_profile_editor_pane;
 pub(super) mod file_pane;
 pub(super) mod get_started_pane;
 pub(super) mod get_started_view;
+pub(super) mod image_pane;
 #[cfg(not(target_family = "wasm"))]
 pub(super) mod local_harness_launch;
 pub(super) mod notebook_pane;
@@ -47,7 +48,7 @@ use crate::{
     code::view::CodeView,
     env_vars::view::env_var_collection::EnvVarCollectionView,
     menu::MenuItem,
-    notebooks::{file::FileNotebookView, notebook::NotebookView},
+    notebooks::{file::FileNotebookView, image::ImageViewerView, notebook::NotebookView},
     settings::PaneSettings,
     settings_view::SettingsView,
     terminal::{available_shells::AvailableShell, TerminalView},
@@ -139,6 +140,7 @@ pub(crate) enum IPaneType {
     Terminal,
     Notebook,
     File,
+    ImageViewer,
     Code,
     CodeDiff,
     EnvVarCollection,
@@ -165,6 +167,7 @@ impl Display for IPaneType {
             IPaneType::Terminal => write!(f, "Terminal"),
             IPaneType::Notebook => write!(f, "Notebook"),
             IPaneType::File => write!(f, "File"),
+            IPaneType::ImageViewer => write!(f, "Image Viewer"),
             IPaneType::Code => write!(f, "Code"),
             IPaneType::CodeDiff => write!(f, "Code Diff"),
             IPaneType::EnvVarCollection => write!(f, "Environment Variable Collection"),
@@ -208,6 +211,11 @@ impl PaneId {
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<FileNotebookView>>`]
     pub fn from_file_pane_ctx(ctx: &ViewContext<PaneView<FileNotebookView>>) -> Self {
         Self::new_from_ctx(IPaneType::File, ctx)
+    }
+
+    /// Creates a [`PaneId`] from a [`ViewContext<PaneView<ImageViewerView>>`]
+    pub fn from_image_pane_ctx(ctx: &ViewContext<PaneView<ImageViewerView>>) -> Self {
+        Self::new_from_ctx(IPaneType::ImageViewer, ctx)
     }
 
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<NotebookView>>`]
@@ -296,6 +304,11 @@ impl PaneId {
     /// Creates a [`PaneId`] from a [`PaneView<FileNotebookView>`] entity ID.
     pub fn from_file_pane_view(file_pane_view: &ViewHandle<PaneView<FileNotebookView>>) -> Self {
         Self::new(IPaneType::File, file_pane_view)
+    }
+
+    /// Creates a [`PaneId`] from a [`PaneView<ImageViewerView>`] entity ID.
+    pub fn from_image_pane_view(image_pane_view: &ViewHandle<PaneView<ImageViewerView>>) -> Self {
+        Self::new(IPaneType::ImageViewer, image_pane_view)
     }
 
     /// Creates a [`PaneId`] from a [`PaneView<TextView>`] entity ID.
@@ -461,6 +474,9 @@ impl PaneId {
             }
             IPaneType::File => {
                 ChildView::<PaneView<FileNotebookView>>::with_id(self.0.pane_view_id).finish()
+            }
+            IPaneType::ImageViewer => {
+                ChildView::<PaneView<ImageViewerView>>::with_id(self.0.pane_view_id).finish()
             }
             IPaneType::Code => {
                 ChildView::<PaneView<CodeView>>::with_id(self.0.pane_view_id).finish()

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -1287,6 +1287,14 @@ fn save_pane_state(
             );
             return Ok(());
         }
+        LeafContents::Image { .. } => {
+            // Image viewer panes are not persisted, logic identical to SshServer/Sftp.
+            debug_assert!(
+                false,
+                "save_pane_state called for non-persisted LeafContents variant"
+            );
+            return Ok(());
+        }
     };
 
     let leaf = model::NewPane {
@@ -1516,6 +1524,9 @@ fn save_pane_state(
             // Unreachable: filtered by `is_persisted` in `save_app_state`.
         }
         LeafContents::Sftp { .. } => {
+            // Unreachable: filtered by `is_persisted` in `save_app_state`.
+        }
+        LeafContents::Image { .. } => {
             // Unreachable: filtered by `is_persisted` in `save_app_state`.
         }
     }

--- a/app/src/server/telemetry.rs
+++ b/app/src/server/telemetry.rs
@@ -2930,6 +2930,9 @@ impl TelemetryEvent {
                         ("warp_markdown_viewer", Some(*layout), None)
                     }
                     FileTarget::CodeEditor(layout) => ("warp_code_editor", Some(*layout), None),
+                    FileTarget::ImageViewer(layout) => {
+                        ("warp_image_viewer", Some(*layout), None)
+                    }
                     FileTarget::EnvEditor => ("env_editor", None, None),
                     FileTarget::SystemDefault => ("system_default", None, None),
                     FileTarget::SystemGeneric => ("system_generic", None, None),

--- a/app/src/util/openable_file_type.rs
+++ b/app/src/util/openable_file_type.rs
@@ -45,6 +45,8 @@ pub enum FileTarget {
     MarkdownViewer(EditorLayout),
     /// Open in Zap's Code Editor.
     CodeEditor(EditorLayout),
+    /// Open in Zap's in-app image viewer.
+    ImageViewer(EditorLayout),
     /// Open in an external editor (e.g. VS Code, Emacs).
     #[cfg(feature = "local_fs")]
     ExternalEditor(Editor),
@@ -219,6 +221,11 @@ pub fn resolve_file_target_with_editor_choice(
         return FileTarget::EnvEditor;
     }
 
+    // 3.5 Image files -> in-app image viewer (before binary fallback)
+    if is_supported_image_file(path) {
+        return FileTarget::ImageViewer(layout);
+    }
+
     // 4. Binary files -> System Default
     if !is_openable_in_warp {
         return FileTarget::SystemGeneric;
@@ -290,7 +297,7 @@ mod tests {
     #[cfg(feature = "local_fs")]
     fn test_resolve_file_target_binary_is_system_generic() {
         let target = resolve_file_target_with_editor_choice(
-            Path::new("image.png"),
+            Path::new("video.mp4"),
             EditorChoice::Zap,
             true, /* prefer_markdown_viewer */
             EditorLayout::SplitPane,
@@ -298,6 +305,20 @@ mod tests {
         );
 
         assert_eq!(target, FileTarget::SystemGeneric);
+    }
+
+    #[test]
+    #[cfg(feature = "local_fs")]
+    fn test_resolve_file_target_image_uses_image_viewer() {
+        let target = resolve_file_target_with_editor_choice(
+            Path::new("photo.png"),
+            EditorChoice::Zap,
+            true, /* prefer_markdown_viewer */
+            EditorLayout::NewTab,
+            None,
+        );
+
+        assert_eq!(target, FileTarget::ImageViewer(EditorLayout::NewTab));
     }
 
     #[test]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5255,6 +5255,12 @@ impl Workspace {
             }
             #[cfg(not(feature = "local_tty"))]
             LeftPanelEvent::OpenRemoteFile { .. } => {}
+            #[cfg(feature = "local_tty")]
+            LeftPanelEvent::OpenRemoteImage { remote_path } => {
+                self.open_remote_image(remote_path.clone(), ctx);
+            }
+            #[cfg(not(feature = "local_tty"))]
+            LeftPanelEvent::OpenRemoteImage { .. } => {}
             LeftPanelEvent::OpenSkillFile { source } => {
                 #[cfg(feature = "local_fs")]
                 {
@@ -6956,7 +6962,18 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         let pane = ImagePane::new(Some(path), session, ctx);
+        self.insert_image_pane(pane, layout, ctx);
+    }
 
+    /// Insert an already-constructed [`ImagePane`] using the editor layout (new tab
+    /// vs. split). Shared by local [`Self::open_image`] and remote
+    /// [`Self::open_remote_image`].
+    fn insert_image_pane(
+        &mut self,
+        pane: ImagePane,
+        layout: EditorLayout,
+        ctx: &mut ViewContext<Self>,
+    ) {
         match layout {
             EditorLayout::NewTab => {
                 let new_tab_placement_setting = TabSettings::as_ref(ctx).new_tab_placement;
@@ -6977,6 +6994,63 @@ impl Workspace {
                 });
             }
         }
+    }
+
+    /// Open a remote image in an image viewer pane. Creates the pane immediately
+    /// (showing a loading spinner with the filename), then fetches the raw bytes
+    /// over the remote-server `ReadFileChunk` RPC and fills them in on completion.
+    #[cfg(feature = "local_tty")]
+    fn open_remote_image(
+        &mut self,
+        remote_path: crate::code::buffer_location::RemotePath,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        log::info!(
+            "Opening remote image: host={host} path={path}",
+            host = remote_path.host_id,
+            path = remote_path.path.as_str()
+        );
+
+        let host_id = remote_path.host_id.clone();
+        let Some(client) = RemoteServerManager::handle(ctx)
+            .as_ref(ctx)
+            .client_for_host(&host_id)
+            .cloned()
+        else {
+            log::warn!("No remote server client for host {host_id:?}; cannot open remote image");
+            return;
+        };
+
+        // 先建带 loading spinner 的空 pane,再异步抓字节填充(spinner-first UX)。
+        let layout = *EditorSettings::as_ref(ctx).open_file_layout.value();
+        let pane = ImagePane::new_remote(remote_path.clone(), ctx);
+        let image_view = pane.image_view(ctx);
+        self.insert_image_pane(pane, layout, ctx);
+
+        let path_str = remote_path.path.as_str().to_string();
+        ctx.spawn(
+            async move {
+                client
+                    .read_file_bytes(path_str)
+                    .await
+                    .map_err(|e| format!("{e}"))
+            },
+            move |_me, result, ctx| match result {
+                Ok(bytes) => {
+                    image_view.update(ctx, |view, ctx| {
+                        view.open_remote(&remote_path, &bytes, ctx);
+                    });
+                }
+                Err(error) => {
+                    // 不开空白 pane —— pane 已显示 loading,这里只记录失败,避免像
+                    // `open_remote_buffer` 那样把所有错误抹成 DoesNotExist。
+                    log::warn!(
+                        "Failed to load remote image {path}: {error}",
+                        path = remote_path.path.as_str()
+                    );
+                }
+            },
+        );
     }
 
     fn attach_path_as_context(&mut self, path: PathBuf, ctx: &mut ViewContext<Self>) {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5191,6 +5191,10 @@ impl Workspace {
                 let open_as_preview = false;
                 self.open_code(code_source, layout, line_col, open_as_preview, &[], ctx);
             }
+            FileTarget::ImageViewer(_layout) => {
+                // Temporary fallback until ImagePane dispatch is wired up (Stage 1, step 4).
+                ctx.open_file_path(&path);
+            }
             FileTarget::ExternalEditor(editor) => {
                 crate::util::file::open_file_path_with_editor(
                     line_col,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -218,6 +218,7 @@ use crate::network::{NetworkStatus, NetworkStatusEvent};
 use crate::notebooks::manager::{NotebookManager, NotebookSource};
 #[cfg(feature = "local_fs")]
 use crate::pane_group::FilePane;
+use crate::pane_group::ImagePane;
 use crate::pane_group::{
     self, AnyPaneContent, CodeDiffPane, CodePane, Direction, NewTerminalOptions, PanesLayout,
     TabBarHoverIndex,
@@ -5191,9 +5192,8 @@ impl Workspace {
                 let open_as_preview = false;
                 self.open_code(code_source, layout, line_col, open_as_preview, &[], ctx);
             }
-            FileTarget::ImageViewer(_layout) => {
-                // Temporary fallback until ImagePane dispatch is wired up (Stage 1, step 4).
-                ctx.open_file_path(&path);
+            FileTarget::ImageViewer(layout) => {
+                self.open_image(path.clone(), self.get_active_session(ctx), layout, ctx);
             }
             FileTarget::ExternalEditor(editor) => {
                 crate::util::file::open_file_path_with_editor(
@@ -6931,6 +6931,37 @@ impl Workspace {
                 let new_idx = match new_tab_placement_setting {
                     NewTabPlacement::AfterAllTabs => self.tab_count(),
                     // Add tab after current tab
+                    NewTabPlacement::AfterCurrentTab => self.active_tab_index + 1,
+                };
+                self.add_tab_from_existing_pane(Box::new(pane), new_idx, ctx);
+            }
+            EditorLayout::SplitPane => {
+                self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+                    pane_group.add_pane_with_direction(
+                        Direction::Right,
+                        pane,
+                        true, /* focus_new_pane */
+                        ctx,
+                    );
+                });
+            }
+        }
+    }
+
+    fn open_image(
+        &mut self,
+        path: PathBuf,
+        session: Option<Arc<Session>>,
+        layout: EditorLayout,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let pane = ImagePane::new(Some(path), session, ctx);
+
+        match layout {
+            EditorLayout::NewTab => {
+                let new_tab_placement_setting = TabSettings::as_ref(ctx).new_tab_placement;
+                let new_idx = match new_tab_placement_setting {
+                    NewTabPlacement::AfterAllTabs => self.tab_count(),
                     NewTabPlacement::AfterCurrentTab => self.active_tab_index + 1,
                 };
                 self.add_tab_from_existing_pane(Box::new(pane), new_idx, ctx);

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -112,6 +112,11 @@ pub enum LeftPanelEvent {
     OpenRemoteFile {
         remote_path: crate::code::buffer_location::RemotePath,
     },
+    /// 用户在远端文件树里点击一个图片 → 主窗口应以远端图片查看器打开它。
+    #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
+    OpenRemoteImage {
+        remote_path: crate::code::buffer_location::RemotePath,
+    },
     NewConversationInNewTab,
     ShowDeleteConfirmationDialog {
         conversation_id: AIConversationId,
@@ -947,6 +952,14 @@ impl LeftPanelView {
             FileTreeEvent::OpenRemoteFile { remote_path } => {
                 #[cfg(feature = "local_tty")]
                 ctx.emit(LeftPanelEvent::OpenRemoteFile {
+                    remote_path: remote_path.clone(),
+                });
+                #[cfg(not(feature = "local_tty"))]
+                let _ = remote_path;
+            }
+            FileTreeEvent::OpenRemoteImage { remote_path } => {
+                #[cfg(feature = "local_tty")]
+                ctx.emit(LeftPanelEvent::OpenRemoteImage {
                     remote_path: remote_path.clone(),
                 });
                 #[cfg(not(feature = "local_tty"))]

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3244,7 +3244,8 @@ impl PaneGroup {
             IPaneType::AIFact => TypedPane::AIFact,
             IPaneType::AIDocument => TypedPane::AIDocument,
             IPaneType::ExecutionProfileEditor => TypedPane::ExecutionProfileEditor,
-            IPaneType::GetStarted
+            IPaneType::ImageViewer
+            | IPaneType::GetStarted
             | IPaneType::SshServer
             | IPaneType::Sftp
             | IPaneType::Welcome

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -14,7 +14,8 @@ use crate::proto::{
     CreateDirectory, CreateDirectoryResponse, DeleteFile, ErrorCode, Initialize,
     InitializeResponse, ListDirectory, ListDirectoryResponse, LoadRepoMetadataDirectoryResponse,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileChunk,
-    ReadFileChunkResponse, ReadFileContextRequest, ReadFileContextResponse, ResolveConflict,
+    read_file_chunk_response, ReadFileChunkResponse, ReadFileContextRequest,
+    ReadFileContextResponse, ResolveConflict,
     ResolveConflictResponse, ResolvePath, ResolvePathResponse, RunCommandRequest,
     RunCommandResponse, SaveBuffer, SaveBufferResponse, ServerMessage, SessionBootstrapped,
     TextEdit, WriteFile, WriteFileChunk, WriteFileChunkResponse,
@@ -459,6 +460,36 @@ impl RemoteServerClient {
                 Err(ClientError::UnexpectedResponse)
             }
         }
+    }
+
+    /// Reads an entire remote file by looping [`Self::read_file_chunk`] until EOF.
+    ///
+    /// Accumulates each chunk into a single buffer, advancing `offset` by the
+    /// server-reported `next_offset`, until a chunk signals `eof`. Used by the
+    /// in-app image viewer to fetch raw image bytes for `AssetSource::Raw`.
+    pub async fn read_file_bytes(&self, path: String) -> Result<Vec<u8>, ClientError> {
+        // 服务端单块上限 8 MiB(`handle_read_file_chunk`)。客户端按 4 MiB 请求,
+        // 远低于 64 MiB 消息上限,给 framing 留足余量。
+        const CHUNK_SIZE: u64 = 4 * 1024 * 1024;
+
+        let mut bytes = Vec::new();
+        let mut offset = 0u64;
+        loop {
+            let response = self.read_file_chunk(path.clone(), offset, CHUNK_SIZE).await?;
+            let success = match response.result {
+                Some(read_file_chunk_response::Result::Success(success)) => success,
+                Some(read_file_chunk_response::Result::Error(err)) => {
+                    return Err(ClientError::FileOperationFailed(err.message));
+                }
+                None => return Err(ClientError::UnexpectedResponse),
+            };
+            bytes.extend_from_slice(&success.bytes);
+            offset = success.next_offset;
+            if success.eof {
+                break;
+            }
+        }
+        Ok(bytes)
     }
 
     /// Writes a byte range to a remote file.


### PR DESCRIPTION
Opening an image from the file tree now routes to an in-app image pane instead of an external app, for both local files and remote (SSH) files.

## What's included
- Read-only `ImageViewerView` (`app/src/notebooks/image/`)
- `ImagePane` with `IPaneType::ImageViewer` — non-persisted (image panes are not restored across restarts)
- `read_file_bytes` added to the remote client (`crates/remote_server/src/client/`)
- Remote image rendering via `AssetSource::Raw`
- File-tree / openable-file-type routing of images to the in-app target (local and remote)

## Scope
15 files, +670/-6. No branding, packaging, or other fork-specific changes are included — this is the image-viewer feature only.

## Verification
Built and click-tested locally on the fork (local and remote image open). Cherry-picked cleanly onto `main` with no conflicts.