### PR TITLE
fix(window): resolve titlebar freezing and resizing issues on macOS 27

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -300,6 +300,15 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     window.titleVisibility = hideTitleBar ? NSWindowTitleHidden : NSWindowTitleVisible;
 }
 
+@interface NSWindow (PrivateAPI)
+- (NSInteger)_resizeDirectionForMouseLocation:(NSPoint)location;
+@end
+
+@interface WarpWindow ()
+- (NSButton *)standardWindowButtonAtEvent:(NSEvent *)event;
+- (BOOL)eventIsOverResizeEdge:(NSEvent *)event;
+@end
+
 @implementation WarpWindow {
     // The windowState is managed on the Rust side.
     void *windowState;
@@ -316,6 +325,7 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     // macOS from cascading or clamping the window position while a tab-drag preview window is
     // being created and positioned under the cursor.
     BOOL _suppressFrameConstraintsDuringDrag;
+    BOOL _leftMouseDownStartedInNativeWindowChrome;
 }
 
 @synthesize testMode;
@@ -385,8 +395,49 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     return [super constrainFrameRect:frameRect toScreen:screen];
 }
 
+- (NSButton *)standardWindowButtonAtEvent:(NSEvent *)event {
+    NSWindowButton buttons[] = {
+        NSWindowCloseButton,
+        NSWindowMiniaturizeButton,
+        NSWindowZoomButton,
+    };
+
+    for (NSUInteger i = 0; i < sizeof(buttons) / sizeof(buttons[0]); i++) {
+        NSButton *button = [self standardWindowButton:buttons[i]];
+        if (button && !button.hidden) {
+            NSPoint point = [button convertPoint:event.locationInWindow fromView:nil];
+            if (NSPointInRect(point, button.bounds)) {
+                return button;
+            }
+        }
+    }
+
+    return nil;
+}
+
+- (BOOL)eventIsOverResizeEdge:(NSEvent *)event {
+    if ((self.styleMask & NSWindowStyleMaskResizable) == 0) {
+        return NO;
+    }
+    if ([self respondsToSelector:@selector(_resizeDirectionForMouseLocation:)]) {
+        return [self _resizeDirectionForMouseLocation:event.locationInWindow] != -1;
+    }
+    return NO;
+}
+
 - (void)sendEvent:(NSEvent *)event {
     switch (event.type) {
+        case NSEventTypeLeftMouseDown: {
+            NSButton *windowButton = [self standardWindowButtonAtEvent:event];
+            if (windowButton) {
+                _leftMouseDownStartedInNativeWindowChrome = NO;
+                [windowButton mouseDown:event];
+                break;
+            }
+            _leftMouseDownStartedInNativeWindowChrome = [self eventIsOverResizeEdge:event];
+            [super sendEvent:event];
+            break;
+        }
         // In some cases, NSWindow's default sendEvent: implementation will dispatch a MouseDown
         // event and subsequent MouseDragged events to the content view, but then dispatch the
         // remaining MouseDragged events and MouseUp event elsewhere.
@@ -396,10 +447,19 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
         // This breaks drag-and-drop for panes and tabs (see CLD-2581), so we work around it with
         // custom dispatching.
         case NSEventTypeLeftMouseUp:
-            [self.contentView mouseUp:event];
+            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
+                [super sendEvent:event];
+            } else {
+                [self.contentView mouseUp:event];
+            }
+            _leftMouseDownStartedInNativeWindowChrome = NO;
             break;
         case NSEventTypeLeftMouseDragged:
-            [self.contentView mouseDragged:event];
+            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
+                [super sendEvent:event];
+            } else {
+                [self.contentView mouseDragged:event];
+            }
             break;
 
         // The NSWindow's default sendEvent: implementation does not propagate RightMouseDown events


### PR DESCRIPTION
## Description / 描述

This PR fixes a severe windowing regression on macOS 27 (Developer Beta) where the custom titlebar window hit-testing fails. As a result, users cannot resize Zap windows from the edges, and the native traffic-light controls (close, minimize, zoom) are completely unresponsive to clicks.
本 PR 修复了 macOS 27 (Developer Beta) 上一个严重的窗口管理回归问题，该问题导致自定义标题栏窗口的点选测试（hit-testing）失败。因此，用户无法通过边缘调整 Zap 窗口的大小，且原生的红绿灯控制按钮（关闭、最小化、缩放）对点击完全没有反应。

This is a backport / port of the upstream fix from Warp (`#12389`). Huge thanks and credit to @dappermint for the original fix and root cause analysis in the upstream repository!
这是对 Warp 上游修复（`#12389`）的向后移植 / 移植。非常感谢 @dappermint 在上游仓库中所做的原始修复和根本原因分析！

* Fixes the custom titlebar hit-testing issue on macOS 27. / 修复了 macOS 27 上的自定义标题栏点选测试（hit-testing）问题。
* Restores mouse click events for window controls and edge resizing. / 恢复了窗口控制按钮和边缘调整大小的鼠标点击事件。

---

## Testing / 测试

* **Manual Verification:** Compiled and tested locally on macOS 27. Verified that window resizing works from all four edges/corners, and the native close, minimize, and maximize buttons function correctly.
**手动验证：** 在 macOS 27 上进行了本地编译和测试。已验证从所有四个边缘/角落调整窗口大小均能正常工作，且原生的关闭、最小化和最大化按钮功能正常。
* **Automated Tests:** No new automated tests were added, as this bug involves OS-level window framework integration and mouse event hit-testing specific to the macOS 27 beta environment, which cannot be easily replicated in the current CI/CD headless environment.
**自动化测试：** 未添加新的自动化测试，因为该错误涉及操作系统级别的窗口框架集成以及特定于 macOS 27 Beta 环境的鼠标事件点选测试（hit-testing），这在当前的 CI/CD 无头（headless）环境中不易复制。

---

## Server API dependencies / 服务器 API 依赖关系

---

## Agent Mode / 智能体模式

* [ ] Zap Agent Mode - This PR was created via Zap's AI Agent Mode / Zap 智能体模式 - 此 PR 是通过 Zap 的 AI 智能体模式创建的

---

## Changelog Entries for Stable / Stable 版本变更日志条目

CHANGELOG-BUG-FIX: Fixed an issue on macOS 27 where the window could not be resized and traffic-light controls were unresponsive. / 修复了 macOS 27 上的一个问题：该问题导致窗口无法调整大小，且红绿灯控制按钮无响应。