### PR TITLE
fix(byop): chat_stream genai Client ignores proxy_mode=Off, requests leak through system proxy

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -2879,14 +2879,28 @@ pub(super) fn build_client(
         ..WebConfig::default()
     };
     let proxy_cfg = current_proxy_config();
-    if proxy_cfg.mode == http_client::ProxyMode::Custom && !proxy_cfg.url.is_empty() {
-        if let Err(err) = web_config.set_proxy_settings(
-            &proxy_cfg.url,
-            &proxy_cfg.username,
-            &proxy_cfg.password,
-            &proxy_cfg.no_proxy,
-        ) {
-            log::warn!("[byop] proxy URL '{}' 无效,跳过代理配置: {err}", proxy_cfg.url);
+    match proxy_cfg.mode {
+        http_client::ProxyMode::Off => {
+            // 完全禁用代理（含系统代理和环境变量），与
+            // http_client::Client::new() 的 Off 行为对齐。
+            web_config.no_proxy = true;
+        }
+        http_client::ProxyMode::System => {
+            // 跟随系统/环境变量代理（reqwest 默认行为）。
+            // WebConfig 不设 proxy → reqwest 读 macOS SystemConfiguration
+            // 或环境变量 HTTP_PROXY / HTTPS_PROXY。
+        }
+        http_client::ProxyMode::Custom => {
+            if !proxy_cfg.url.is_empty() {
+                if let Err(err) = web_config.set_proxy_settings(
+                    &proxy_cfg.url,
+                    &proxy_cfg.username,
+                    &proxy_cfg.password,
+                    &proxy_cfg.no_proxy,
+                ) {
+                    log::warn!("[byop] proxy URL '{}' 无效,跳过代理配置: {err}", proxy_cfg.url);
+                }
+            }
         }
     }
     Client::builder()

--- a/lib/rust-genai/src/client/web_config.rs
+++ b/lib/rust-genai/src/client/web_config.rs
@@ -24,6 +24,11 @@ pub struct WebConfig {
 	pub read_timeout: Option<Duration>,
 	pub default_headers: Option<reqwest::header::HeaderMap>,
 	pub proxy: Option<reqwest::Proxy>,
+	/// When true, disable automatic proxy discovery (system proxy, env vars).
+	/// Calls `reqwest::ClientBuilder::no_proxy()`. If an explicit `proxy` is
+	/// also set on this config, the explicit proxy still takes effect.
+	/// Default: false.
+	pub no_proxy: bool,
 	/// Enable gzip response decompression. **Default: false** (Zap fork
 	/// — upstream genai default is true). See struct-level docs for rationale.
 	pub gzip: bool,
@@ -39,6 +44,7 @@ impl Default for WebConfig {
 			read_timeout: None,
 			default_headers: None,
 			proxy: None,
+			no_proxy: false,
 			// Zap: gzip off by default — see struct-level docs above.
 			gzip: false,
 			tcp_nodelay: true,
@@ -129,6 +135,9 @@ impl WebConfig {
 		}
 		if let Some(ref headers) = self.default_headers {
 			builder = builder.default_headers(headers.clone());
+		}
+		if self.no_proxy {
+			builder = builder.no_proxy();
 		}
 		if let Some(ref proxy) = self.proxy {
 			builder = builder.proxy(proxy.clone());


### PR DESCRIPTION
## Problem

When ZAP global `proxy_mode` is `Off`, BYOP streaming requests still go through the macOS system proxy, causing **502 Bad Gateway** for internal model endpoints.

## Root Cause

`build_client()` only handles `ProxyMode::Custom`. `Off` and `System` are silently ignored, so `WebConfig.proxy` stays `None`. genai's internal `reqwest::ClientBuilder` falls back to reading macOS SystemConfiguration, routing requests through the system proxy.

Meanwhile, `http_client::Client::new()` correctly handles all three modes via `current_proxy_config().apply(builder)`.

## Fix

Two-file change:

### `lib/rust-genai/src/client/web_config.rs`
- Add `no_proxy: bool` field to `WebConfig` (default `false`, backward compatible)
- In `apply_to_builder()`: if `no_proxy` is `true`, call `builder.no_proxy()`

### `app/src/ai/agent_providers/chat_stream.rs`
- Replace `if Custom` branch with complete `match` on all three `ProxyMode` variants:
  - **Off** → `web_config.no_proxy = true`
  - **System** → no-op (reqwest default)
  - **Custom** → existing logic unchanged