### PR TITLE
fix(right-panel): unsubscribe before re-subscribing on tab switch

### DIFF
--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -557,6 +557,14 @@ impl RightPanelView {
     ) {
         let pane_group_id = pane_group.id();
 
+        // Unsubscribe from the previous pane group before subscribing to the
+        // new one. Without this, every tab switch appends a duplicate
+        // subscription, causing recompute_terminal_availability to fire N
+        // times per event after N switches.
+        if let Some(prev) = &self.active_pane_group {
+            ctx.unsubscribe_to_view(prev);
+        }
+
         // Subscribe to pane group events so we can recompute terminal
         // availability when terminal state changes (e.g. command
         // starts/finishes).


### PR DESCRIPTION
## 关联 Issue

Fixes #239

## 问题点（确定性描述）

**根因**：`app/src/workspace/view/right_panel.rs:563`

`set_active_pane_group` 在每次 tab 切换时无条件调用 `ctx.subscribe_to_view(&pane_group, …)`，但从不调用 `unsubscribe_to_view` 清理旧订阅。

底层 `subscribe_to_view`（`crates/warpui_core/src/core/view/context.rs:201-216`）始终执行 `.push()`，无任何去重逻辑：

```rust
self.app
    .subscriptions
    .entry(handle.id())
    .or_default()
    .push(Subscription::FromView {   // 无去重，每次都追加
        window_id: self.window_id,
        view_id: self.view_id,
        callback: Box::new(...),
    });
```

**触发路径**：

1. 用户切换 Tab → `Workspace::activate_tab` (`view.rs:4332`)
2. → `set_active_tab_index` (`view.rs:4390`)
3. → `right_panel_view.update(…set_active_pane_group)` (`view.rs:4425-4431`)
4. → `ctx.subscribe_to_view(&pane_group, …)` (`right_panel.rs:563`) **每次追加一条新订阅**
5. 终端触发 `TerminalViewStateChanged` → 该 pane_group 的订阅 Vec 中 N 条回调各触发一次 → N × `recompute_terminal_availability` → N × `ctx.notify()` → N 次重绘

切换越多，每次终端事件触发的重绘次数线性增长，导致 UI 越来越卡顿。

## 复现证据

`app/src/workspace/view/right_panel.rs:552-577`（修复前）：

```rust
pub fn set_active_pane_group(
    &mut self,
    pane_group: ViewHandle<PaneGroup>,
    working_directories_model: &ModelHandle<WorkingDirectoriesModel>,
    ctx: &mut ViewContext<Self>,
) {
    let pane_group_id = pane_group.id();

    // 每次 tab 切换都执行，无 unsubscribe 保护
    ctx.subscribe_to_view(&pane_group, |me, _, event, ctx| {
        if matches!(event, PaneGroupEvent::TerminalViewStateChanged) {
            me.recompute_terminal_availability(ctx);  // N 次
        }
    });

    self.active_pane_group = Some(pane_group);
```

`grep -n "unsubscribe_to_view" right_panel.rs` → **无任何输出**（确认从未清理）。

## 规模声明

| 指标 | 数值 |
|------|------|
| 修改文件数 | 1 |
| 修改行数 | 8（含 4 行注释）|
| 影响面 grep 命中数 | 4 处调用 `set_active_pane_group`，均无需联动修改 |

属于小修复范围，无公共 API 变更，无新依赖，无并发/鉴权路径。

## 修改文件清单

| 文件 | 行号范围 | 改动说明 |
|------|----------|---------|
| `app/src/workspace/view/right_panel.rs` | 560-566（新增） | 在 `subscribe_to_view` 前对 `self.active_pane_group` 调用 `unsubscribe_to_view`，确保每个 pane_group 最多保留一条来自 RightPanelView 的订阅 |

## 验证

- `cargo check -p warp`：pre-existing build failure（`warp_multi_agent_api` proto build，与本次改动无关，存在于 main 分支）
- `git diff --name-only` 输出与 5.1 文件清单完全一致：`app/src/workspace/view/right_panel.rs`
- 改动逻辑验证：`unsubscribe_to_view` 通过 `(window_id, view_id)` 移除所有来自当前视图的订阅（`context.rs:237-242`），然后 `subscribe_to_view` 重新建立唯一订阅；切换到同一 pane_group 时先 unsub 再 sub，结果仍为 1 条；切换到不同 pane_group 时旧组清零，新组 1 条。

## 影响面

- 调用方（无需修改）：`view.rs:3448, 3551, 4419-4431`
- 受影响模块：`RightPanelView` 事件订阅管理
- 现有行为不变：`recompute_terminal_availability` 在 `TerminalViewStateChanged` 时仍会被调用，但每次精确调用 1 次而非 N 次

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5MRtCouHNM6HXxH34ntE3)_