### PR TITLE
fix(ssh-manager): prevent folder name overflow in sidebar

### DIFF
--- a/app/src/ssh_manager/panel.rs
+++ b/app/src/ssh_manager/panel.rs
@@ -1522,7 +1522,7 @@ impl SshManagerPanel {
             )
             .with_child(chevron_el)
             .with_child(icon_el)
-            .with_child(label_or_editor)
+            .with_child(warpui::elements::Shrinkable::new(1.0, label_or_editor).finish())
             .with_main_axis_size(MainAxisSize::Max)
             .finish();
 


### PR DESCRIPTION
## 关联 Issue

Fixes #266

## 问题点（确定性描述）

`app/src/ssh_manager/panel.rs:1525` — `render_row()` 中，节点名称文本元素（`Text::new_inline`）直接作为 child 加入 `Flex::row()`，未经 `Shrinkable` 包裹：

```rust
// 改前（1525 行）
.with_child(label_or_editor)
```

在 `MainAxisSize::Max` 的 Flex 行中，未经 `Shrinkable` 约束的 `Text` 元素会要求其自然宽度（全文字串宽度），从而溢出侧边栏右边界。

## 复现证据

`app/src/ssh_manager/panel.rs:1504-1512`（文本构建，无宽度约束）：
```rust
Text::new_inline(
    node.name.clone(),
    appearance.ui_font_family(),
    appearance.ui_font_subheading(),
)
.with_color(theme.main_text_color(theme.background()).into())
.finish()
```

对比 `app/src/drive/index.rs:1203`（Drive 面板对长文本的处理方式）：
```rust
.with_child(Shrinkable::new(1., title).finish());
```

## 规模声明

| 指标 | 值 |
|---|---|
| 修改文件数 | 1 |
| 修改行数 | 1 |
| 影响面 grep 命中数 | 1（`label_or_editor` 仅在 panel.rs 内） |

属于小修复范围，无公共 API 变更，无依赖变更。

## 修改文件清单

- `app/src/ssh_manager/panel.rs` 第 1525 行：将 `label_or_editor` 用 `warpui::elements::Shrinkable::new(1.0, ...).finish()` 包裹，使其在 Flex 行中弹性收缩至可用空间内。

```rust
// 改后
.with_child(warpui::elements::Shrinkable::new(1.0, label_or_editor).finish())
```

## 验证

```
cargo test -p warp ssh_manager::panel -- --test-threads=4

running 20 tests
test ssh_manager::panel::tests::depths_empty_nodes ... ok
test ssh_manager::panel::tests::depths_single_root ... ok
test ssh_manager::panel::tests::depths_multiple_roots ... ok
test ssh_manager::panel::tests::depths_nested_tree ... ok
test ssh_manager::panel::tests::parent_deeply_nested_folder_selected_returns_immediate_parent ... ok
test ssh_manager::panel::tests::parent_empty_nodes_with_selection_returns_none ... ok
test ssh_manager::panel::tests::parent_folder_selected_returns_folder_id ... ok
test ssh_manager::panel::tests::parent_invalid_selected_id_returns_none ... ok
test ssh_manager::panel::tests::parent_no_selection_returns_none ... ok
test ssh_manager::panel::tests::parent_server_at_root_selected_returns_none ... ok
test ssh_manager::panel::tests::parent_server_under_folder_selected_returns_folder_id ... ok
test ssh_manager::panel::tests::sort_empty ... ok
test ssh_manager::panel::tests::sort_keeps_orphaned_existing_nodes_visible_as_roots ... ok
test ssh_manager::panel::tests::sort_deeply_nested ... ok
test ssh_manager::panel::tests::sort_multiple_roots_by_sort_order ... ok
test ssh_manager::panel::tests::sort_respects_parent_child_order ... ok
test ssh_manager::panel::tests::sort_preserves_existing_folder_children_in_tree_order ... ok
test ssh_manager::panel::tests::sort_multiple_roots_with_children ... ok
test ssh_manager::panel::tests::sort_single_root ... ok
test ssh_manager::panel::tests::panel_content_can_scroll_when_ssh_list_is_taller_than_panel ... ok

test result: ok. 20 passed; 0 failed; 0 ignored
```

## 影响面

- 受影响模块：`app/src/ssh_manager/panel.rs`（仅 `render_row` 内部）
- 调用方：`render_tree()` → `render_row()` — 纯 UI 渲染路径，无数据逻辑变更
- 重命名态（`is_renaming` 分支）使用 `ConstrainedBox::new(input).with_width(180.0)` 已有宽度约束，不受影响

---
_Generated by [Claude Code](https://claude.ai/code/session_014zkTCGjff6v8tTzi5SWBZP)_