### PR TITLE
修复 macOS GUI 启动时 CLI 智能体检测遗漏

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -3,15 +3,17 @@
 //! This module provides types for detecting and working with CLI-based AI agents
 //! like Claude Code, Gemini CLI, Codex, Amp, and Droid.
 
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::path::Path;
 use ai::skills::SkillProvider;
 use enum_iterator::Sequence;
 use markdown_parser::parse_markdown;
 use pathfinder_color::ColorU;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
+use std::borrow::Cow;
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use warp_editor::content::{buffer::Buffer, markdown::MarkdownStyle};
 
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
@@ -590,22 +592,13 @@ pub struct CLIAgentInstallModel {
 impl CLIAgentInstallModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         ctx.spawn(
-            async move {
-                enum_iterator::all::<CLIAgent>()
-                    .filter(|a| !matches!(a, CLIAgent::Unknown))
-                    .map(|a| (a, cli_agent_is_on_path(a)))
-                    .collect::<HashMap<CLIAgent, bool>>()
-            },
+            async move { scan_cli_agent_installations() },
             Self::on_scan_complete,
         );
         Self { cache: None }
     }
 
-    fn on_scan_complete(
-        &mut self,
-        results: HashMap<CLIAgent, bool>,
-        ctx: &mut ModelContext<Self>,
-    ) {
+    fn on_scan_complete(&mut self, results: HashMap<CLIAgent, bool>, ctx: &mut ModelContext<Self>) {
         self.cache = Some(results.clone());
 
         // 自动同步到 per-agent 设置
@@ -641,7 +634,97 @@ impl Entity for CLIAgentInstallModel {
 
 impl SingletonEntity for CLIAgentInstallModel {}
 
-/// 同步 PATH 搜索，检测指定 agent 是否安装。仅供 `ctx.spawn` 异步任务内部使用。
+/// 同步 PATH 搜索，检测所有 agent 是否安装。仅供 `ctx.spawn` 异步任务内部使用。
+#[cfg(unix)]
+fn scan_cli_agent_installations() -> HashMap<CLIAgent, bool> {
+    let search_dirs = cli_agent_search_dirs().collect::<Vec<_>>();
+    enum_iterator::all::<CLIAgent>()
+        .filter(|a| !matches!(a, CLIAgent::Unknown))
+        .map(|a| (a, cli_agent_is_on_path_with_dirs(a, &search_dirs)))
+        .collect()
+}
+
+/// 同步 PATH 搜索，检测所有 agent 是否安装。仅供 `ctx.spawn` 异步任务内部使用。
+#[cfg(windows)]
+fn scan_cli_agent_installations() -> HashMap<CLIAgent, bool> {
+    enum_iterator::all::<CLIAgent>()
+        .filter(|a| !matches!(a, CLIAgent::Unknown))
+        .map(|a| (a, cli_agent_is_on_path(a)))
+        .collect()
+}
+
+#[cfg(unix)]
+fn cli_agent_is_on_path_with_dirs(agent: CLIAgent, search_dirs: &[PathBuf]) -> bool {
+    match agent {
+        CLIAgent::Unknown => false,
+        CLIAgent::CursorCli => is_on_path_in_dirs("cursor-agent", search_dirs),
+        CLIAgent::DeepSeek => {
+            is_on_path_in_dirs("deepseek", search_dirs)
+                || is_on_path_in_dirs("deepseek-tui", search_dirs)
+        }
+        other => is_on_path_in_dirs(other.command_prefix(), search_dirs),
+    }
+}
+
+/// 内联 PATH 搜索，零进程、零闪窗。
+#[cfg(unix)]
+fn is_on_path_in_dirs(cmd: &str, search_dirs: &[PathBuf]) -> bool {
+    search_dirs.iter().any(|dir| dir.join(cmd).is_file())
+}
+
+#[cfg(unix)]
+fn cli_agent_search_dirs() -> impl Iterator<Item = PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Some(path_var) = std::env::var_os("PATH") {
+        dirs.extend(std::env::split_paths(&path_var));
+    }
+
+    extend_common_cli_dirs(&mut dirs);
+    dedupe_paths(dirs).into_iter()
+}
+
+#[cfg(unix)]
+fn extend_common_cli_dirs(dirs: &mut Vec<PathBuf>) {
+    dirs.extend([
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/opt/homebrew/sbin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/usr/local/sbin"),
+    ]);
+
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return;
+    };
+
+    dirs.extend([
+        home.join(".cargo/bin"),
+        home.join(".bun/bin"),
+        home.join(".local/bin"),
+    ]);
+
+    if let Ok(node_versions) = std::fs::read_dir(home.join(".nvm/versions/node")) {
+        dirs.extend(
+            node_versions
+                .filter_map(Result::ok)
+                .map(|entry| entry.path().join("bin")),
+        );
+    }
+}
+
+#[cfg(unix)]
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::with_capacity(paths.len());
+    let mut deduped = Vec::with_capacity(paths.len());
+    for path in paths {
+        if seen.insert(path.clone()) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+#[cfg(windows)]
 fn cli_agent_is_on_path(agent: CLIAgent) -> bool {
     match agent {
         CLIAgent::Unknown => false,
@@ -649,15 +732,6 @@ fn cli_agent_is_on_path(agent: CLIAgent) -> bool {
         CLIAgent::DeepSeek => is_on_path("deepseek") || is_on_path("deepseek-tui"),
         other => is_on_path(other.command_prefix()),
     }
-}
-
-/// 内联 PATH 搜索，零进程、零闪窗。
-#[cfg(unix)]
-fn is_on_path(cmd: &str) -> bool {
-    let Ok(path_var) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path_var).any(|dir| dir.join(cmd).is_file())
 }
 
 #[cfg(windows)]

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -13,7 +13,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use warp_editor::content::{buffer::Buffer, markdown::MarkdownStyle};
 
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -7,6 +7,8 @@ use warp_editor::render::model::LineCount;
 use warp_util::path::EscapeChar;
 use warpui::App;
 
+#[cfg(unix)]
+use super::cli_agent_search_dirs;
 use super::{
     build_diff_hunk_prompt, build_review_prompt, build_selection_line_range_prompt,
     build_selection_substring_prompt, CLIAgent, UBER_TEAM_UID,
@@ -510,4 +512,26 @@ fn test_detect_aifx_agent_run_claude_wrong_team() {
             );
         });
     });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_agent_search_dirs_include_common_gui_app_paths() {
+    let dirs: Vec<PathBuf> = cli_agent_search_dirs().collect();
+
+    assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin")));
+    assert!(dirs.contains(&PathBuf::from("/usr/local/bin")));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_agent_search_dirs_include_home_managed_bins() {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return;
+    };
+    let dirs: Vec<PathBuf> = cli_agent_search_dirs().collect();
+
+    assert!(dirs.contains(&home.join(".cargo/bin")));
+    assert!(dirs.contains(&home.join(".bun/bin")));
+    assert!(dirs.contains(&home.join(".local/bin")));
 }


