### PR TITLE
fix: use UI language setting in prompt suggestions

### DIFF
--- a/app/src/ai/agent_providers/active_ai/mod.rs
+++ b/app/src/ai/agent_providers/active_ai/mod.rs
@@ -23,6 +23,8 @@ use super::oneshot::{
     OneshotConfig, OneshotOptions,
 };
 use crate::ai::predict::generate_am_query_suggestions::GenerateAMQuerySuggestionsResponse;
+use crate::settings::language::{Language, LanguageSettings};
+use warpui::SingletonEntity;
 
 pub mod parsing;
 
@@ -150,7 +152,21 @@ pub mod prompt_suggestions {
         input: Input,
     ) -> Option<RenderedRequest> {
         let cfg = resolve_active_ai_oneshot(app, terminal_view_id)?;
-        let system = render("prompt_suggestions_system.j2", context! {});
+        let language = *LanguageSettings::as_ref(app).language;
+        let language_str = match language {
+            Language::System => match crate::i18n::current_languages().first() {
+                Some(li) if li.language.as_str() == "zh" => "Simplified Chinese".to_string(),
+                Some(li) if li.language.as_str() == "ja" => "Japanese".to_string(),
+                Some(li) if li.language.as_str() == "en" => "English".to_string(),
+                _ => "English".to_string(),
+            },
+            Language::English => "English".to_string(),
+            Language::SimplifiedChinese => "Simplified Chinese".to_string(),
+            Language::Japanese => "Japanese".to_string(),
+        };
+        let system = render("prompt_suggestions_system.j2", context! {
+            language => language_str,
+        });
         let user = render(
             "prompt_suggestions_user.j2",
             context! {
@@ -445,5 +461,47 @@ pub mod next_command {
             log::warn!("[active_ai] next_command sanitize REJECTED raw response");
         }
         sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_suggestions_renders_language_directive() {
+        // Verify that the template renders the explicit language directive
+        // for each supported UI language. The Rust code maps Language::System
+        // to one of these three strings; anything else falls back to English.
+        let cases = [
+            ("English", "Respond in English."),
+            ("Simplified Chinese", "Respond in Simplified Chinese."),
+            ("Japanese", "Respond in Japanese."),
+        ];
+
+        for (input_lang, expected_directive) in &cases {
+            let rendered = render("prompt_suggestions_system.j2", context! {
+                language => input_lang,
+            });
+            assert!(
+                rendered.contains(expected_directive),
+                "Expected '{}' in rendered prompt for language '{}', but got:\n{}",
+                expected_directive,
+                input_lang,
+                rendered
+            );
+        }
+    }
+
+    #[test]
+    fn prompt_suggestions_has_no_chinese_examples() {
+        let rendered = render("prompt_suggestions_system.j2", context! {
+            language => "English",
+        });
+        assert!(
+            !rendered.contains("查看") && !rendered.contains("解决") && !rendered.contains("修复"),
+            "Prompt should not contain Chinese example text, but got:\n{}",
+            rendered
+        );
     }
 }

--- a/app/src/ai/agent_providers/prompts/active_ai/prompt_suggestions_system.j2
+++ b/app/src/ai/agent_providers/prompts/active_ai/prompt_suggestions_system.j2
@@ -1,8 +1,8 @@
 You are inside a terminal emulator. The user just finished a command.
 Predict the single most useful follow-up — OR stay silent.
 
-Output: ONLY one JSON object, no markdown / commentary. Match the user's
-language (English / 中文 / …). Strictly valid JSON. No trailing commas,
+Output: ONLY one JSON object, no markdown / commentary. Respond in {{ language }}.
+Strictly valid JSON. No trailing commas,
 no comments.
 
 Schemas:
@@ -56,7 +56,7 @@ Hard limits:
   $ ls -la /var/log/nginx
   -rw-r--r-- … error.log
   -rw-r--r-- … access.log
-  → {"kind":"simple","query":"查看 nginx error.log 最近 50 行","should_plan_task":false}
+  → {"kind":"simple","query":"View last 50 lines of nginx error.log","should_plan_task":false}
   (signal: concrete log filenames in a project-relevant path)
 
   $ git status
@@ -66,12 +66,12 @@ Hard limits:
   $ git status
   Unmerged paths:
     both modified: src/auth.ts
-  → {"kind":"simple","query":"解决 src/auth.ts 的合并冲突","should_plan_task":false}
+  → {"kind":"simple","query":"Resolve merge conflict in src/auth.ts","should_plan_task":false}
 
   $ pytest
   exit=1
   tests/test_auth.py::test_login FAILED
-  → {"kind":"coding","query":"修复 test_login 的断言失败","files":["tests/test_auth.py"]}
+  → {"kind":"coding","query":"Fix assertion failure in test_login","files":["tests/test_auth.py"]}
 
   $ cargo build
   exit=0  Compiling …  Finished `dev` in 4.21s
@@ -80,11 +80,11 @@ Hard limits:
   $ docker ps
   CONTAINER ID  …  STATUS              NAMES
   abc123…       …  Exited (1) 2m ago   redis-cache
-  → {"kind":"simple","query":"查看 redis-cache 退出日志并重启","should_plan_task":false}
+  → {"kind":"simple","query":"Check redis-cache exit logs and restart","should_plan_task":false}
 
   $ git push
   exit=1  ! [rejected]  main -> main (non-fast-forward)
-  → {"kind":"simple","query":"先 rebase 远端 main 再重推","should_plan_task":false}
+  → {"kind":"simple","query":"Rebase remote main first then force push","should_plan_task":false}
 
   $ cat README.md
   → {"kind":"none"}


### PR DESCRIPTION
This PR fixes the AI inline suggestions ignoring the user's UI language setting.

**Problem:**
- The `prompt_suggestions_system.j2` template contained Chinese examples and an ambiguous instruction to `Match the user's language`.
- The model (e.g. Kimi via Moonshot AI, GLM5.1 via Z.ai) consistently output Chinese suggestions because all few-shot examples were in Chinese.
- The template did not receive the actual UI language from the application settings.

**Changes:**
1. Read the user's UI language from `LanguageSettings` and pass it to the prompt template via a `language` variable.
2. Replace the ambiguous instruction with an explicit `Respond in {{ language }}.` directive.
3. Translate all Chinese example queries in the few-shot prompts to English.

**Fixes:** #191
