### PR TITLE
fix(wsl): fix tab completion for non-/mnt/ WSL paths

### DIFF
--- a/crates/warp_util/src/path.rs
+++ b/crates/warp_util/src/path.rs
@@ -474,7 +474,7 @@ pub fn convert_wsl_to_windows_host_path(
             for component in unix_path
                 .with_windows_encoding()
                 .components()
-                .skip_while(|component| *component == TypedComponent::Unix(UnixComponent::RootDir))
+                .skip(1)
             {
                 windows_path.push(component.as_bytes());
             }


### PR DESCRIPTION
## 関連 Issue

Fixes #232

## 問題点（根因）

`crates/warp_util/src/path.rs:477` の `convert_wsl_to_windows_host_path` 関数内、WSL 非 `/mnt/` パス（`/home/user` など）を処理する `_ =>` ブランチに誤った `skip_while` 条件が存在した。

```rust
// 修正前（バグ）
for component in unix_path
    .with_windows_encoding()
    .components()
    .skip_while(|component| *component == TypedComponent::Unix(UnixComponent::RootDir))
```

`unix_path.with_windows_encoding()` は Windows エンコードの `TypedPathBuf`（**Windows 型**）を返す。そのコンポーネントは `TypedComponent::Windows(WindowsComponent::RootDir)` だが、`skip_while` は `TypedComponent::Unix(UnixComponent::RootDir)` と比較しており、条件が永遠に一致しない。

その結果、ルートディレクトリコンポーネント（`\`）がスキップされずに UNC パス `\\WSL$\<distro>` に push される。これにより `windows_path` が不正な形式となり、`PathBuf::try_from(windows_path)` が失敗して `WSLPathConversionError::CouldNotConvertToPath` を返す。その結果、タブ補完が動作せずユーザーに `WARN Failed to convert path: Could not convert TypedPathBuf to std::path::PathBuf` が表示される。

## 複現証拠

- エラー発生箇所：`app/src/completer/mod.rs:65`
  ```rust
  log::warn!("Failed to convert path: {err:#}");
  ```
- `CouldNotConvertToPath` 定義：`crates/warp_util/src/path.rs:440-441`
- バグコード：`crates/warp_util/src/path.rs:474-480`

## 規模声明

| 項目 | 値 |
|---|---|
| 修改ファイル数 | **1** (`crates/warp_util/src/path.rs`) |
| 修改行数 | **1** |
| 影響面 grep 命中 | 1 定義のみ変更、呼び出し側シグネチャ変更なし |

## 修改ファイル清単

| ファイル | 行番号 | 変更内容 |
|---|---|---|
| `crates/warp_util/src/path.rs` | 477 | `.skip_while(Unix条件)` → `.skip(1)` |

```rust
// 修正後
for component in unix_path
    .with_windows_encoding()
    .components()
    .skip(1)
```

これはコードベース内の他のすべての `with_windows_encoding().components()` 呼び出しと同じパターン（`path.rs:387`, `399`, `412`, `466`）。

## 検証

```
cargo check -p warp_util → Finished (no errors)
cargo test  -p warp_util → test result: ok. 58 passed; 0 failed (+ 3 doc-tests)
```

`#[cfg(windows)]` テスト `test_convert_wsl_to_windows_host_path`（`crates/warp_util/src/path_test.rs:559`）が `/home/andy` → `\\WSL$\Ubuntu\home\andy` のケースを直接カバー。

## 影響面

`convert_wsl_to_windows_host_path` の呼び出し元はシグネチャ変更なし：
- `app/src/completer/mod.rs:62`
- `crates/ai/src/paths.rs:91`
- `crates/warp_terminal/src/shell/mod.rs:773, 802`
- `app/src/terminal/writeable_pty/bootstrap_file/windows.rs:51`
- `app/src/pane_group/mod.rs:5475`
- `app/src/terminal/local_tty/shell.rs:529`

---
_Generated by [Claude Code](https://claude.ai/code/session_013WzG2jugQfdCyU52DPE5uP)_