### PR DESCRIPTION
## 背景

macOS 上从 Finder、Dock 等图形界面启动 Zap 时，进程继承到的 PATH 可能只有：

```text
/usr/bin:/bin:/usr/sbin:/sbin
```

这会导致已经通过 Homebrew、Cargo、Bun 或 nvm 安装的 CLI 智能体无法被识别，例如：

- `/opt/homebrew/bin/codex`
- `~/.nvm/versions/node/*/bin/claude`

最终表现为设置页里「已安装的智能体」为空。

## 改动

- 保留原有的 PATH 扫描逻辑。
- 在 Unix/macOS 下额外补扫常见 CLI 安装目录：
  - `/opt/homebrew/bin`
  - `/opt/homebrew/sbin`
  - `/usr/local/bin`
  - `/usr/local/sbin`
  - `~/.cargo/bin`
  - `~/.bun/bin`
  - `~/.local/bin`
  - `~/.nvm/versions/node/*/bin`
- 对扫描目录先去重并复用同一份目录列表，避免每个 agent 重复遍历 nvm 版本目录。
- 增加测试覆盖常见 GUI App 启动场景下应包含的扫描目录。

## 验证

- 本地已确认问题原因：Zap 进程 PATH 为 `/usr/bin:/bin:/usr/sbin:/sbin` 时会漏检 Homebrew/nvm 安装的 `codex` 和 `claude`。
- 已通过：

```bash
cargo test -p warp terminal::cli_agent --lib --features gui
```

结果：`130 passed; 0 failed`。