### PR TITLE
fix(sftp): SFTP 文件浏览器对话框居中修复

### DIFF
--- a/app/src/sftp_manager/browser.rs
+++ b/app/src/sftp_manager/browser.rs
@@ -1860,15 +1860,9 @@ impl View for SftpBrowserView {
                 self.dialog_cancel_btn.clone(),
                 self.dialog_close_btn.clone(),
             );
-            let centered_dialog = Flex::column()
-                .with_main_axis_size(MainAxisSize::Max)
-                .with_main_axis_alignment(MainAxisAlignment::Center)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(dialog_el)
-                .finish();
             let mut stack = Stack::new();
             stack.add_child(main_content);
-            stack.add_overlay_child(centered_dialog);
+            stack.add_overlay_child(Align::new(dialog_el).finish());
             main_content = stack.finish();
         }
 


### PR DESCRIPTION
## 关联 Issue

Fixes #248

## 问题点（确定性描述）

**根因**：`app/src/sftp_manager/browser.rs:1863`（修复前行号）

`render()` 函数中，对话框覆盖层使用 `Flex::column()` 配合 `CrossAxisAlignment::Center` 包裹，但该 Flex 列的宽度仅等于子元素自然宽度（对话框最大 `DIALOG_MAX_WIDTH = 360px`），而非 SFTP 面板全宽。

Flex 在绘制时计算水平偏移（`crates/warpui_core/src/elements/flex/mod.rs:469`）：
```rust
CrossAxisAlignment::Center => parent_cross_size / 2. - child_cross_size / 2.
// = 360/2 - 360/2 = 0   →   对话框始终在 Flex 列左边缘
```

该 360px 宽的 Flex 列通过 `add_overlay_child` 被放置在 Stack 原点 `(0,0)` = 面板左上角（`crates/warpui_core/src/elements/stack/mod.rs:284`）。结果：**对话框始终固定在面板左上角，而非在面板中央显示**。

## 复现证据

`app/src/sftp_manager/browser.rs`（修复前 1852–1872 行）：

```rust
// 旧代码（有问题）
let centered_dialog = Flex::column()
    .with_main_axis_size(MainAxisSize::Max)
    .with_main_axis_alignment(MainAxisAlignment::Center)
    .with_cross_axis_alignment(CrossAxisAlignment::Center)  // 仅在 360px 内居中 → 无效
    .with_child(dialog_el)
    .finish();
let mut stack = Stack::new();
stack.add_child(main_content);
stack.add_overlay_child(centered_dialog);  // 放置在面板左上角 (0,0)
```

## 规模声明

| 指标 | 数值 |
|------|------|
| 改动文件数 | 1 |
| 净改动行数 | -6 行 |
| 影响面调用方 | 0（内联渲染逻辑） |

## 修改文件清单

| 文件 | 改动说明 |
|------|---------|
| `app/src/sftp_manager/browser.rs` | 将 `Flex::column()` 居中包裹替换为 `Align::new()`，Align 填满面板并精确居中子元素 |

```rust
// 新代码（修复后）
let mut stack = Stack::new();
stack.add_child(main_content);
stack.add_overlay_child(Align::new(dialog_el).finish());
```

`Align::new()` 的 `layout()` 返回 `constraint.max`（面板全尺寸），`paint()` 将对话框精确居中（`crates/warpui_core/src/elements/align.rs:70–106`）。与文件内既有用法（`browser.rs:1019, 1356`）一致。

## 验证

- 改动仅涉及 1 个文件，`Align` 在该文件 `use` 语句中已导入（`browser.rs:18`）
- 语法模式与文件内现有 `Align::new(...).finish()` 调用（行 1019、1356）完全一致
- 行为测试（`browser_tests.rs`、`browser_integration_tests.rs`）测试 dialog 状态逻辑，不受布局变更影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpYCAniaYCPNhgmsa6iC1J

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpYCAniaYCPNhgmsa6iC1J)_