### PR TITLE
修复 SSH/CLI subagent 历史终端输出与返回卡片丢失

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1,8 +1,8 @@
 use crate::ai::agent::comment::CodeReview;
-use crate::ai::blocklist::block::cli_controller::LongRunningCommandControlState;
 use crate::ai::agent::linearization::compute_task_depths;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
+use crate::ai::blocklist::block::cli_controller::LongRunningCommandControlState;
 use crate::ai::blocklist::{RequestInput, ResponseStreamId, SerializedBlockListItem};
 use crate::ai::byop_readiness::RepairStateStatus;
 use crate::code_review::CodeReviewTelemetryEvent;
@@ -624,6 +624,45 @@ impl AIConversation {
             self.task_store.modify_task(&task_id, |task| {
                 task.reassign_exchange_ids();
             });
+        }
+    }
+
+    fn is_default_restored_timestamp(timestamp: DateTime<Local>) -> bool {
+        timestamp.timestamp() == 0 && timestamp.timestamp_subsec_nanos() == 0
+    }
+
+    pub(crate) fn repair_default_restored_exchange_timestamps(
+        &mut self,
+        fallback_timestamp: DateTime<Local>,
+    ) {
+        let exchange_ids_to_repair: Vec<_> = self
+            .task_store
+            .all_exchanges()
+            .filter(|exchange| {
+                Self::is_default_restored_timestamp(exchange.start_time)
+                    || exchange
+                        .finish_time
+                        .is_some_and(Self::is_default_restored_timestamp)
+            })
+            .map(|exchange| exchange.id)
+            .collect();
+
+        for exchange_id in exchange_ids_to_repair {
+            let Some(exchange) = self.task_store.exchange_mut(exchange_id) else {
+                continue;
+            };
+
+            // 旧数据或本地合成消息可能没有 CurrentTime/timestamp,恢复时会落到 Unix epoch。
+            // 只修正这种默认值,避免覆盖消息中已经恢复出的真实时间。
+            if Self::is_default_restored_timestamp(exchange.start_time) {
+                exchange.start_time = fallback_timestamp;
+            }
+            if exchange
+                .finish_time
+                .is_some_and(Self::is_default_restored_timestamp)
+            {
+                exchange.finish_time = Some(fallback_timestamp);
+            }
         }
     }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3182,9 +3182,9 @@ impl AIConversation {
         messages: &[api::Message],
         command_blocks: &mut Vec<CommandBlockInfo>,
     ) {
-        // 只跟踪当前 messages 扫描里最近一次由 RunShellCommand 创建的命令块，
-        // 避免后续 attachment/context 生成的块被 CLI subagent 误绑定。
-        let mut last_run_shell_command_block_index = None;
+        // 记录每个 RunShellCommand 的稳定 command id，CLI subagent 会用这个 id
+        // 指向实际被接管的命令块，不能只按最近一条命令猜测。
+        let mut run_shell_command_block_indices_by_id = HashMap::new();
 
         // Build a map from tool_call_id to (RunShellCommandResult, result_message_id)
         // for efficient lookup within this message set.
@@ -3238,9 +3238,9 @@ impl AIConversation {
                     {
                         if let Some(api::run_shell_command_result::Result::CommandFinished(
                             api::ShellCommandFinished {
+                                command_id,
                                 output: command_output,
                                 exit_code,
-                                ..
                             },
                         )) = &cmd_result.result
                         {
@@ -3264,20 +3264,23 @@ impl AIConversation {
                                 subagent_task_id: None,
                                 message_id: (*result_message_id).to_string(),
                             });
-                            last_run_shell_command_block_index =
-                                command_blocks.len().checked_sub(1);
+                            if let Some(index) = command_blocks.len().checked_sub(1) {
+                                run_shell_command_block_indices_by_id
+                                    .insert(command_id.clone(), index);
+                            }
                         }
                     }
                 }
 
-                // CLI subagent 紧跟在命令 tool call 之后时，把稳定 block id 和 subtask id
-                // 回填到最近生成的命令块，供历史恢复时重建只读关联。
+                // CLI subagent metadata 中的 command_id 是恢复时的真实关联源。
+                // 同一组 messages 里可能有多条命令，必须按 command_id 精确回填。
                 if let Some(subagent) = tool_call.subagent() {
                     if let Some(api::message::tool_call::subagent::Metadata::Cli(cli)) =
                         &subagent.metadata
                     {
-                        if let Some(command_block) = last_run_shell_command_block_index
-                            .and_then(|index| command_blocks.get_mut(index))
+                        if let Some(command_block) = run_shell_command_block_indices_by_id
+                            .get(&cli.command_id)
+                            .and_then(|index| command_blocks.get_mut(*index))
                         {
                             command_block.block_id = Some(BlockId::from(cli.command_id.clone()));
                             command_block.subagent_task_id =

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -124,6 +124,71 @@ pub enum RestoreConversationError {
 #[error("Subagent task not found")]
 pub struct SubagentTaskNotFound;
 
+/// CLI subagent 终端 block 的持久化快照。
+#[derive(Debug, Clone)]
+struct CliSubagentBlockSnapshot {
+    task_id: TaskId,
+    block_id: BlockId,
+    block: SerializedBlock,
+}
+
+impl CliSubagentBlockSnapshot {
+    fn new(task_id: TaskId, mut block: SerializedBlock) -> Self {
+        let block_id = block.id.clone();
+        // 以快照 key 为准，避免后续恢复时 block.id 与索引不一致。
+        block.id = block_id.clone();
+        Self {
+            task_id,
+            block_id,
+            block,
+        }
+    }
+}
+
+impl Serialize for CliSubagentBlockSnapshot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Snapshot<'a> {
+            task_id: &'a TaskId,
+            block_id: &'a BlockId,
+            block: &'a SerializedBlock,
+        }
+
+        Snapshot {
+            task_id: &self.task_id,
+            block_id: &self.block_id,
+            block: &self.block,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CliSubagentBlockSnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Snapshot {
+            task_id: TaskId,
+            block_id: BlockId,
+            block: SerializedBlock,
+        }
+
+        let mut snapshot = Snapshot::deserialize(deserializer)?;
+        // 反序列化时同步 block.id，保证后续 block_list 查找使用稳定 id。
+        snapshot.block.id = snapshot.block_id.clone();
+        Ok(Self {
+            task_id: snapshot.task_id,
+            block_id: snapshot.block_id,
+            block: snapshot.block,
+        })
+    }
+}
+
 /// An Agent Mode conversation.
 #[derive(Debug, Clone)]
 pub struct AIConversation {
@@ -234,6 +299,10 @@ pub struct AIConversation {
     /// Zap BYOP repair sidecar。invalid sidecar 必须原样保留,避免保存时
     /// 静默授权 repair 或抹掉损坏元数据。
     pub(crate) byop_repair_state: RepairStateStatus,
+
+    /// CLI subagent 真实终端 block 快照。task messages 可能只包含截断/摘要输出，
+    /// 因此关闭标签后需要靠这里恢复 SSH 等交互式终端内容。
+    cli_subagent_block_snapshots: HashMap<BlockId, CliSubagentBlockSnapshot>,
 }
 
 pub(crate) fn artifact_from_fork_proto(
@@ -285,6 +354,51 @@ impl AIConversation {
             last_event_sequence: None,
             compaction_state: Default::default(),
             byop_repair_state: RepairStateStatus::default(),
+            cli_subagent_block_snapshots: Default::default(),
+        }
+    }
+
+    fn cli_subagent_block_snapshots_from_json(
+        json: Option<String>,
+    ) -> HashMap<BlockId, CliSubagentBlockSnapshot> {
+        let Some(json) = json else {
+            return HashMap::new();
+        };
+
+        let snapshots = match serde_json::from_str::<Vec<CliSubagentBlockSnapshot>>(&json) {
+            Ok(snapshots) => snapshots,
+            Err(e) => {
+                log::warn!(
+                    "Failed to deserialize CLI subagent block snapshots; falling back to task messages: {e}"
+                );
+                return HashMap::new();
+            }
+        };
+
+        snapshots
+            .into_iter()
+            .map(|snapshot| (snapshot.block_id.clone(), snapshot))
+            .collect()
+    }
+
+    fn cli_subagent_block_snapshots_json(&self) -> Option<String> {
+        if self.cli_subagent_block_snapshots.is_empty() {
+            return None;
+        }
+
+        // 排序仅用于让持久化 JSON 稳定，避免无意义写入抖动。
+        let snapshots = self
+            .cli_subagent_block_snapshots
+            .values()
+            .sorted_by_key(|snapshot| snapshot.block_id.as_str().to_owned())
+            .cloned()
+            .collect_vec();
+        match serde_json::to_string(&snapshots) {
+            Ok(json) => Some(json),
+            Err(e) => {
+                log::error!("Failed to serialize CLI subagent block snapshots: {e}");
+                None
+            }
         }
     }
 
@@ -367,6 +481,7 @@ impl AIConversation {
             last_event_sequence,
             compaction_state,
             byop_repair_state,
+            cli_subagent_block_snapshots,
         ) = if let Some(data) = conversation_data {
             let server_conversation_token = data
                 .server_conversation_token
@@ -408,6 +523,9 @@ impl AIConversation {
                 .unwrap_or_default();
             let byop_repair_state =
                 RepairStateStatus::from_sidecar_json(data.byop_repair_state_json);
+            let cli_subagent_block_snapshots = Self::cli_subagent_block_snapshots_from_json(
+                data.cli_subagent_block_snapshots_json,
+            );
             if let Some(error_category) = byop_repair_state.error_category() {
                 log::error!(
                     "[byop-repair] failed to load repair sidecar category={error_category:?}"
@@ -428,6 +546,7 @@ impl AIConversation {
                 last_event_sequence,
                 compaction_state,
                 byop_repair_state,
+                cli_subagent_block_snapshots,
             )
         } else {
             (
@@ -444,6 +563,7 @@ impl AIConversation {
                 None,
                 crate::ai::byop_compaction::state::CompactionState::default(),
                 RepairStateStatus::default(),
+                HashMap::new(),
             )
         };
 
@@ -488,6 +608,7 @@ impl AIConversation {
             last_event_sequence,
             compaction_state,
             byop_repair_state,
+            cli_subagent_block_snapshots,
         })
     }
 
@@ -2908,6 +3029,7 @@ impl AIConversation {
                     }
                 },
                 byop_repair_state_json: self.byop_repair_state.to_sidecar_json(),
+                cli_subagent_block_snapshots_json: self.cli_subagent_block_snapshots_json(),
             },
         }
     }
@@ -3123,6 +3245,73 @@ impl AIConversation {
     fn to_stylized_bytes(s: &str) -> Vec<u8> {
         let s = s.replace("\r\n", "\n");
         s.replace('\n', "\r\n").into_bytes()
+    }
+
+    fn cli_subagent_ai_metadata_json(
+        &self,
+        task_id: &TaskId,
+        requested_command_action_id: Option<AIAgentActionId>,
+    ) -> Option<String> {
+        serde_json::to_string(&Some(Into::<SerializedAIMetadata>::into(
+            AgentInteractionMetadata::new(
+                requested_command_action_id,
+                self.id(),
+                Some(task_id.clone()),
+                Some(LongRunningCommandControlState::Agent {
+                    is_blocked: false,
+                    should_hide_responses: false,
+                }),
+                false,
+                false,
+            ),
+        )))
+        .ok()
+    }
+
+    fn requested_command_action_id_from_snapshot(
+        block: &SerializedBlock,
+    ) -> Option<AIAgentActionId> {
+        block
+            .ai_metadata
+            .as_ref()
+            .and_then(|json| serde_json::from_str::<Option<SerializedAIMetadata>>(json).ok())
+            .flatten()
+            .map(AgentInteractionMetadata::from)
+            .and_then(|metadata| metadata.requested_command_action_id().cloned())
+    }
+
+    fn normalized_cli_subagent_snapshot_block(
+        &self,
+        snapshot: &CliSubagentBlockSnapshot,
+        requested_command_action_id: Option<AIAgentActionId>,
+    ) -> SerializedBlock {
+        let mut block = snapshot.block.clone();
+        let requested_command_action_id = requested_command_action_id
+            .or_else(|| Self::requested_command_action_id_from_snapshot(&block));
+
+        // 恢复历史时必须同时恢复终端内容和 agent 关联元数据，
+        // 否则 block 能显示但展开的 CLI subagent 视图找不到归属。
+        block.id = snapshot.block_id.clone();
+        block.ai_metadata =
+            self.cli_subagent_ai_metadata_json(&snapshot.task_id, requested_command_action_id);
+        block.agent_view_visibility =
+            Some(AgentViewVisibility::new_from_conversation(self.id).into());
+        block
+    }
+
+    pub(crate) fn upsert_cli_subagent_block_snapshot(
+        &mut self,
+        task_id: TaskId,
+        block: SerializedBlock,
+        requested_command_action_id: Option<AIAgentActionId>,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) {
+        let mut snapshot = CliSubagentBlockSnapshot::new(task_id, block);
+        snapshot.block =
+            self.normalized_cli_subagent_snapshot_block(&snapshot, requested_command_action_id);
+        self.cli_subagent_block_snapshots
+            .insert(snapshot.block_id.clone(), snapshot);
+        self.write_updated_conversation_state(ctx);
     }
 
     /// Finds the RunShellCommand result for a given tool_call_id.
@@ -3356,6 +3545,7 @@ impl AIConversation {
     /// to know where to insert AI blocks relative to the command blocks.
     pub fn to_serialized_blocklist_items(&self) -> Vec<SerializedBlockListItem> {
         let mut serialized_blocks = Vec::new();
+        let mut used_cli_snapshot_block_ids = HashSet::new();
 
         // Extract all command blocks from the task messages
         let command_blocks = self.extract_command_blocks();
@@ -3376,6 +3566,25 @@ impl AIConversation {
 
         // Create serialized blocks from the extracted command blocks
         for command_block in command_blocks {
+            let matching_cli_snapshot = command_block.block_id.as_ref().and_then(|block_id| {
+                self.cli_subagent_block_snapshots
+                    .get(block_id)
+                    .filter(|snapshot| {
+                        command_block.subagent_task_id.as_ref() == Some(&snapshot.task_id)
+                    })
+            });
+            if let Some(snapshot) = matching_cli_snapshot {
+                // task message 里的输出可能只是 SSH 交互的截断结果；真实终端快照优先。
+                used_cli_snapshot_block_ids.insert(snapshot.block_id.clone());
+                serialized_blocks.push(SerializedBlockListItem::Command {
+                    block: Box::new(self.normalized_cli_subagent_snapshot_block(
+                        snapshot,
+                        command_block.requested_command_action_id,
+                    )),
+                });
+                continue;
+            }
+
             // Find the exchange that contains this command block's message ID
             let (pwd, timestamp) = message_id_to_exchange
                 .get(command_block.message_id.as_str())
@@ -3432,6 +3641,31 @@ impl AIConversation {
             };
             serialized_blocks.push(SerializedBlockListItem::Command {
                 block: Box::new(serialized_block),
+            });
+        }
+
+        // 有些交互式 CLI subagent 会话没有可用的 RunShellCommand 完成结果；
+        // 此时 task messages 无法生成 command block，仍要靠 sidecar 追加真实终端快照。
+        let remaining_cli_snapshots = self
+            .cli_subagent_block_snapshots
+            .values()
+            .filter(|snapshot| !used_cli_snapshot_block_ids.contains(&snapshot.block_id))
+            .filter(|snapshot| {
+                self.task_store
+                    .get(&snapshot.task_id)
+                    .is_some_and(|task| task.is_cli_subagent())
+            })
+            .sorted_by_key(|snapshot| {
+                (
+                    snapshot.block.start_ts.unwrap_or_default(),
+                    snapshot.block_id.as_str().to_owned(),
+                )
+            })
+            .collect_vec();
+
+        for snapshot in remaining_cli_snapshots {
+            serialized_blocks.push(SerializedBlockListItem::Command {
+                block: Box::new(self.normalized_cli_subagent_snapshot_block(snapshot, None)),
             });
         }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3182,6 +3182,10 @@ impl AIConversation {
         messages: &[api::Message],
         command_blocks: &mut Vec<CommandBlockInfo>,
     ) {
+        // 只跟踪当前 messages 扫描里最近一次由 RunShellCommand 创建的命令块，
+        // 避免后续 attachment/context 生成的块被 CLI subagent 误绑定。
+        let mut last_run_shell_command_block_index = None;
+
         // Build a map from tool_call_id to (RunShellCommandResult, result_message_id)
         // for efficient lookup within this message set.
         let tool_call_results: HashMap<&str, (&api::RunShellCommandResult, &str)> = messages
@@ -3260,6 +3264,8 @@ impl AIConversation {
                                 subagent_task_id: None,
                                 message_id: (*result_message_id).to_string(),
                             });
+                            last_run_shell_command_block_index =
+                                command_blocks.len().checked_sub(1);
                         }
                     }
                 }
@@ -3270,7 +3276,9 @@ impl AIConversation {
                     if let Some(api::message::tool_call::subagent::Metadata::Cli(cli)) =
                         &subagent.metadata
                     {
-                        if let Some(command_block) = command_blocks.last_mut() {
+                        if let Some(command_block) = last_run_shell_command_block_index
+                            .and_then(|index| command_blocks.get_mut(index))
+                        {
                             command_block.block_id = Some(BlockId::from(cli.command_id.clone()));
                             command_block.subagent_task_id =
                                 Some(TaskId::new(subagent.task_id.clone()));

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1,4 +1,5 @@
 use crate::ai::agent::comment::CodeReview;
+use crate::ai::blocklist::block::cli_controller::LongRunningCommandControlState;
 use crate::ai::agent::linearization::compute_task_depths;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
@@ -95,6 +96,12 @@ pub(crate) struct CommandBlockInfo {
     pub(crate) output: String,
     pub(crate) exit_code: ExitCode,
     pub(crate) ai_metadata: Option<String>,
+    /// 为 CLI subagent 恢复时保留稳定的 command block id。
+    pub(crate) block_id: Option<BlockId>,
+    /// 记录发起命令的 action id，用于恢复 requested command 关联。
+    pub(crate) requested_command_action_id: Option<AIAgentActionId>,
+    /// 记录 CLI subagent task id，用于恢复只读详情卡关联。
+    pub(crate) subagent_task_id: Option<TaskId>,
     /// The api message ID that this command block was extracted from.
     /// Used to find the corresponding exchange for timestamp and PWD.
     pub(crate) message_id: String,
@@ -3248,8 +3255,25 @@ impl AIConversation {
                                     ))
                                     .unwrap_or_default(),
                                 ),
+                                block_id: None,
+                                requested_command_action_id: Some(tool_call_id.clone().into()),
+                                subagent_task_id: None,
                                 message_id: (*result_message_id).to_string(),
                             });
+                        }
+                    }
+                }
+
+                // CLI subagent 紧跟在命令 tool call 之后时，把稳定 block id 和 subtask id
+                // 回填到最近生成的命令块，供历史恢复时重建只读关联。
+                if let Some(subagent) = tool_call.subagent() {
+                    if let Some(api::message::tool_call::subagent::Metadata::Cli(cli)) =
+                        &subagent.metadata
+                    {
+                        if let Some(command_block) = command_blocks.last_mut() {
+                            command_block.block_id = Some(BlockId::from(cli.command_id.clone()));
+                            command_block.subagent_task_id =
+                                Some(TaskId::new(subagent.task_id.clone()));
                         }
                     }
                 }
@@ -3276,6 +3300,9 @@ impl AIConversation {
                         output: cmd.output.clone(),
                         exit_code: ExitCode::from(cmd.exit_code),
                         ai_metadata: None,
+                        block_id: None,
+                        requested_command_action_id: None,
+                        subagent_task_id: None,
                         message_id: message_id.clone(),
                     });
                 }
@@ -3299,6 +3326,9 @@ impl AIConversation {
                             output: executed_shell_command.output.clone(),
                             exit_code: ExitCode::from(executed_shell_command.exit_code),
                             ai_metadata: None,
+                            block_id: None,
+                            requested_command_action_id: None,
+                            subagent_task_id: None,
                             message_id: message_id.clone(),
                         });
                     }
@@ -3341,8 +3371,29 @@ impl AIConversation {
                 .map(|exchange| (exchange.working_directory.clone(), exchange.start_time))
                 .unwrap_or((fallback_pwd.clone(), fallback_time));
 
+            // CLI subagent 恢复时序列化可见、只读的 agent 关联元数据；其他块保持原有元数据。
+            let ai_metadata = if let Some(subagent_task_id) = command_block.subagent_task_id.clone()
+            {
+                serde_json::to_string(&Some(Into::<SerializedAIMetadata>::into(
+                    AgentInteractionMetadata::new(
+                        command_block.requested_command_action_id.clone(),
+                        self.id(),
+                        Some(subagent_task_id),
+                        Some(LongRunningCommandControlState::Agent {
+                            is_blocked: false,
+                            should_hide_responses: false,
+                        }),
+                        false,
+                        false,
+                    ),
+                )))
+                .ok()
+            } else {
+                command_block.ai_metadata
+            };
+
             let serialized_block = SerializedBlock {
-                id: BlockId::new(),
+                id: command_block.block_id.unwrap_or_else(BlockId::new),
                 stylized_command: Self::to_stylized_bytes(&command_block.command),
                 stylized_output: Self::to_stylized_bytes(&command_block.output),
                 pwd,
@@ -3362,7 +3413,7 @@ impl AIConversation {
                 shell_host: None,
                 is_background: false,
                 prompt_snapshot: None,
-                ai_metadata: command_block.ai_metadata,
+                ai_metadata,
                 is_local: Some(true),
                 agent_view_visibility: Some(
                     AgentViewVisibility::new_from_conversation(self.id).into(),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -133,10 +133,8 @@ struct CliSubagentBlockSnapshot {
 }
 
 impl CliSubagentBlockSnapshot {
-    fn new(task_id: TaskId, mut block: SerializedBlock) -> Self {
+    fn new(task_id: TaskId, block: SerializedBlock) -> Self {
         let block_id = block.id.clone();
-        // 以快照 key 为准，避免后续恢复时 block.id 与索引不一致。
-        block.id = block_id.clone();
         Self {
             task_id,
             block_id,

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -2,14 +2,18 @@ use std::collections::HashMap;
 
 use super::{
     artifact_from_fork_proto, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
+    TaskId,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::blocklist::SerializedBlockListItem;
 use crate::ai::byop_readiness::{
     InvalidRepairState, RepairRecord, RepairSource, RepairState, RepairStateLoadError,
     RepairStateStatus, ToolCallKey,
 };
 use crate::persistence::model::AgentConversationData;
 use crate::persistence::ModelEvent;
+use crate::terminal::model::block::{AgentInteractionMetadata, SerializedAIMetadata};
+use crate::terminal::model::BlockId;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 
@@ -76,6 +80,69 @@ fn tool_call_message(id: &str, call_id: &str) -> api::Message {
         request_id: "request-1".to_string(),
         timestamp: None,
     }
+}
+
+fn run_shell_command_tool() -> api::message::tool_call::Tool {
+    use api::message::tool_call::run_shell_command::WaitUntilCompleteValue;
+
+    api::message::tool_call::Tool::RunShellCommand(api::message::tool_call::RunShellCommand {
+        command: "echo hi".to_string(),
+        is_read_only: true,
+        uses_pager: false,
+        is_risky: false,
+        citations: vec![],
+        wait_until_complete_value: Some(WaitUntilCompleteValue::WaitUntilComplete(true)),
+        risk_category: 0,
+    })
+}
+
+fn tool_call_message_with_tool(id: &str, call_id: &str, tool: api::message::tool_call::Tool) -> api::Message {
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: call_id.to_string(),
+            tool: Some(tool),
+        })),
+        request_id: "request-1".to_string(),
+        timestamp: None,
+    }
+}
+
+fn tool_call_result_message_with_result(
+    id: &str,
+    call_id: &str,
+    result: api::message::tool_call_result::Result,
+) -> api::Message {
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: call_id.to_string(),
+                result: Some(result),
+                context: None,
+            },
+        )),
+        request_id: "request-1".to_string(),
+        timestamp: None,
+    }
+}
+
+fn cli_subagent_tool(subtask_id: &str, command_id: &str) -> api::message::tool_call::Tool {
+    api::message::tool_call::Tool::Subagent(api::message::tool_call::Subagent {
+        task_id: subtask_id.to_string(),
+        payload: String::new(),
+        metadata: Some(api::message::tool_call::subagent::Metadata::Cli(
+            api::message::tool_call::subagent::CliSubagent {
+                command_id: command_id.to_string(),
+            },
+        )),
+    })
 }
 
 fn restored_conversation_with_queries(queries: &[&str]) -> AIConversation {
@@ -284,6 +351,84 @@ fn byop_repair_sidecar_survives_serialization_after_fork_token_cleared() {
         RepairStateStatus::from_sidecar_json(conversation_data.byop_repair_state_json),
         RepairStateStatus::Valid(RepairState::new(vec![record]))
     );
+}
+
+#[allow(deprecated)]
+#[test]
+fn test_cli_subagent_serialized_block_preserves_block_id_and_metadata() {
+    let cli_task_id = TaskId::new("cli-task-1".to_string());
+    let conversation = AIConversation::new_restored(
+        AIConversationId::new(),
+        vec![
+            api::Task {
+                id: "root-task".to_string(),
+                messages: vec![
+                    tool_call_message_with_tool(
+                        "tool-call-1",
+                        "call-1",
+                        run_shell_command_tool(),
+                    ),
+                    tool_call_result_message_with_result(
+                        "tool-result-1",
+                        "call-1",
+                        api::message::tool_call_result::Result::RunShellCommand(
+                            api::RunShellCommandResult {
+                                command: "echo hi".to_string(),
+                                output: String::new(),
+                                exit_code: 0,
+                                result: Some(
+                                    api::run_shell_command_result::Result::CommandFinished(
+                                        api::ShellCommandFinished {
+                                            command_id: "cli-block-1".to_string(),
+                                            output: "hi".to_string(),
+                                            exit_code: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    tool_call_message_with_tool(
+                        "subagent-call-1",
+                        "subagent-call-1",
+                        cli_subagent_tool(&String::from(cli_task_id.clone()), "cli-block-1"),
+                    ),
+                ],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+            api::Task {
+                id: String::from(cli_task_id.clone()),
+                messages: vec![],
+                dependencies: Some(api::task::Dependencies {
+                    parent_task_id: "root-task".to_string(),
+                }),
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+        ],
+        None,
+    )
+    .unwrap();
+
+    let blocks = conversation.to_serialized_blocklist_items();
+    let SerializedBlockListItem::Command { block } = &blocks[0];
+    assert_eq!(block.id, BlockId::from("cli-block-1".to_string()));
+
+    let metadata = block
+        .ai_metadata
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<Option<SerializedAIMetadata>>(json).ok())
+        .flatten()
+        .expect("CLI subagent command block should serialize AI metadata");
+    let agent_metadata: AgentInteractionMetadata = metadata.into();
+    assert_eq!(agent_metadata.conversation_id(), &conversation.id());
+    assert_eq!(agent_metadata.subagent_task_id(), Some(&cli_task_id));
+    assert!(agent_metadata.long_running_control_state().is_some());
+    assert!(!agent_metadata.should_hide_block());
 }
 
 #[test]

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -591,6 +591,122 @@ fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_block
     assert_ne!(context_block.id, BlockId::from("cli-block-1".to_string()));
 }
 
+#[allow(deprecated)]
+#[test]
+fn test_cli_subagent_serialized_block_uses_metadata_command_id_not_latest_command() {
+    let cli_task_id = TaskId::new("cli-task-first-command".to_string());
+    let conversation = AIConversation::new_restored(
+        AIConversationId::new(),
+        vec![
+            api::Task {
+                id: "root-task".to_string(),
+                messages: vec![
+                    tool_call_message_with_tool(
+                        "tool-call-1",
+                        "call-1",
+                        run_shell_command_tool(),
+                    ),
+                    tool_call_result_message_with_result(
+                        "tool-result-1",
+                        "call-1",
+                        api::message::tool_call_result::Result::RunShellCommand(
+                            api::RunShellCommandResult {
+                                command: "echo hi".to_string(),
+                                output: String::new(),
+                                exit_code: 0,
+                                result: Some(
+                                    api::run_shell_command_result::Result::CommandFinished(
+                                        api::ShellCommandFinished {
+                                            command_id: "cli-block-1".to_string(),
+                                            output: "first".to_string(),
+                                            exit_code: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    tool_call_message_with_tool(
+                        "tool-call-2",
+                        "call-2",
+                        run_shell_command_tool(),
+                    ),
+                    tool_call_result_message_with_result(
+                        "tool-result-2",
+                        "call-2",
+                        api::message::tool_call_result::Result::RunShellCommand(
+                            api::RunShellCommandResult {
+                                command: "echo hi".to_string(),
+                                output: String::new(),
+                                exit_code: 0,
+                                result: Some(
+                                    api::run_shell_command_result::Result::CommandFinished(
+                                        api::ShellCommandFinished {
+                                            command_id: "other-block".to_string(),
+                                            output: "second".to_string(),
+                                            exit_code: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    tool_call_message_with_tool(
+                        "subagent-call-1",
+                        "subagent-call-1",
+                        cli_subagent_tool(&String::from(cli_task_id.clone()), "cli-block-1"),
+                    ),
+                ],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+            api::Task {
+                id: String::from(cli_task_id.clone()),
+                messages: vec![],
+                dependencies: Some(api::task::Dependencies {
+                    parent_task_id: "root-task".to_string(),
+                }),
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+        ],
+        None,
+    )
+    .unwrap();
+
+    let blocks = conversation.to_serialized_blocklist_items();
+    assert_eq!(blocks.len(), 2);
+
+    let SerializedBlockListItem::Command { block: first_block } = &blocks[0];
+    assert_eq!(first_block.id, BlockId::from("cli-block-1".to_string()));
+    let first_metadata = first_block
+        .ai_metadata
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<Option<SerializedAIMetadata>>(json).ok())
+        .flatten()
+        .expect("CLI subagent metadata should attach to the referenced command block");
+    let first_agent_metadata: AgentInteractionMetadata = first_metadata.into();
+    assert_eq!(first_agent_metadata.subagent_task_id(), Some(&cli_task_id));
+    assert_eq!(String::from_utf8_lossy(&first_block.stylized_output), "first");
+
+    let SerializedBlockListItem::Command {
+        block: second_block,
+    } = &blocks[1];
+    assert_ne!(second_block.id, BlockId::from("cli-block-1".to_string()));
+    assert_eq!(String::from_utf8_lossy(&second_block.stylized_output), "second");
+    let second_metadata = second_block
+        .ai_metadata
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<Option<SerializedAIMetadata>>(json).ok())
+        .flatten()
+        .expect("second command should keep requested-command metadata");
+    let second_agent_metadata: AgentInteractionMetadata = second_metadata.into();
+    assert_eq!(second_agent_metadata.subagent_task_id(), None);
+}
+
 #[test]
 fn fork_artifacts_adds_file_artifacts_to_conversation() {
     let proto_artifact = api::message::artifact_event::ConversationArtifact {

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -5,14 +5,18 @@ use super::{
     TaskId,
 };
 use crate::ai::artifacts::Artifact;
-use crate::ai::blocklist::SerializedBlockListItem;
+use crate::ai::blocklist::{
+    block::cli_controller::LongRunningCommandControlState, SerializedBlockListItem,
+};
 use crate::ai::byop_readiness::{
     InvalidRepairState, RepairRecord, RepairSource, RepairState, RepairStateLoadError,
     RepairStateStatus, ToolCallKey,
 };
 use crate::persistence::model::AgentConversationData;
 use crate::persistence::ModelEvent;
-use crate::terminal::model::block::{AgentInteractionMetadata, SerializedAIMetadata};
+use crate::terminal::model::block::{
+    AgentInteractionMetadata, AgentViewVisibility, SerializedAIMetadata, SerializedBlock,
+};
 use crate::terminal::model::BlockId;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
@@ -197,6 +201,60 @@ fn cli_subagent_tool(subtask_id: &str, command_id: &str) -> api::message::tool_c
             },
         )),
     })
+}
+
+fn empty_agent_conversation_data_for_test() -> AgentConversationData {
+    AgentConversationData {
+        server_conversation_token: None,
+        conversation_usage_metadata: None,
+        reverted_action_ids: None,
+        forked_from_server_conversation_token: None,
+        artifacts_json: None,
+        parent_agent_id: None,
+        agent_name: None,
+        parent_conversation_id: None,
+        run_id: None,
+        autoexecute_override: None,
+        last_event_sequence: None,
+        compaction_state_json: None,
+        byop_repair_state_json: None,
+        cli_subagent_block_snapshots_json: None,
+    }
+}
+
+fn cli_subagent_snapshot_json_for_test(
+    conversation_id: AIConversationId,
+    task_id: &TaskId,
+    block_id: &BlockId,
+    command: &[u8],
+    output: &[u8],
+) -> String {
+    // 模拟已关闭标签后唯一能留在 SQLite conversation_data 里的终端快照。
+    let mut block = SerializedBlock::new_for_test(command.to_vec(), output.to_vec());
+    block.id = block_id.clone();
+    block.ai_metadata = serde_json::to_string(&Some(Into::<SerializedAIMetadata>::into(
+        AgentInteractionMetadata::new(
+            None,
+            conversation_id,
+            Some(task_id.clone()),
+            Some(LongRunningCommandControlState::Agent {
+                is_blocked: false,
+                should_hide_responses: false,
+            }),
+            false,
+            false,
+        ),
+    )))
+    .ok();
+    block.agent_view_visibility =
+        Some(AgentViewVisibility::new_from_conversation(conversation_id).into());
+
+    serde_json::to_string(&vec![serde_json::json!({
+        "task_id": String::from(task_id.clone()),
+        "block_id": block_id.as_str(),
+        "block": block,
+    })])
+    .expect("CLI subagent snapshot JSON should serialize")
 }
 
 fn restored_conversation_with_queries(queries: &[&str]) -> AIConversation {
@@ -487,6 +545,147 @@ fn test_cli_subagent_serialized_block_preserves_block_id_and_metadata() {
 
 #[allow(deprecated)]
 #[test]
+fn test_cli_subagent_serialized_block_prefers_persisted_snapshot_output() {
+    let conversation_id = AIConversationId::new();
+    let cli_task_id = TaskId::new("cli-task-snapshot".to_string());
+    let block_id = BlockId::from("cli-block-snapshot".to_string());
+    let snapshot_output =
+        b"* Documentation: https://help.ubuntu.com\r\nCONTAINER ID   IMAGE\r\nanalyzer-runtime\r\n";
+    let mut conversation_data = empty_agent_conversation_data_for_test();
+    conversation_data.cli_subagent_block_snapshots_json =
+        Some(cli_subagent_snapshot_json_for_test(
+            conversation_id,
+            &cli_task_id,
+            &block_id,
+            b"ssh jump",
+            snapshot_output,
+        ));
+
+    let conversation = AIConversation::new_restored(
+        conversation_id,
+        vec![
+            api::Task {
+                id: "root-task".to_string(),
+                messages: vec![
+                    tool_call_message_with_tool("tool-call-1", "call-1", run_shell_command_tool()),
+                    tool_call_result_message_with_result(
+                        "tool-result-1",
+                        "call-1",
+                        api::message::tool_call_result::Result::RunShellCommand(
+                            api::RunShellCommandResult {
+                                command: "ssh jump".to_string(),
+                                output: String::new(),
+                                exit_code: 0,
+                                result: Some(
+                                    api::run_shell_command_result::Result::CommandFinished(
+                                        api::ShellCommandFinished {
+                                            command_id: String::from(block_id.clone()),
+                                            output: "truncated task output".to_string(),
+                                            exit_code: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    tool_call_message_with_tool(
+                        "subagent-call-1",
+                        "subagent-call-1",
+                        cli_subagent_tool(&String::from(cli_task_id.clone()), block_id.as_str()),
+                    ),
+                ],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+            api::Task {
+                id: String::from(cli_task_id.clone()),
+                messages: vec![],
+                dependencies: Some(api::task::Dependencies {
+                    parent_task_id: "root-task".to_string(),
+                }),
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+        ],
+        Some(conversation_data),
+    )
+    .unwrap();
+
+    let blocks = conversation.to_serialized_blocklist_items();
+    let SerializedBlockListItem::Command { block } = &blocks[0];
+    assert_eq!(block.id, block_id);
+    let output = String::from_utf8_lossy(&block.stylized_output);
+    assert!(
+        output.contains("analyzer-runtime"),
+        "restored block should use the persisted SSH terminal snapshot: {output}"
+    );
+    assert!(
+        !output.contains("truncated task output"),
+        "task-message output must not overwrite the richer terminal snapshot"
+    );
+}
+
+#[allow(deprecated)]
+#[test]
+fn test_cli_subagent_serialized_block_restores_snapshot_without_command_result() {
+    let conversation_id = AIConversationId::new();
+    let cli_task_id = TaskId::new("cli-task-snapshot-only".to_string());
+    let block_id = BlockId::from("cli-block-snapshot-only".to_string());
+    let mut conversation_data = empty_agent_conversation_data_for_test();
+    conversation_data.cli_subagent_block_snapshots_json =
+        Some(cli_subagent_snapshot_json_for_test(
+            conversation_id,
+            &cli_task_id,
+            &block_id,
+            b"ssh jump",
+            b"Last login: Wed Jul 1\r\ndocker ps -a\r\n",
+        ));
+
+    let conversation = AIConversation::new_restored(
+        conversation_id,
+        vec![
+            api::Task {
+                id: "root-task".to_string(),
+                messages: vec![tool_call_message_with_tool(
+                    "subagent-call-1",
+                    "subagent-call-1",
+                    cli_subagent_tool(&String::from(cli_task_id.clone()), block_id.as_str()),
+                )],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+            api::Task {
+                id: String::from(cli_task_id.clone()),
+                messages: vec![],
+                dependencies: Some(api::task::Dependencies {
+                    parent_task_id: "root-task".to_string(),
+                }),
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+        ],
+        Some(conversation_data),
+    )
+    .unwrap();
+
+    let blocks = conversation.to_serialized_blocklist_items();
+    assert_eq!(blocks.len(), 1);
+    let SerializedBlockListItem::Command { block } = &blocks[0];
+    assert_eq!(block.id, block_id);
+    assert!(
+        String::from_utf8_lossy(&block.stylized_output).contains("docker ps -a"),
+        "snapshot-only CLI subagent history should still restore terminal output"
+    );
+}
+
+#[allow(deprecated)]
+#[test]
 fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_blocks() {
     let cli_task_id = TaskId::new("cli-task-attachment-context".to_string());
     let conversation = AIConversation::new_restored(
@@ -495,11 +694,7 @@ fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_block
             api::Task {
                 id: "root-task".to_string(),
                 messages: vec![
-                    tool_call_message_with_tool(
-                        "tool-call-1",
-                        "call-1",
-                        run_shell_command_tool(),
-                    ),
+                    tool_call_message_with_tool("tool-call-1", "call-1", run_shell_command_tool()),
                     tool_call_result_message_with_result(
                         "tool-result-1",
                         "call-1",
@@ -556,7 +751,9 @@ fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_block
     let blocks = conversation.to_serialized_blocklist_items();
     assert_eq!(blocks.len(), 3);
 
-    let SerializedBlockListItem::Command { block: run_shell_block } = &blocks[0];
+    let SerializedBlockListItem::Command {
+        block: run_shell_block,
+    } = &blocks[0];
     assert_eq!(run_shell_block.id, BlockId::from("cli-block-1".to_string()));
     let run_shell_metadata = run_shell_block
         .ai_metadata
@@ -578,7 +775,10 @@ fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_block
         "cat attachment.txt"
     );
     assert!(attachment_block.ai_metadata.is_none());
-    assert_ne!(attachment_block.id, BlockId::from("cli-block-1".to_string()));
+    assert_ne!(
+        attachment_block.id,
+        BlockId::from("cli-block-1".to_string())
+    );
 
     let SerializedBlockListItem::Command {
         block: context_block,
@@ -601,11 +801,7 @@ fn test_cli_subagent_serialized_block_uses_metadata_command_id_not_latest_comman
             api::Task {
                 id: "root-task".to_string(),
                 messages: vec![
-                    tool_call_message_with_tool(
-                        "tool-call-1",
-                        "call-1",
-                        run_shell_command_tool(),
-                    ),
+                    tool_call_message_with_tool("tool-call-1", "call-1", run_shell_command_tool()),
                     tool_call_result_message_with_result(
                         "tool-result-1",
                         "call-1",
@@ -626,11 +822,7 @@ fn test_cli_subagent_serialized_block_uses_metadata_command_id_not_latest_comman
                             },
                         ),
                     ),
-                    tool_call_message_with_tool(
-                        "tool-call-2",
-                        "call-2",
-                        run_shell_command_tool(),
-                    ),
+                    tool_call_message_with_tool("tool-call-2", "call-2", run_shell_command_tool()),
                     tool_call_result_message_with_result(
                         "tool-result-2",
                         "call-2",
@@ -690,13 +882,19 @@ fn test_cli_subagent_serialized_block_uses_metadata_command_id_not_latest_comman
         .expect("CLI subagent metadata should attach to the referenced command block");
     let first_agent_metadata: AgentInteractionMetadata = first_metadata.into();
     assert_eq!(first_agent_metadata.subagent_task_id(), Some(&cli_task_id));
-    assert_eq!(String::from_utf8_lossy(&first_block.stylized_output), "first");
+    assert_eq!(
+        String::from_utf8_lossy(&first_block.stylized_output),
+        "first"
+    );
 
     let SerializedBlockListItem::Command {
         block: second_block,
     } = &blocks[1];
     assert_ne!(second_block.id, BlockId::from("cli-block-1".to_string()));
-    assert_eq!(String::from_utf8_lossy(&second_block.stylized_output), "second");
+    assert_eq!(
+        String::from_utf8_lossy(&second_block.stylized_output),
+        "second"
+    );
     let second_metadata = second_block
         .ai_metadata
         .as_ref()

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -51,6 +51,60 @@ fn user_query_message(id: &str, request_id: &str, query: &str) -> api::Message {
     }
 }
 
+#[allow(deprecated)]
+fn user_query_message_with_shell_context(
+    id: &str,
+    request_id: &str,
+    query: &str,
+    attachment_command: &str,
+    context_command: &str,
+) -> api::Message {
+    let mut referenced_attachments = HashMap::new();
+    referenced_attachments.insert(
+        "attachment-command".to_string(),
+        api::Attachment {
+            value: Some(api::attachment::Value::ExecutedShellCommand(
+                api::ExecutedShellCommand {
+                    command: attachment_command.to_string(),
+                    output: "attachment output".to_string(),
+                    exit_code: 0,
+                    command_id: "attachment-block".to_string(),
+                    is_auto_attached: false,
+                    started_ts: None,
+                    finished_ts: None,
+                },
+            )),
+        },
+    );
+
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+            query: query.to_string(),
+            context: Some(api::InputContext {
+                executed_shell_commands: vec![api::ExecutedShellCommand {
+                    command: context_command.to_string(),
+                    output: "context output".to_string(),
+                    exit_code: 0,
+                    command_id: "context-block".to_string(),
+                    is_auto_attached: false,
+                    started_ts: None,
+                    finished_ts: None,
+                }],
+                ..Default::default()
+            }),
+            referenced_attachments,
+            mode: None,
+            intended_agent: Default::default(),
+        })),
+        request_id: request_id.to_string(),
+        timestamp: None,
+    }
+}
+
 fn agent_output_message(id: &str, request_id: &str) -> api::Message {
     api::Message {
         id: id.to_string(),
@@ -429,6 +483,112 @@ fn test_cli_subagent_serialized_block_preserves_block_id_and_metadata() {
     assert_eq!(agent_metadata.subagent_task_id(), Some(&cli_task_id));
     assert!(agent_metadata.long_running_control_state().is_some());
     assert!(!agent_metadata.should_hide_block());
+}
+
+#[allow(deprecated)]
+#[test]
+fn test_cli_subagent_serialized_block_ignores_later_attachment_and_context_blocks() {
+    let cli_task_id = TaskId::new("cli-task-attachment-context".to_string());
+    let conversation = AIConversation::new_restored(
+        AIConversationId::new(),
+        vec![
+            api::Task {
+                id: "root-task".to_string(),
+                messages: vec![
+                    tool_call_message_with_tool(
+                        "tool-call-1",
+                        "call-1",
+                        run_shell_command_tool(),
+                    ),
+                    tool_call_result_message_with_result(
+                        "tool-result-1",
+                        "call-1",
+                        api::message::tool_call_result::Result::RunShellCommand(
+                            api::RunShellCommandResult {
+                                command: "echo hi".to_string(),
+                                output: String::new(),
+                                exit_code: 0,
+                                result: Some(
+                                    api::run_shell_command_result::Result::CommandFinished(
+                                        api::ShellCommandFinished {
+                                            command_id: "cli-block-1".to_string(),
+                                            output: "hi".to_string(),
+                                            exit_code: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    user_query_message_with_shell_context(
+                        "user-with-shell-context",
+                        "request-attachment-context",
+                        "show recent shell state",
+                        "cat attachment.txt",
+                        "cat context.txt",
+                    ),
+                    tool_call_message_with_tool(
+                        "subagent-call-1",
+                        "subagent-call-1",
+                        cli_subagent_tool(&String::from(cli_task_id.clone()), "cli-block-1"),
+                    ),
+                ],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+            api::Task {
+                id: String::from(cli_task_id.clone()),
+                messages: vec![],
+                dependencies: Some(api::task::Dependencies {
+                    parent_task_id: "root-task".to_string(),
+                }),
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            },
+        ],
+        None,
+    )
+    .unwrap();
+
+    let blocks = conversation.to_serialized_blocklist_items();
+    assert_eq!(blocks.len(), 3);
+
+    let SerializedBlockListItem::Command { block: run_shell_block } = &blocks[0];
+    assert_eq!(run_shell_block.id, BlockId::from("cli-block-1".to_string()));
+    let run_shell_metadata = run_shell_block
+        .ai_metadata
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<Option<SerializedAIMetadata>>(json).ok())
+        .flatten()
+        .expect("CLI subagent metadata should stay on the RunShellCommand block");
+    let run_shell_agent_metadata: AgentInteractionMetadata = run_shell_metadata.into();
+    assert_eq!(
+        run_shell_agent_metadata.subagent_task_id(),
+        Some(&cli_task_id)
+    );
+
+    let SerializedBlockListItem::Command {
+        block: attachment_block,
+    } = &blocks[1];
+    assert_eq!(
+        String::from_utf8_lossy(&attachment_block.stylized_command),
+        "cat attachment.txt"
+    );
+    assert!(attachment_block.ai_metadata.is_none());
+    assert_ne!(attachment_block.id, BlockId::from("cli-block-1".to_string()));
+
+    let SerializedBlockListItem::Command {
+        block: context_block,
+    } = &blocks[2];
+    assert_eq!(
+        String::from_utf8_lossy(&context_block.stylized_command),
+        "cat context.txt"
+    );
+    assert!(context_block.ai_metadata.is_none());
+    assert_ne!(context_block.id, BlockId::from("cli-block-1".to_string()));
 }
 
 #[test]

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -154,6 +154,7 @@ fn test_display_status_uses_matching_conversation_for_in_progress_task() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -207,6 +208,7 @@ fn test_display_status_updates_when_blocked_conversation_resumes() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -284,6 +286,7 @@ fn test_display_status_terminal_task_state_overrides_matching_conversation() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -337,6 +340,7 @@ fn test_status_filter_uses_display_status_for_task_backed_conversations() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -620,6 +624,7 @@ fn test_get_tasks_and_conversations_prefers_task_when_task_id_matches_conversati
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -679,6 +684,7 @@ fn test_get_tasks_and_conversations_prefers_task_when_server_token_matches() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 
@@ -737,6 +743,7 @@ fn test_get_tasks_and_conversations_keeps_unrelated_tasks_and_conversations() {
                 last_event_sequence: None,
                 compaction_state_json: None,
                 byop_repair_state_json: None,
+                cli_subagent_block_snapshots_json: None,
             },
         );
 

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -60,7 +60,7 @@ use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::TelemetryEvent;
 use crate::settings::{AISettings, SelectionSettings};
 use crate::terminal::input::SET_INPUT_MODE_TERMINAL_ACTION_NAME;
-use crate::terminal::model::block::BlockId;
+use crate::terminal::model::block::{AgentInteractionMetadata, BlockId};
 use crate::terminal::{ShellLaunchData, TerminalModel};
 use crate::view_components::DismissibleToast;
 use crate::workspace::WorkspaceAction;
@@ -210,6 +210,24 @@ fn cli_subagent_should_render_user_input(
     is_input_dismissed: bool,
 ) -> bool {
     !should_hide_responses && !is_input_dismissed
+}
+
+/// 判断 CLI subagent 视图在不同模式下是否应该渲染。
+fn cli_subagent_should_render_for_metadata(
+    mode: CLISubagentViewMode,
+    metadata: Option<&AgentInteractionMetadata>,
+    conversation_id: AIConversationId,
+    task_id: &TaskId,
+    is_agent_monitoring: bool,
+    is_eligible_for_agent_handoff: bool,
+) -> bool {
+    match mode {
+        CLISubagentViewMode::Live => is_agent_monitoring && !is_eligible_for_agent_handoff,
+        CLISubagentViewMode::RestoredReadOnly => metadata.is_some_and(|metadata| {
+            metadata.conversation_id() == &conversation_id
+                && metadata.subagent_task_id() == Some(task_id)
+        }),
+    }
 }
 
 /// 统计 CLI 浮窗实际渲染的 output sections，供脱敏索引与 render 累计保持一致。
@@ -413,6 +431,8 @@ pub struct CLISubagentView {
     action_model: ModelHandle<BlocklistAIActionModel>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     conversation_id: AIConversationId,
+    task_id: TaskId,
+    mode: CLISubagentViewMode,
     terminal_view_id: EntityId,
 
     state_handles: StateHandles,
@@ -448,6 +468,12 @@ pub struct CLISubagentView {
     shell_launch_data: Option<ShellLaunchData>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CLISubagentViewMode {
+    Live,
+    RestoredReadOnly,
+}
+
 impl CLISubagentView {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -459,6 +485,59 @@ impl CLISubagentView {
         task_id: TaskId,
         current_working_directory: Option<String>,
         shell_launch_data: Option<ShellLaunchData>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        Self::new_with_mode(
+            block_id,
+            action_model,
+            subagent_controller,
+            terminal_model,
+            conversation_id,
+            task_id,
+            current_working_directory,
+            shell_launch_data,
+            CLISubagentViewMode::Live,
+            ctx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_restored(
+        block_id: BlockId,
+        action_model: ModelHandle<BlocklistAIActionModel>,
+        subagent_controller: ModelHandle<CLISubagentController>,
+        terminal_model: Arc<FairMutex<TerminalModel>>,
+        conversation_id: AIConversationId,
+        task_id: TaskId,
+        current_working_directory: Option<String>,
+        shell_launch_data: Option<ShellLaunchData>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        Self::new_with_mode(
+            block_id,
+            action_model,
+            subagent_controller,
+            terminal_model,
+            conversation_id,
+            task_id,
+            current_working_directory,
+            shell_launch_data,
+            CLISubagentViewMode::RestoredReadOnly,
+            ctx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_mode(
+        block_id: BlockId,
+        action_model: ModelHandle<BlocklistAIActionModel>,
+        subagent_controller: ModelHandle<CLISubagentController>,
+        terminal_model: Arc<FairMutex<TerminalModel>>,
+        conversation_id: AIConversationId,
+        task_id: TaskId,
+        current_working_directory: Option<String>,
+        shell_launch_data: Option<ShellLaunchData>,
+        mode: CLISubagentViewMode,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let allow_button = CompactibleSplitActionButton::new(
@@ -582,7 +661,7 @@ impl CLISubagentView {
                         if let Ok(model) = AIBlockModelImpl::<CLISubagentView>::new(
                             appended_exchange_id,
                             *conversation_id,
-                            false,
+                            mode == CLISubagentViewMode::RestoredReadOnly,
                             false,
                             ctx,
                         ) {
@@ -685,7 +764,7 @@ impl CLISubagentView {
         let model = AIBlockModelImpl::<CLISubagentView>::new(
             exchange_id,
             conversation_id,
-            false,
+            mode == CLISubagentViewMode::RestoredReadOnly,
             false,
             ctx,
         )
@@ -713,7 +792,7 @@ impl CLISubagentView {
             if let Ok(history_model) = AIBlockModelImpl::<CLISubagentView>::new(
                 history_exchange_id,
                 conversation_id,
-                false,
+                mode == CLISubagentViewMode::RestoredReadOnly,
                 false,
                 ctx,
             ) {
@@ -767,6 +846,8 @@ impl CLISubagentView {
             terminal_model,
             subagent_controller,
             conversation_id,
+            task_id,
+            mode,
             terminal_view_id: ctx.view_id(),
             link_detection_state: Default::default(),
             code_editor_views: Default::default(),
@@ -1354,7 +1435,14 @@ impl View for CLISubagentView {
             return Empty::new().finish();
         };
 
-        if !block.is_agent_monitoring() || block.is_eligible_for_agent_handoff() {
+        if !cli_subagent_should_render_for_metadata(
+            self.mode,
+            block.agent_interaction_metadata(),
+            self.conversation_id,
+            &self.task_id,
+            block.is_agent_monitoring(),
+            block.is_eligible_for_agent_handoff(),
+        ) {
             return Empty::new().finish();
         }
 
@@ -1370,6 +1458,7 @@ impl View for CLISubagentView {
         let mut conversation_items = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        let is_restored_read_only = self.mode == CLISubagentViewMode::RestoredReadOnly;
 
         let models_to_render = if self.history_models.is_empty() {
             vec![&self.model]
@@ -1747,138 +1836,151 @@ impl View for CLISubagentView {
                 rendered_output_index += 1;
             }
 
-            if let Some(rendered_action) = blocked_action.and_then(|action| match action.action {
-                AIAgentActionType::WriteToLongRunningShellCommand { input, mode, .. } => {
-                    Some(render_blocked_action(
-                        BlockedActionProps {
-                            header: BLOCKED_ACTION_MESSAGE_FOR_WRITE_TO_LONG_RUNNING_SHELL_COMMAND
-                                .to_string(),
-                            description: Some(render_write_to_pty_input(
-                                WriteToPtyInputProps {
-                                    input: input.clone(),
-                                    mode,
+            if !is_restored_read_only {
+                if let Some(rendered_action) =
+                    blocked_action.and_then(|action| match action.action {
+                        AIAgentActionType::WriteToLongRunningShellCommand {
+                            input, mode, ..
+                        } => Some(render_blocked_action(
+                            BlockedActionProps {
+                                header:
+                                    BLOCKED_ACTION_MESSAGE_FOR_WRITE_TO_LONG_RUNNING_SHELL_COMMAND
+                                        .to_string(),
+                                description: Some(render_write_to_pty_input(
+                                    WriteToPtyInputProps {
+                                        input: input.clone(),
+                                        mode,
+                                    },
+                                    app,
+                                )),
+                                is_allow_menu_open: self.is_allow_menu_open,
+                                allow_menu: Some(&self.allow_menu),
+                                buttons: vec![
+                                    &self.allow_button,
+                                    &self.reject_button,
+                                    &self.take_over_button,
+                                ],
+                                speedbump: should_show_write_to_pty_speedbump(app).then_some(
+                                    PermissionsSpeedbumpProps {
+                                        always_allow_checked: self
+                                            .always_allow_write_to_pty_checked,
+                                        speedbump_checkbox_handle: &self
+                                            .state_handles
+                                            .speedbump_checkbox_handle,
+                                        speedbump_checkbox_action:
+                                            CLISubagentAction::ToggleAlwaysAllowWriteToPty,
+                                        ai_settings_link: &self.state_handles.ai_settings_link,
+                                    },
+                                ),
+                            },
+                            app,
+                        )),
+                        AIAgentActionType::TransferShellCommandControlToUser { ref reason } => {
+                            Some(render_blocked_action(
+                                BlockedActionProps {
+                                    header: BLOCKED_ACTION_MESSAGE_FOR_TRANSFER_CONTROL.to_string(),
+                                    description: Some(render_transfer_control_reason(reason, app)),
+                                    is_allow_menu_open: false,
+                                    allow_menu: None,
+                                    buttons: vec![
+                                        &self.reject_button,
+                                        &self.transfer_control_button,
+                                    ],
+                                    speedbump: None,
                                 },
                                 app,
-                            )),
-                            is_allow_menu_open: self.is_allow_menu_open,
-                            allow_menu: Some(&self.allow_menu),
-                            buttons: vec![
-                                &self.allow_button,
-                                &self.reject_button,
-                                &self.take_over_button,
-                            ],
-                            speedbump: should_show_write_to_pty_speedbump(app).then_some(
-                                PermissionsSpeedbumpProps {
-                                    always_allow_checked: self.always_allow_write_to_pty_checked,
-                                    speedbump_checkbox_handle: &self
-                                        .state_handles
-                                        .speedbump_checkbox_handle,
-                                    speedbump_checkbox_action:
-                                        CLISubagentAction::ToggleAlwaysAllowWriteToPty,
-                                    ai_settings_link: &self.state_handles.ai_settings_link,
-                                },
-                            ),
-                        },
-                        app,
-                    ))
-                }
-                AIAgentActionType::TransferShellCommandControlToUser { ref reason } => {
-                    Some(render_blocked_action(
-                        BlockedActionProps {
-                            header: BLOCKED_ACTION_MESSAGE_FOR_TRANSFER_CONTROL.to_string(),
-                            description: Some(render_transfer_control_reason(reason, app)),
-                            is_allow_menu_open: false,
-                            allow_menu: None,
-                            buttons: vec![&self.reject_button, &self.transfer_control_button],
-                            speedbump: None,
-                        },
-                        app,
-                    ))
-                }
-                AIAgentActionType::ReadFiles(..)
-                | AIAgentActionType::Grep { .. }
-                | AIAgentActionType::FileGlobV2 { .. } => Some(render_blocked_action(
-                    BlockedActionProps {
-                        header: get_blocked_action_header(action.action.clone())
-                            .unwrap_or_default(),
-                        description: render_search_action_input(action.action.clone(), app),
-                        is_allow_menu_open: self.is_allow_menu_open,
-                        allow_menu: Some(&self.allow_menu),
-                        buttons: vec![
-                            &self.allow_button,
-                            &self.reject_button,
-                            &self.take_over_button,
-                        ],
-                        speedbump: should_show_read_files_speedbump(app).then_some(
-                            PermissionsSpeedbumpProps {
-                                always_allow_checked: self.always_allow_read_files_checked,
-                                speedbump_checkbox_handle: &self
-                                    .state_handles
-                                    .speedbump_checkbox_handle,
-                                speedbump_checkbox_action:
-                                    CLISubagentAction::ToggleAlwaysAllowReadFiles,
-                                ai_settings_link: &self.state_handles.ai_settings_link,
+                            ))
+                        }
+                        AIAgentActionType::ReadFiles(..)
+                        | AIAgentActionType::Grep { .. }
+                        | AIAgentActionType::FileGlobV2 { .. } => Some(render_blocked_action(
+                            BlockedActionProps {
+                                header: get_blocked_action_header(action.action.clone())
+                                    .unwrap_or_default(),
+                                description: render_search_action_input(action.action.clone(), app),
+                                is_allow_menu_open: self.is_allow_menu_open,
+                                allow_menu: Some(&self.allow_menu),
+                                buttons: vec![
+                                    &self.allow_button,
+                                    &self.reject_button,
+                                    &self.take_over_button,
+                                ],
+                                speedbump: should_show_read_files_speedbump(app).then_some(
+                                    PermissionsSpeedbumpProps {
+                                        always_allow_checked: self.always_allow_read_files_checked,
+                                        speedbump_checkbox_handle: &self
+                                            .state_handles
+                                            .speedbump_checkbox_handle,
+                                        speedbump_checkbox_action:
+                                            CLISubagentAction::ToggleAlwaysAllowReadFiles,
+                                        ai_settings_link: &self.state_handles.ai_settings_link,
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                    app,
-                )),
-                _ => None,
-            }) {
-                let action_selection_handle = selection_handle_for_index(
-                    &self.state_handles.action_selection_handles,
-                    model_index,
-                );
-                let selected_text = self.selected_text.clone();
-                let query_selection_handles = self.state_handles.query_selection_handles.clone();
-                let output_selection_handles = self.state_handles.output_selection_handles.clone();
-                let action_selection_handles = self.state_handles.action_selection_handles.clone();
-                // 克隆一份本区域句柄进闭包，判断"本区域是否真的在参与选择"。
-                // Flex 会把同一鼠标事件广播给所有兄弟 SelectableArea，未命中的气泡也会触发本回调，
-                // 此时不能用未命中的回调去清掉真正命中区域的划词状态。
-                let action_selection_handle_clone = action_selection_handle.clone();
-                let mut selectable_action = SelectableArea::new(
-                    action_selection_handle,
-                    move |selection_args, ctx, _| {
-                        let selection = selection_args.selection;
-                        // 只有本区域确实参与选择时（正在 selecting 或已产生非空选中文本），
-                        // 才清掉其它同级区域的旧选择；未命中广播则保持原状。
-                        let is_this_area_active = action_selection_handle_clone.is_selecting()
-                            || selection.as_ref().is_some_and(|s| !s.is_empty());
-                        if is_this_area_active {
-                            clear_selection_handles_for_active_area(
-                                &query_selection_handles,
-                                &output_selection_handles,
-                                &action_selection_handles,
-                                SelectionHandleGroup::Action,
-                                model_index,
-                            );
-                        }
-                        if let Some(selection) = selection.filter(|selection| !selection.is_empty())
-                        {
-                            ctx.dispatch_typed_action(CLISubagentAction::CopyOnSelect(
-                                selection.clone(),
-                            ));
-                            *selected_text.write() = Some(selection);
-                            ctx.dispatch_typed_action(CLISubagentAction::SelectText);
-                        } else if is_this_area_active {
-                            *selected_text.write() = None;
-                        }
-                    },
-                    rendered_action,
-                )
-                .with_word_boundaries_policy(semantic_selection.word_boundary_policy())
-                .with_smart_select_fn(semantic_selection.smart_select_fn());
+                            app,
+                        )),
+                        _ => None,
+                    })
+                {
+                    let action_selection_handle = selection_handle_for_index(
+                        &self.state_handles.action_selection_handles,
+                        model_index,
+                    );
+                    let selected_text = self.selected_text.clone();
+                    let query_selection_handles =
+                        self.state_handles.query_selection_handles.clone();
+                    let output_selection_handles =
+                        self.state_handles.output_selection_handles.clone();
+                    let action_selection_handles =
+                        self.state_handles.action_selection_handles.clone();
+                    // 克隆一份本区域句柄进闭包，判断"本区域是否真的在参与选择"。
+                    // Flex 会把同一鼠标事件广播给所有兄弟 SelectableArea，未命中的气泡也会触发本回调，
+                    // 此时不能用未命中的回调去清掉真正命中区域的划词状态。
+                    let action_selection_handle_clone = action_selection_handle.clone();
+                    let mut selectable_action = SelectableArea::new(
+                        action_selection_handle,
+                        move |selection_args, ctx, _| {
+                            let selection = selection_args.selection;
+                            // 只有本区域确实参与选择时（正在 selecting 或已产生非空选中文本），
+                            // 才清掉其它同级区域的旧选择；未命中广播则保持原状。
+                            let is_this_area_active = action_selection_handle_clone.is_selecting()
+                                || selection.as_ref().is_some_and(|s| !s.is_empty());
+                            if is_this_area_active {
+                                clear_selection_handles_for_active_area(
+                                    &query_selection_handles,
+                                    &output_selection_handles,
+                                    &action_selection_handles,
+                                    SelectionHandleGroup::Action,
+                                    model_index,
+                                );
+                            }
+                            if let Some(selection) =
+                                selection.filter(|selection| !selection.is_empty())
+                            {
+                                ctx.dispatch_typed_action(CLISubagentAction::CopyOnSelect(
+                                    selection.clone(),
+                                ));
+                                *selected_text.write() = Some(selection);
+                                ctx.dispatch_typed_action(CLISubagentAction::SelectText);
+                            } else if is_this_area_active {
+                                *selected_text.write() = None;
+                            }
+                        },
+                        rendered_action,
+                    )
+                    .with_word_boundaries_policy(semantic_selection.word_boundary_policy())
+                    .with_smart_select_fn(semantic_selection.smart_select_fn());
 
-                if FeatureFlag::RectSelection.is_enabled() {
-                    selectable_action = selectable_action.should_support_rect_select();
+                    if FeatureFlag::RectSelection.is_enabled() {
+                        selectable_action = selectable_action.should_support_rect_select();
+                    }
+
+                    conversation_items.add_child(
+                        Container::new(selectable_action.finish())
+                            .with_margin_bottom(8.)
+                            .finish(),
+                    );
                 }
-
-                conversation_items.add_child(
-                    Container::new(selectable_action.finish())
-                        .with_margin_bottom(8.)
-                        .finish(),
-                );
             }
         }
 
@@ -1947,6 +2049,9 @@ impl View for CLISubagentView {
 
     fn keymap_context(&self, app: &AppContext) -> warpui::keymap::Context {
         let mut context = Self::default_keymap_context();
+        if self.mode == CLISubagentViewMode::RestoredReadOnly {
+            return context;
+        }
 
         let terminal_model = self.terminal_model.lock();
         let active_block = terminal_model.block_list().active_block();
@@ -1985,6 +2090,7 @@ impl TypedActionView for CLISubagentView {
     type Action = CLISubagentAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        let is_restored_read_only = self.mode == CLISubagentViewMode::RestoredReadOnly;
         match action {
             CLISubagentAction::CopyCode(code) => {
                 ctx.clipboard()
@@ -2003,23 +2109,41 @@ impl TypedActionView for CLISubagentView {
                 log::info!("Received open code block action: {source:?}");
             }
             CLISubagentAction::ExecuteBlockedAction => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.handle_execute_blocked_action(false, ctx);
             }
             CLISubagentAction::ExecuteAndAutoApprove => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.handle_execute_blocked_action(true, ctx);
             }
             CLISubagentAction::RejectBlockedAction {
                 should_user_take_over,
             } => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.handle_reject_blocked_action(*should_user_take_over, ctx);
             }
             CLISubagentAction::TakeControlOfRunningCommand => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.take_control_of_running_command(ctx);
             }
             CLISubagentAction::ToggleAllowMenu => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.toggle_allow_menu(ctx);
             }
             CLISubagentAction::ToggleAlwaysAllowWriteToPty => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.always_allow_write_to_pty_checked = !self.always_allow_write_to_pty_checked;
                 BlocklistAIPermissions::handle(ctx).update(ctx, |model, ctx| {
                     if let Err(e) = model.set_always_allow_write_to_pty(
@@ -2033,6 +2157,9 @@ impl TypedActionView for CLISubagentView {
                 ctx.notify();
             }
             CLISubagentAction::ToggleAlwaysAllowReadFiles => {
+                if is_restored_read_only {
+                    return;
+                }
                 self.always_allow_read_files_checked = !self.always_allow_read_files_checked;
                 BlocklistAIPermissions::handle(ctx).update(ctx, |model, ctx| {
                     if let Err(e) = model.set_always_allow_read_files(
@@ -2697,6 +2824,29 @@ mod tests {
         AIAgentTextSection::PlainText {
             text: AgentOutputText::from(text.to_string()),
         }
+    }
+
+    #[test]
+    fn restored_cli_subagent_view_renders_for_matching_metadata() {
+        let conversation_id = AIConversationId::new();
+        let task_id = TaskId::new("task-1".to_string());
+        let metadata = AgentInteractionMetadata::new(
+            None,
+            conversation_id,
+            Some(task_id.clone()),
+            None,
+            false,
+            false,
+        );
+
+        assert!(cli_subagent_should_render_for_metadata(
+            CLISubagentViewMode::RestoredReadOnly,
+            Some(&metadata),
+            conversation_id,
+            &task_id,
+            false,
+            false,
+        ));
     }
 
     #[test]

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -2850,6 +2850,47 @@ mod tests {
     }
 
     #[test]
+    fn restored_cli_subagent_view_requires_matching_metadata() {
+        let conversation_id = AIConversationId::new();
+        let other_conversation_id = AIConversationId::new();
+        let task_id = TaskId::new("task-1".to_string());
+        let other_task_id = TaskId::new("task-2".to_string());
+        let metadata = AgentInteractionMetadata::new(
+            None,
+            conversation_id,
+            Some(task_id.clone()),
+            None,
+            false,
+            false,
+        );
+
+        assert!(!cli_subagent_should_render_for_metadata(
+            CLISubagentViewMode::RestoredReadOnly,
+            None,
+            conversation_id,
+            &task_id,
+            true,
+            false,
+        ));
+        assert!(!cli_subagent_should_render_for_metadata(
+            CLISubagentViewMode::RestoredReadOnly,
+            Some(&metadata),
+            other_conversation_id,
+            &task_id,
+            true,
+            false,
+        ));
+        assert!(!cli_subagent_should_render_for_metadata(
+            CLISubagentViewMode::RestoredReadOnly,
+            Some(&metadata),
+            conversation_id,
+            &other_task_id,
+            true,
+            false,
+        ));
+    }
+
+    #[test]
     fn cli_subagent_resize_width_bounds_allow_nearly_full_window() {
         assert_eq!(cli_subagent_width_bounds(1000.0), (360.0, 984.0));
     }

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -300,7 +300,9 @@ impl CLISubagentController {
                         .entry(snapshot_block_id.clone())
                         .or_default()
                         .last_snapshot_at = Some(Instant::now());
-                    ctx.emit(CLISubagentEvent::UpdatedLastSnapshot);
+                    ctx.emit(CLISubagentEvent::UpdatedLastSnapshot {
+                        block_id: snapshot_block_id,
+                    });
                 }
 
                 // Zap BYOP: silent_create_for_byop 不 emit CreatedSubtask,这里手动
@@ -354,13 +356,12 @@ impl CLISubagentController {
                     .as_ref()
                     .is_some_and(|state| state.last_snapshot_at.is_some())
                 {
-                    ctx.emit(CLISubagentEvent::UpdatedLastSnapshot);
+                    ctx.emit(CLISubagentEvent::UpdatedLastSnapshot {
+                        block_id: block_id.clone(),
+                    });
                 }
 
-                if removed_subagent_state
-                    .as_ref()
-                    .is_some_and(|state| state.task_id.is_some())
-                {
+                if let Some(task_id) = removed_subagent_state.and_then(|state| state.task_id) {
                     let is_inline_agent_view =
                         me.agent_view_controller.as_ref().is_some_and(|controller| {
                             controller.read(ctx, |controller, _| controller.is_inline())
@@ -382,6 +383,7 @@ impl CLISubagentController {
 
                     ctx.emit(CLISubagentEvent::FinishedSubagent {
                         block_id,
+                        task_id,
                         conversation_id,
                         initial_requested_command_action_id: requested_command_action_id,
                     });
@@ -715,6 +717,7 @@ pub enum CLISubagentEvent {
     // Emitted when a CLI subagent's execution ends.
     FinishedSubagent {
         block_id: BlockId,
+        task_id: TaskId,
         conversation_id: Option<AIConversationId>,
         initial_requested_command_action_id: Option<AIAgentActionId>,
     },
@@ -723,7 +726,9 @@ pub enum CLISubagentEvent {
         requested_command_action_id: Option<AIAgentActionId>,
         agent_has_control: bool,
     },
-    UpdatedLastSnapshot,
+    UpdatedLastSnapshot {
+        block_id: BlockId,
+    },
     ToggledHideResponses,
     /// Emitted when the user hands control back to the agent after a
     /// TransferShellCommandControlToUser action.

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -236,7 +236,7 @@ impl BlocklistAIStatusBar {
                 | CLISubagentEvent::ToggledHideResponses => {
                     ctx.notify();
                 }
-                CLISubagentEvent::UpdatedLastSnapshot => {
+                CLISubagentEvent::UpdatedLastSnapshot { .. } => {
                     let has_active_snapshot = me.should_refresh_last_read_timer(ctx);
                     if has_active_snapshot {
                         me.start_last_read_timer(ctx);

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1070,6 +1070,7 @@ impl BlocklistAIHistoryModel {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json,
+            cli_subagent_block_snapshots_json: None,
         };
         let forked_conversation_id = AIConversationId::new();
         if let Err(e) = sqlite_sender.send(ModelEvent::UpdateMultiAgentConversation {
@@ -1239,6 +1240,7 @@ impl BlocklistAIHistoryModel {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json,
+            cli_subagent_block_snapshots_json: None,
         };
 
         let forked_conversation_id = AIConversationId::new();

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 
+use chrono::TimeZone;
 use futures::FutureExt;
 use itertools::Itertools as _;
 use persistence::model::AgentConversationRecord;
@@ -60,6 +61,7 @@ pub fn convert_persisted_conversation_to_ai_conversation_with_metadata(
             AgentConversationRecord {
                 conversation_id,
                 conversation_data,
+                last_modified_at,
                 ..
             },
     } = persisted_conversation;
@@ -75,7 +77,13 @@ pub fn convert_persisted_conversation_to_ai_conversation_with_metadata(
     let conversation_data = serde_json::from_str::<AgentConversationData>(&conversation_data).ok();
 
     match AIConversation::new_restored(conversation_id, tasks, conversation_data) {
-        Ok(conversation) => Some(conversation),
+        Ok(mut conversation) => {
+            // 持久化 Task 里的旧消息可能没有 CurrentTime/timestamp,恢复 exchange 时会退到
+            // Unix epoch。SQLite 行级更新时间是这个会话最后写入的可靠兜底时间。
+            let fallback_timestamp = chrono::Local.from_utc_datetime(&last_modified_at);
+            conversation.repair_default_restored_exchange_timestamps(fallback_timestamp);
+            Some(conversation)
+        }
         Err(e) => {
             log::debug!("Skipping persisted conversation (legacy/incomplete): {e:?}");
             None

--- a/app/src/ai/blocklist/history_model_test.rs
+++ b/app/src/ai/blocklist/history_model_test.rs
@@ -1149,6 +1149,7 @@ fn test_find_by_token_after_insert_forked_conversation_from_tasks() {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json: None,
+            cli_subagent_block_snapshots_json: None,
         };
         let tasks = vec![warp_multi_agent_api::Task {
             id: "root-task".to_string(),

--- a/app/src/ai/blocklist/history_model_test.rs
+++ b/app/src/ai/blocklist/history_model_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local, TimeZone, Utc};
 use itertools::Itertools;
 use warpui::{App, EntityId};
 
@@ -18,7 +18,13 @@ use crate::{
         llms::LLMId,
     },
     input_suggestions::HistoryInputSuggestion,
-    persistence::{model::PersistedAutoexecuteMode, ModelEvent},
+    persistence::{
+        model::{
+            AgentConversation, AgentConversationData, AgentConversationRecord,
+            PersistedAutoexecuteMode,
+        },
+        ModelEvent,
+    },
     terminal::model::session::SessionId,
     test_util::settings::initialize_settings_for_tests,
     GlobalResourceHandles, GlobalResourceHandlesProvider,
@@ -26,8 +32,8 @@ use crate::{
 use warp_multi_agent_api as api;
 
 use super::{
-    AIConversationMetadata, AIQueryHistoryOutputStatus, BlocklistAIHistoryModel, PersistedAIInput,
-    PersistedAIInputType,
+    convert_persisted_conversation_to_ai_conversation_with_metadata, AIConversationMetadata,
+    AIQueryHistoryOutputStatus, BlocklistAIHistoryModel, PersistedAIInput, PersistedAIInputType,
 };
 
 fn initialize_history_model_test_app(app: &mut App) {
@@ -105,6 +111,75 @@ fn byop_test_task(task_id: &str, messages: Vec<api::Message>) -> api::Task {
     }
 }
 
+fn empty_agent_conversation_data_for_test() -> AgentConversationData {
+    AgentConversationData {
+        server_conversation_token: None,
+        conversation_usage_metadata: None,
+        reverted_action_ids: None,
+        forked_from_server_conversation_token: None,
+        artifacts_json: None,
+        parent_agent_id: None,
+        agent_name: None,
+        parent_conversation_id: None,
+        run_id: None,
+        autoexecute_override: None,
+        last_event_sequence: None,
+        compaction_state_json: None,
+        byop_repair_state_json: None,
+        cli_subagent_block_snapshots_json: None,
+    }
+}
+
+fn timestamp_from_local_time(time: DateTime<Local>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: time.timestamp(),
+        nanos: time.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn persisted_agent_conversation_for_test(
+    conversation_id: AIConversationId,
+    last_modified_at: chrono::NaiveDateTime,
+    messages: Vec<api::Message>,
+) -> AgentConversation {
+    AgentConversation {
+        conversation: AgentConversationRecord {
+            id: 1,
+            conversation_id: conversation_id.to_string(),
+            conversation_data: serde_json::to_string(&empty_agent_conversation_data_for_test())
+                .expect("test conversation data should serialize"),
+            last_modified_at,
+        },
+        tasks: vec![byop_test_task("root-task", messages)],
+    }
+}
+
+fn byop_user_query_message(
+    message_id: &str,
+    request_id: &str,
+    query: &str,
+    current_time: Option<DateTime<Local>>,
+) -> api::Message {
+    api::Message {
+        id: message_id.to_owned(),
+        task_id: "root-task".to_owned(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+            query: query.to_owned(),
+            context: current_time.map(|time| api::InputContext {
+                current_time: Some(timestamp_from_local_time(time)),
+                ..Default::default()
+            }),
+            referenced_attachments: Default::default(),
+            mode: None,
+            intended_agent: Default::default(),
+        })),
+        request_id: request_id.to_owned(),
+        timestamp: None,
+    }
+}
+
 fn byop_tool_call_message(task_id: &str, message_id: &str, call_id: &str) -> api::Message {
     api::Message {
         id: message_id.to_owned(),
@@ -136,6 +211,61 @@ fn byop_tool_result_message(task_id: &str, message_id: &str, call_id: &str) -> a
         request_id: "request-1".to_owned(),
         timestamp: None,
     }
+}
+
+#[test]
+fn persisted_conversation_uses_record_timestamp_when_restored_messages_have_no_time() {
+    let conversation_id = AIConversationId::new();
+    let fallback_time = Utc
+        .with_ymd_and_hms(2026, 7, 2, 7, 13, 11)
+        .unwrap()
+        .naive_utc();
+    let persisted_conversation = persisted_agent_conversation_for_test(
+        conversation_id,
+        fallback_time,
+        vec![byop_user_query_message(
+            "user-query-1",
+            "request-1",
+            "restore me",
+            None,
+        )],
+    );
+
+    let restored =
+        convert_persisted_conversation_to_ai_conversation_with_metadata(persisted_conversation)
+            .expect("persisted conversation should restore");
+
+    let restored_time = restored
+        .last_modified_at()
+        .expect("restored conversation should have an exchange timestamp");
+    assert_eq!(restored_time, Local.from_utc_datetime(&fallback_time));
+    assert_ne!(restored_time, Local.timestamp_opt(0, 0).single().unwrap());
+}
+
+#[test]
+fn persisted_conversation_keeps_restored_message_time_when_present() {
+    let conversation_id = AIConversationId::new();
+    let fallback_time = Utc
+        .with_ymd_and_hms(2026, 7, 2, 7, 13, 11)
+        .unwrap()
+        .naive_utc();
+    let message_time = Local.with_ymd_and_hms(2026, 7, 2, 16, 42, 0).unwrap();
+    let persisted_conversation = persisted_agent_conversation_for_test(
+        conversation_id,
+        fallback_time,
+        vec![byop_user_query_message(
+            "user-query-1",
+            "request-1",
+            "restore me",
+            Some(message_time),
+        )],
+    );
+
+    let restored =
+        convert_persisted_conversation_to_ai_conversation_with_metadata(persisted_conversation)
+            .expect("persisted conversation should restore");
+
+    assert_eq!(restored.last_modified_at(), Some(message_time));
 }
 
 #[test]

--- a/app/src/terminal/input/models/view.rs
+++ b/app/src/terminal/input/models/view.rs
@@ -325,7 +325,7 @@ impl InlineModelSelectorView {
             | CLISubagentEvent::UpdatedControl { .. } => {
                 me.menu_view.update(ctx, |_, ctx| ctx.notify());
             }
-            CLISubagentEvent::UpdatedLastSnapshot
+            CLISubagentEvent::UpdatedLastSnapshot { .. }
             | CLISubagentEvent::ToggledHideResponses
             | CLISubagentEvent::ControlHandedBackAfterTransfer => {}
         });

--- a/app/src/terminal/model/block/serialized_block.rs
+++ b/app/src/terminal/model/block/serialized_block.rs
@@ -90,6 +90,16 @@ fn default_as_true() -> bool {
     true
 }
 
+/// `should_hide_block` 的序列化判定：仅当值为 `false`（可见）时写入 JSON。
+///
+/// 历史上该字段被无条件 `skip`，导致 CLI subagent 等需要保持可见的块在重启恢复后
+/// 被 `default = true` 误判为隐藏。这里收窄为「只持久化可见状态」：
+/// - `true`（隐藏，默认）：不序列化，反序列化走 `default_as_true`，与旧数据兼容。
+/// - `false`（可见）：序列化写入，恢复后保持可见。
+fn skip_hide_when_true(value: &bool) -> bool {
+    *value
+}
+
 /// Blocklist AI metadata associated with this block.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SerializedAIMetadata {
@@ -111,7 +121,7 @@ pub struct SerializedAIMetadata {
 
     /// `true` if this block should be hidden from the user (as is the case with AI-requested
     /// commands, for example).
-    #[serde(default = "default_as_true")]
+    #[serde(default = "default_as_true", skip_serializing_if = "skip_hide_when_true")]
     should_hide_block: bool,
 }
 

--- a/app/src/terminal/model/block/serialized_block.rs
+++ b/app/src/terminal/model/block/serialized_block.rs
@@ -111,7 +111,7 @@ pub struct SerializedAIMetadata {
 
     /// `true` if this block should be hidden from the user (as is the case with AI-requested
     /// commands, for example).
-    #[serde(default = "default_as_true", skip)]
+    #[serde(default = "default_as_true")]
     should_hide_block: bool,
 }
 

--- a/app/src/terminal/model/block/serialized_block_tests.rs
+++ b/app/src/terminal/model/block/serialized_block_tests.rs
@@ -61,3 +61,40 @@ fn from_json_accepts_integer_array_bytes() {
     assert_eq!(block.stylized_command, b"echo hello");
     assert_eq!(block.stylized_output, b"hello world");
 }
+
+#[test]
+fn serialized_ai_metadata_defaults_missing_should_hide_block_to_true() {
+    let conversation_id = AIConversationId::new();
+    let json = serde_json::json!({
+        "requested_command_action_id": null,
+        "conversation_id": conversation_id,
+        "subagent_task_id": null,
+        "long_running_control_state": null,
+        "has_agent_written_to_block": false
+    });
+
+    let metadata: SerializedAIMetadata = serde_json::from_value(json).unwrap();
+    let agent_metadata: AgentInteractionMetadata = metadata.into();
+
+    assert!(agent_metadata.should_hide_block());
+}
+
+#[test]
+fn serialized_ai_metadata_preserves_explicit_visible_block() {
+    let metadata = SerializedAIMetadata::from(AgentInteractionMetadata::new(
+        None,
+        AIConversationId::new(),
+        Some(TaskId::new("cli-task-1".to_string())),
+        None,
+        false,
+        false,
+    ));
+
+    let json = serde_json::to_value(&metadata).unwrap();
+    assert_eq!(json["should_hide_block"], false);
+
+    let restored_metadata: SerializedAIMetadata = serde_json::from_value(json).unwrap();
+    let agent_metadata: AgentInteractionMetadata = restored_metadata.into();
+
+    assert!(!agent_metadata.should_hide_block());
+}

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5460,8 +5460,11 @@ impl TerminalView {
                 }
             }
             CLISubagentEvent::ToggledHideResponses => {}
-            CLISubagentEvent::UpdatedLastSnapshot { block_id } => {
-                self.persist_cli_subagent_block_snapshot(block_id, None, None, None, ctx);
+            CLISubagentEvent::UpdatedLastSnapshot { .. } => {
+                // 仅更新内存中的 last_snapshot_at（已在 controller 内完成），
+                // 不触发全量落盘。落盘由低频的 SpawnedSubagent / FinishedSubagent 承担，
+                // 避免 BlockCompleted 时 UpdatedLastSnapshot 与紧随其后的 FinishedSubagent
+                // 连续两次全量序列化整个 conversation 造成主线程写放大。
             }
             CLISubagentEvent::ControlHandedBackAfterTransfer => {
                 // Notify the shell command executor that control was handed back after transfer.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5188,28 +5188,14 @@ impl TerminalView {
             self.cli_subagent_views.len()
         );
 
-        ctx.subscribe_to_view(&subagent_view, |me, view, event, ctx| match event {
-            CLISubagentViewEvent::TextSelected => {
-                // CLI subagent 的文本选择不能和 block list / alt screen 选择并存，
-                // 先清掉终端侧选择，再交给统一的 rich content selection 逻辑收尾。
-                {
-                    let mut model = me.model.lock();
-                    model.block_list_mut().clear_selection();
-                    model.alt_screen_mut().clear_selection();
-                }
-                // 清理临时拖选状态，避免切换到 CLI subagent view 后仍残留旧选择视觉。
-                me.is_selecting = false;
-                me.block_text_selection_start_position = None;
-                me.clear_selected_text_except(Some(view.id()), ctx);
-                ctx.notify();
-            }
-            CLISubagentViewEvent::CopiedEmptyText => {
-                me.copy(ctx);
-            }
-            #[cfg(windows)]
-            CLISubagentViewEvent::WindowsCtrlC => {
-                me.ctrl_c(ctx);
-            }
+        let should_forward_windows_ctrl_c = is_live;
+        ctx.subscribe_to_view(&subagent_view, move |me, view, event, ctx| {
+            me.handle_cli_subagent_view_event(
+                view.id(),
+                event,
+                should_forward_windows_ctrl_c,
+                ctx,
+            );
         });
 
         if is_live {
@@ -5230,6 +5216,40 @@ impl TerminalView {
                         .lock()
                         .block_list_mut()
                         .remove_rich_content(result_ai_block_id);
+                }
+            }
+        }
+    }
+
+    fn handle_cli_subagent_view_event(
+        &mut self,
+        cli_subagent_view_id: EntityId,
+        event: &CLISubagentViewEvent,
+        should_forward_windows_ctrl_c: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            CLISubagentViewEvent::TextSelected => {
+                // CLI subagent 的文本选择不能和 block list / alt screen 选择并存，
+                // 先清掉终端侧选择，再交给统一的 rich content selection 逻辑收尾。
+                {
+                    let mut model = self.model.lock();
+                    model.block_list_mut().clear_selection();
+                    model.alt_screen_mut().clear_selection();
+                }
+                // 清理临时拖选状态，避免切换到 CLI subagent view 后仍残留旧选择视觉。
+                self.is_selecting = false;
+                self.block_text_selection_start_position = None;
+                self.clear_selected_text_except(Some(cli_subagent_view_id), ctx);
+                ctx.notify();
+            }
+            CLISubagentViewEvent::CopiedEmptyText => {
+                self.copy(ctx);
+            }
+            #[cfg(windows)]
+            CLISubagentViewEvent::WindowsCtrlC => {
+                if should_forward_windows_ctrl_c {
+                    self.ctrl_c(ctx);
                 }
             }
         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3086,12 +3086,38 @@ impl TerminalView {
                     // LRC conversations should only have one entry point (the original LRC block).
                     let has_existing_lrc_block =
                         me.has_existing_lrc_agent_view_block(*conversation_id);
+                    let has_existing_agent_view_entry_block =
+                        me.has_agent_view_entry_block_for_conversation(*conversation_id);
+                    let is_restored_existing_conversation_origin = matches!(
+                        origin,
+                        AgentViewEntryOrigin::ConversationListView
+                            | AgentViewEntryOrigin::RestoreExistingConversation
+                            | AgentViewEntryOrigin::AgentViewBlock
+                            | AgentViewEntryOrigin::ConversationSelector
+                            | AgentViewEntryOrigin::InlineHistoryMenu
+                            | AgentViewEntryOrigin::InlineConversationMenu
+                    );
+                    let has_conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(conversation_id)
+                        .is_some();
+                    let should_insert_restored_unmodified_entry_card = !was_modified
+                        && !was_new
+                        && !*was_ambient_agent
+                        && is_restored_existing_conversation_origin
+                        && has_conversation
+                        && !is_exit_due_to_user_takeover_of_lrc
+                        && !has_existing_lrc_block
+                        && !has_existing_agent_view_entry_block;
 
                     let should_insert = (!me
                         .last_visible_item_is_agent_view_block_for_conversation(*conversation_id)
                         && was_modified
                         && !is_exit_due_to_user_takeover_of_lrc
                         && !has_existing_lrc_block)
+                        // restored/历史会话只读查看时不会新增 exchange；
+                        // 用户按 ESC 返回 terminal 后仍需要一个 terminal-mode 入口卡片，
+                        // 否则 fullscreen AgentView 退出后所有 Agent block 都会被隐藏。
+                        || should_insert_restored_unmodified_entry_card
                         // If the agent view was entered via accepting a 'new conversation
                         // speedbump', an entry block should always be inserted.
                         || matches!(origin, AgentViewEntryOrigin::AgentRequestedNewConversation);
@@ -3100,7 +3126,7 @@ impl TerminalView {
                             AgentViewEntryBlockParams {
                                 conversation_id: *conversation_id,
                                 is_new: was_new,
-                                is_restored: false, /* is_restored */
+                                is_restored: should_insert_restored_unmodified_entry_card,
                                 origin: *origin,
                                 agent_view_controller: me.agent_view_controller.clone(),
                             },
@@ -19582,6 +19608,18 @@ impl TerminalView {
         }
 
         false
+    }
+
+    /// 返回当前终端里是否已经有该 conversation 的 AgentView 入口卡片。
+    fn has_agent_view_entry_block_for_conversation(
+        &self,
+        conversation_id: AIConversationId,
+    ) -> bool {
+        self.rich_content_views.iter().any(|content| {
+            content
+                .agent_view_entry_metadata()
+                .is_some_and(|metadata| metadata.conversation_id == conversation_id)
+        })
     }
 
     /// Returns true when there exists an AgentViewBlock with origin LongRunningCommand that matches

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -74,7 +74,9 @@ use super::CLIAgent;
 #[cfg(feature = "local_fs")]
 use crate::ai::agent::{CurrentHead, DiffBase};
 use crate::ai::ambient_agents::{conversation_output_status_from_conversation, AmbientAgentTaskId};
-use crate::ai::blocklist::block::cli::{CLISubagentView, CLISubagentViewEvent};
+use crate::ai::blocklist::block::cli::{
+    CLISubagentView, CLISubagentViewEvent, CLISubagentViewMode,
+};
 use crate::ai::blocklist::block::cli_controller::{
     CLISubagentController, CLISubagentEvent, UserTakeOverReason,
 };
@@ -172,6 +174,7 @@ use warpui::{ViewHandle, WeakModelHandle};
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 
+use crate::ai::agent::task::TaskId;
 #[cfg(any(test, feature = "integration_tests"))]
 use crate::ai::agent::UserQueryMode;
 use crate::ai::agent::{
@@ -5136,6 +5139,102 @@ impl TerminalView {
         ctx.notify();
     }
 
+    pub(super) fn create_cli_subagent_view(
+        &mut self,
+        block_id: BlockId,
+        conversation_id: AIConversationId,
+        task_id: TaskId,
+        mode: CLISubagentViewMode,
+        initial_requested_command_action_id: Option<&AIAgentActionId>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let is_live = mode == CLISubagentViewMode::Live;
+        let block_id_for_view = block_id.clone();
+        let task_id_for_view = task_id.clone();
+        let ai_action_model = self.ai_action_model.clone();
+        let cli_subagent_controller = self.cli_subagent_controller.clone();
+        let terminal_model = self.model.clone();
+        let current_working_directory = self.pwd();
+        let shell_launch_data = self.shell_launch_data_if_local(ctx);
+
+        let subagent_view = ctx.add_typed_action_view(move |ctx| match mode {
+            CLISubagentViewMode::Live => CLISubagentView::new(
+                block_id_for_view,
+                ai_action_model,
+                cli_subagent_controller,
+                terminal_model,
+                conversation_id,
+                task_id_for_view,
+                current_working_directory,
+                shell_launch_data,
+                ctx,
+            ),
+            CLISubagentViewMode::RestoredReadOnly => CLISubagentView::new_restored(
+                block_id_for_view,
+                ai_action_model,
+                cli_subagent_controller,
+                terminal_model,
+                conversation_id,
+                task_id_for_view,
+                current_working_directory,
+                shell_launch_data,
+                ctx,
+            ),
+        });
+        self.cli_subagent_views
+            .insert(block_id.clone(), subagent_view.clone());
+        log::info!(
+            "[byop-diag] cli_subagent_views.len()={} after insert",
+            self.cli_subagent_views.len()
+        );
+
+        ctx.subscribe_to_view(&subagent_view, |me, view, event, ctx| match event {
+            CLISubagentViewEvent::TextSelected => {
+                // CLI subagent 的文本选择不能和 block list / alt screen 选择并存，
+                // 先清掉终端侧选择，再交给统一的 rich content selection 逻辑收尾。
+                {
+                    let mut model = me.model.lock();
+                    model.block_list_mut().clear_selection();
+                    model.alt_screen_mut().clear_selection();
+                }
+                // 清理临时拖选状态，避免切换到 CLI subagent view 后仍残留旧选择视觉。
+                me.is_selecting = false;
+                me.block_text_selection_start_position = None;
+                me.clear_selected_text_except(Some(view.id()), ctx);
+                ctx.notify();
+            }
+            CLISubagentViewEvent::CopiedEmptyText => {
+                me.copy(ctx);
+            }
+            #[cfg(windows)]
+            CLISubagentViewEvent::WindowsCtrlC => {
+                me.ctrl_c(ctx);
+            }
+        });
+
+        if is_live {
+            if let Some(initial_requested_command_id) = initial_requested_command_action_id {
+                // live spawn 时，触发 CLI subagent 的那轮 AI block 只是桥接工具调用，
+                // 真正 UI 挂在 command block 上；移除它以保持 requested command 视觉连续。
+                if let Some(result_ai_block_id) = self.rich_content_views.iter().find_map(|view| {
+                    let ai_metadata = view.ai_block_metadata()?;
+                    ai_metadata
+                        .ai_block_handle
+                        .as_ref(ctx)
+                        .contains_action_result(initial_requested_command_id, ctx)
+                        .then_some(view.view_id())
+                }) {
+                    self.rich_content_views
+                        .retain(|rich_content| rich_content.view_id() != result_ai_block_id);
+                    self.model
+                        .lock()
+                        .block_list_mut()
+                        .remove_rich_content(result_ai_block_id);
+                }
+            }
+        }
+    }
+
     fn handle_cli_subagent_controller_event(
         &mut self,
         _: ModelHandle<CLISubagentController>,
@@ -5154,88 +5253,14 @@ impl TerminalView {
                      block_id={block_id:?} task_id={task_id:?} conv={conversation_id:?} \
                      → 创建 CLISubagentView 加进 cli_subagent_views map"
                 );
-                let subagent_view = ctx.add_typed_action_view(|ctx| {
-                    CLISubagentView::new(
-                        block_id.clone(),
-                        self.ai_action_model.clone(),
-                        self.cli_subagent_controller.clone(),
-                        self.model.clone(),
-                        *conversation_id,
-                        task_id.clone(),
-                        self.pwd(),
-                        self.shell_launch_data_if_local(ctx),
-                        ctx,
-                    )
-                });
-                self.cli_subagent_views
-                    .insert(block_id.clone(), subagent_view.clone());
-                log::info!(
-                    "[byop-diag] cli_subagent_views.len()={} after insert",
-                    self.cli_subagent_views.len()
+                self.create_cli_subagent_view(
+                    block_id.clone(),
+                    *conversation_id,
+                    task_id.clone(),
+                    CLISubagentViewMode::Live,
+                    initial_requested_command_action_id.as_ref(),
+                    ctx,
                 );
-
-                ctx.subscribe_to_view(&subagent_view, |me, view, event, ctx| match event {
-                    CLISubagentViewEvent::TextSelected => {
-                        // Unlike AI blocks, CLI subagent view text selections should not coexist
-                        // with block list or alt screen text selections. Clear those first before
-                        // calling `clear_selected_text_except`, which handles the side effects
-                        // (clipboard sync, context model, etc.) and clears other rich content views.
-                        {
-                            let mut model = me.model.lock();
-                            model.block_list_mut().clear_selection();
-                            model.alt_screen_mut().clear_selection();
-                        }
-                        // Also reset transient terminal-side selection state so stale alt-screen
-                        // selection visuals don't persist after switching selection focus to the
-                        // CLI subagent view.
-                        me.is_selecting = false;
-                        me.block_text_selection_start_position = None;
-                        me.clear_selected_text_except(Some(view.id()), ctx);
-                        ctx.notify();
-                    }
-                    CLISubagentViewEvent::CopiedEmptyText => {
-                        me.copy(ctx);
-                    }
-                    #[cfg(windows)]
-                    CLISubagentViewEvent::WindowsCtrlC => {
-                        me.ctrl_c(ctx);
-                    }
-                });
-
-                if let Some(initial_requested_command_id) = initial_requested_command_action_id {
-                    // Remove the AI block for the request/response pair that resulted in spawning
-                    // the CLI subagent. You can think of this block as corresponding to the
-                    // initial action result input for the long running requested command (the
-                    // initial output snapshot) and the output containing the subagent tool call.
-                    //
-                    // This block doesn't actually have any renderable inputs or outputs (typically,
-                    // the output tool call would be rendered like all our other tool calls), but
-                    // the CLI subagent tool call is 'special' in that it corresponds to UI rendered
-                    // on the _command_ block for the previously requested command.
-                    //
-                    // We remove this block so the AI block originally containing the requested
-                    // command remains immediately above the actual command block in the blocklist,
-                    // which enables visual continuity in the requested command's expanded state
-                    // (e.g. the expanded requested command header appears right on top of the
-                    // running command block; they appear part of the same UI component).
-                    if let Some(result_ai_block_id) =
-                        self.rich_content_views.iter().find_map(|view| {
-                            let ai_metadata = view.ai_block_metadata()?;
-                            ai_metadata
-                                .ai_block_handle
-                                .as_ref(ctx)
-                                .contains_action_result(initial_requested_command_id, ctx)
-                                .then_some(view.view_id())
-                        })
-                    {
-                        self.rich_content_views
-                            .retain(|rich_content| rich_content.view_id() != result_ai_block_id);
-                        self.model
-                            .lock()
-                            .block_list_mut()
-                            .remove_rich_content(result_ai_block_id);
-                    }
-                }
             }
             CLISubagentEvent::UpdatedControl {
                 agent_has_control, ..

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5371,6 +5371,35 @@ impl TerminalView {
                 );
                 self.cli_subagent_views.remove(block_id);
 
+                // SSH 等交互式 CLI subagent 会话结束后，Live 卡片会被回收，
+                // 但用户仍应能在终端里看到折叠的只读终端交互卡片（与重开历史时一致）。
+                // 这里在 block 仍持有匹配 metadata 的前提下，用 RestoredReadOnly 模式重建。
+                if let Some(conversation_id) = conversation_id {
+                    let should_restore = {
+                        let model = self.model.lock();
+                        model.block_list().block_with_id(block_id).is_some_and(
+                            |block| {
+                                block.agent_interaction_metadata().is_some_and(|metadata| {
+                                    metadata.conversation_id() == conversation_id
+                                        && metadata.subagent_task_id() == Some(task_id)
+                                })
+                            },
+                        )
+                    };
+                    if should_restore
+                        && !self.cli_subagent_views.contains_key(block_id)
+                    {
+                        self.create_cli_subagent_view(
+                            block_id.clone(),
+                            *conversation_id,
+                            task_id.clone(),
+                            CLISubagentViewMode::RestoredReadOnly,
+                            None,
+                            ctx,
+                        );
+                    }
+                }
+
                 if FeatureFlag::AgentView.is_enabled() {
                     let Some(conversation_id) = conversation_id else {
                         return;

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5255,6 +5255,64 @@ impl TerminalView {
         }
     }
 
+    fn persist_cli_subagent_block_snapshot(
+        &mut self,
+        block_id: &BlockId,
+        conversation_id: Option<AIConversationId>,
+        task_id: Option<TaskId>,
+        requested_command_action_id: Option<AIAgentActionId>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some((block_snapshot, conversation_id, task_id, requested_command_action_id)) = ({
+            let model = self.model.lock();
+            let Some(block) = model.block_list().block_with_id(block_id) else {
+                log::warn!("Cannot persist CLI subagent snapshot; block {block_id:?} not found");
+                return;
+            };
+            let metadata = block.agent_interaction_metadata();
+            let conversation_id =
+                conversation_id.or_else(|| metadata.map(|metadata| *metadata.conversation_id()));
+            let task_id = task_id
+                .or_else(|| metadata.and_then(|metadata| metadata.subagent_task_id().cloned()));
+            let requested_command_action_id = requested_command_action_id.or_else(|| {
+                metadata.and_then(|metadata| metadata.requested_command_action_id().cloned())
+            });
+
+            // 只在持锁期间复制 block 快照，写 conversation 时不持有 TerminalModel 锁。
+            let block_snapshot = SerializedBlock::from(block);
+            conversation_id
+                .zip(task_id)
+                .map(|(conversation_id, task_id)| {
+                    (
+                        block_snapshot,
+                        conversation_id,
+                        task_id,
+                        requested_command_action_id,
+                    )
+                })
+        }) else {
+            log::warn!(
+                "Cannot persist CLI subagent snapshot; block {block_id:?} has no conversation/task metadata"
+            );
+            return;
+        };
+
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, move |history_model, ctx| {
+            let Some(conversation) = history_model.conversation_mut(&conversation_id) else {
+                log::warn!(
+                    "Cannot persist CLI subagent snapshot; conversation {conversation_id} not found"
+                );
+                return;
+            };
+            conversation.upsert_cli_subagent_block_snapshot(
+                task_id,
+                block_snapshot,
+                requested_command_action_id,
+                ctx,
+            );
+        });
+    }
+
     fn handle_cli_subagent_controller_event(
         &mut self,
         _: ModelHandle<CLISubagentController>,
@@ -5281,6 +5339,13 @@ impl TerminalView {
                     initial_requested_command_action_id.as_ref(),
                     ctx,
                 );
+                self.persist_cli_subagent_block_snapshot(
+                    block_id,
+                    Some(*conversation_id),
+                    Some(task_id.clone()),
+                    initial_requested_command_action_id.clone(),
+                    ctx,
+                );
             }
             CLISubagentEvent::UpdatedControl {
                 agent_has_control, ..
@@ -5293,9 +5358,17 @@ impl TerminalView {
             }
             CLISubagentEvent::FinishedSubagent {
                 block_id,
+                task_id,
                 conversation_id,
-                ..
+                initial_requested_command_action_id,
             } => {
+                self.persist_cli_subagent_block_snapshot(
+                    block_id,
+                    *conversation_id,
+                    Some(task_id.clone()),
+                    initial_requested_command_action_id.clone(),
+                    ctx,
+                );
                 self.cli_subagent_views.remove(block_id);
 
                 if FeatureFlag::AgentView.is_enabled() {
@@ -5332,7 +5405,9 @@ impl TerminalView {
                 }
             }
             CLISubagentEvent::ToggledHideResponses => {}
-            CLISubagentEvent::UpdatedLastSnapshot => {}
+            CLISubagentEvent::UpdatedLastSnapshot { block_id } => {
+                self.persist_cli_subagent_block_snapshot(block_id, None, None, None, ctx);
+            }
             CLISubagentEvent::ControlHandedBackAfterTransfer => {
                 // Notify the shell command executor that control was handed back after transfer.
                 self.ai_action_model

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -9,6 +9,7 @@ use super::blocklist_filter::exchanges_for_blocklist;
 use crate::ai::blocklist::agent_view::{
     AgentViewEntryBlockParams, AgentViewEntryOrigin, DismissalStrategy, EphemeralMessage,
 };
+use crate::ai::blocklist::block::cli::CLISubagentViewMode;
 use crate::ai::blocklist::block::cli_controller::CLISubagentController;
 use crate::ai::blocklist::history_model::{CLIAgentConversation, LoadedConversationData};
 use crate::ai::blocklist::BlocklistAIContextModel;
@@ -528,6 +529,49 @@ impl TerminalView {
         blocks_created
     }
 
+    pub(super) fn restore_cli_subagent_views_for_conversation(
+        &mut self,
+        conversation: &AIConversation,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let targets = conversation
+            .all_tasks()
+            .filter(|task| task.is_cli_subagent())
+            .filter_map(|task| {
+                let block_id = task.cli_subagent_block_id()?;
+                Some((block_id, task.id().clone()))
+            })
+            .collect::<Vec<_>>();
+
+        for (block_id, task_id) in targets {
+            let should_restore = {
+                let model = self.model.lock();
+                model
+                    .block_list()
+                    .block_with_id(&block_id)
+                    .is_some_and(|block| {
+                        // 已恢复的 command block 已经完成，不能依赖 live 长任务 predicate；
+                        // 这里用持久化 metadata 精确确认它属于当前 conversation 的 CLI subagent task。
+                        block.agent_interaction_metadata().is_some_and(|metadata| {
+                            metadata.conversation_id() == &conversation.id()
+                                && metadata.subagent_task_id() == Some(&task_id)
+                        })
+                    })
+            };
+
+            if should_restore && !self.cli_subagent_views.contains_key(&block_id) {
+                self.create_cli_subagent_view(
+                    block_id,
+                    conversation.id(),
+                    task_id,
+                    CLISubagentViewMode::RestoredReadOnly,
+                    None,
+                    ctx,
+                );
+            }
+        }
+    }
+
     /// Restore a conversation using the stored exchanges for said conversation.
     /// This is used for opening a historical conversation from the agent mode homepage, and
     /// when loading from a debug link.
@@ -542,6 +586,7 @@ impl TerminalView {
             "Restoring conversation after view creation: {}",
             conversation_id
         );
+        let conversation_for_cli_subagent_restore = restored.ai_conversation.clone();
 
         // Calculate height for AI blocks
         let size_info = *self.size_info;
@@ -587,6 +632,10 @@ impl TerminalView {
         // Restore action results from all exchanges
         let blocks_created =
             self.restore_conversations_from_block_params(all_ai_block_params, vec![restored], ctx);
+        self.restore_cli_subagent_views_for_conversation(
+            &conversation_for_cli_subagent_restore,
+            ctx,
+        );
 
         log::info!(
             "Successfully restored {blocks_created} AI blocks for conversation: {conversation_id}"
@@ -647,6 +696,10 @@ impl TerminalView {
         if restored_conversations.is_empty() {
             return;
         }
+        let conversations_for_cli_subagent_restore = restored_conversations
+            .iter()
+            .map(|restored| restored.ai_conversation.clone())
+            .collect::<Vec<_>>();
         let conversation_ids = restored_conversations
             .iter()
             .map(|r| r.ai_conversation.id())
@@ -724,6 +777,9 @@ impl TerminalView {
             restored_conversations,
             ctx,
         );
+        for conversation in &conversations_for_cli_subagent_restore {
+            self.restore_cli_subagent_views_for_conversation(conversation, ctx);
+        }
 
         if is_fork_conversation_in_new_pane {
             for conversation_id in &conversation_ids {

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -12,7 +13,7 @@ use crate::ai::blocklist::agent_view::{
 use crate::ai::blocklist::block::cli::CLISubagentViewMode;
 use crate::ai::blocklist::block::cli_controller::CLISubagentController;
 use crate::ai::blocklist::history_model::{CLIAgentConversation, LoadedConversationData};
-use crate::ai::blocklist::BlocklistAIContextModel;
+use crate::ai::blocklist::{BlocklistAIContextModel, SerializedBlockListItem};
 use crate::terminal::input::message_bar::Message as InputMessage;
 use crate::terminal::input::message_bar::MessageItem;
 use crate::terminal::model::block::SerializedBlock;
@@ -309,6 +310,40 @@ impl TerminalView {
             .insert_restored_block(&block);
     }
 
+    fn restore_missing_cli_subagent_blocks_for_conversation(
+        &mut self,
+        conversation: &AIConversation,
+    ) {
+        let cli_subagent_block_ids = conversation
+            .all_tasks()
+            .filter(|task| task.is_cli_subagent())
+            .filter_map(|task| task.cli_subagent_block_id())
+            .collect::<HashSet<_>>();
+        if cli_subagent_block_ids.is_empty() {
+            return;
+        }
+
+        // 历史列表进入已有 terminal 时不会预先把 conversation 的 block 快照塞进
+        // TerminalModel；这里只补 CLI subagent 持久化快照，避免普通历史命令重复出现。
+        let serialized_blocks = conversation.to_serialized_blocklist_items();
+        let mut terminal_model = self.model.lock();
+        for item in serialized_blocks {
+            let SerializedBlockListItem::Command { block } = item;
+            if !cli_subagent_block_ids.contains(&block.id)
+                || terminal_model
+                    .block_list()
+                    .block_with_id(&block.id)
+                    .is_some()
+            {
+                continue;
+            }
+
+            terminal_model
+                .block_list_mut()
+                .insert_restored_block(&block);
+        }
+    }
+
     /// Get AIConversations to restore given conversation IDs.
     pub(super) fn get_conversations_to_restore(
         conversation_ids: &[AIConversationId],
@@ -587,6 +622,7 @@ impl TerminalView {
             conversation_id
         );
         let conversation_for_cli_subagent_restore = restored.ai_conversation.clone();
+        self.restore_missing_cli_subagent_blocks_for_conversation(&restored.ai_conversation);
 
         // Calculate height for AI blocks
         let size_info = *self.size_info;

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -1037,6 +1037,7 @@ impl TerminalView {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json: None,
+            cli_subagent_block_snapshots_json: None,
         };
 
         match AIConversation::new_restored(conversation_id, tasks, Some(conversation_data)) {

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -13,6 +13,7 @@ use warpui::{notification::UserNotification, Presenter, WindowInvalidation};
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
+use crate::ai::blocklist::SerializedBlockListItem;
 use warpui::App;
 
 use crate::pane_group::focus_state::PaneGroupFocusState;
@@ -48,12 +49,10 @@ use crate::terminal::block_list_viewport::{ClampingMode, ScrollLines};
 use crate::terminal::session_settings::AgentToolbarChipSelection;
 use crate::view_components::find::FindWithinBlockState;
 
-use crate::terminal::model::ansi::{self, InitShellValue, PrecmdValue};
+use crate::terminal::model::ansi::{self, InitShellValue};
 use crate::terminal::model::ansi::{BootstrappedValue, PreexecValue};
-use crate::terminal::model::block::AgentInteractionMetadata;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::model::blocks::{insert_block, TotalIndex};
-use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::terminal_model::WithinBlock;
 use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
 use crate::test_util::ai_agent_tasks::{
@@ -89,25 +88,108 @@ impl TerminalManager for TestTerminalManager {
     }
 }
 
+fn tool_call_message_with_tool_for_test(
+    id: &str,
+    call_id: &str,
+    tool: api::message::tool_call::Tool,
+) -> api::Message {
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: call_id.to_string(),
+            tool: Some(tool),
+        })),
+        request_id: "request-1".to_string(),
+        timestamp: None,
+    }
+}
+
+fn tool_call_result_message_with_result_for_test(
+    id: &str,
+    call_id: &str,
+    result: api::message::tool_call_result::Result,
+) -> api::Message {
+    api::Message {
+        id: id.to_string(),
+        task_id: "root-task".to_string(),
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: call_id.to_string(),
+                result: Some(result),
+                context: None,
+            },
+        )),
+        request_id: "request-1".to_string(),
+        timestamp: None,
+    }
+}
+
+fn run_shell_command_tool_for_test(command: &str) -> api::message::tool_call::Tool {
+    use api::message::tool_call::run_shell_command::WaitUntilCompleteValue;
+
+    // CLI subagent 会挂在这条 shell command block 上；字段只保留序列化所需的最小值。
+    api::message::tool_call::Tool::RunShellCommand(api::message::tool_call::RunShellCommand {
+        command: command.to_string(),
+        is_read_only: true,
+        uses_pager: false,
+        is_risky: false,
+        citations: vec![],
+        wait_until_complete_value: Some(WaitUntilCompleteValue::WaitUntilComplete(true)),
+        risk_category: 0,
+    })
+}
+
+#[allow(deprecated)]
 fn build_restored_conversation_with_cli_subagent_for_test(
     block_id: BlockId,
     task_id: TaskId,
 ) -> AIConversation {
     // 构造包含 CLI subagent tool call 的历史 conversation，模拟普通 /agent 历史恢复数据。
     let root_task_id = "root-task";
+    let block_id_string = String::from(block_id);
     let task_id_string = String::from(task_id);
     let root_task = create_api_task(
         root_task_id,
-        vec![create_subagent_tool_call_message(
-            "cli-subagent-call",
-            root_task_id,
-            &task_id_string,
-            Some(api::message::tool_call::subagent::Metadata::Cli(
-                api::message::tool_call::subagent::CliSubagent {
-                    command_id: String::from(block_id),
-                },
-            )),
-        )],
+        vec![
+            tool_call_message_with_tool_for_test(
+                "run-shell-call",
+                "run-shell-call-1",
+                run_shell_command_tool_for_test("ssh jump"),
+            ),
+            tool_call_result_message_with_result_for_test(
+                "run-shell-result",
+                "run-shell-call-1",
+                api::message::tool_call_result::Result::RunShellCommand(
+                    api::RunShellCommandResult {
+                        command: "ssh jump".to_string(),
+                        output: String::new(),
+                        exit_code: 0,
+                        result: Some(api::run_shell_command_result::Result::CommandFinished(
+                            api::ShellCommandFinished {
+                                command_id: block_id_string.clone(),
+                                output: "jump output".to_string(),
+                                exit_code: 0,
+                            },
+                        )),
+                    },
+                ),
+            ),
+            create_subagent_tool_call_message(
+                "cli-subagent-call",
+                root_task_id,
+                &task_id_string,
+                Some(api::message::tool_call::subagent::Metadata::Cli(
+                    api::message::tool_call::subagent::CliSubagent {
+                        command_id: block_id_string,
+                    },
+                )),
+            ),
+        ],
     );
     let subtask = create_api_subtask(
         &task_id_string,
@@ -119,36 +201,42 @@ fn build_restored_conversation_with_cli_subagent_for_test(
         .expect("restored CLI subagent conversation should build")
 }
 
-fn create_restored_cli_subagent_block_for_test(
-    view: &mut TerminalView,
-    block_id: BlockId,
-    conversation_id: AIConversationId,
-    task_id: TaskId,
-) {
-    // 恢复路径只依赖 block id 和 AI metadata；这里避免创建完整命令输出，让测试聚焦接线。
-    let mut model = view.model.lock();
-    let block_list = model.block_list_mut();
-    block_list.create_new_block_with_local_status(
-        block_id.clone(),
-        BootstrapStage::RestoreBlocks,
-        Some(PrecmdValue::default()),
-        true,
+fn build_restored_conversation_without_cli_subagent_for_test() -> AIConversation {
+    // 构造普通 /agent 历史 conversation，用于确认没有 CLI subagent 时不会误建浮窗。
+    let root_task_id = "root-task";
+    let root_task = create_api_task(
+        root_task_id,
+        vec![create_message("ordinary-agent-output", root_task_id)],
     );
-    block_list
-        .mut_block_from_id(&block_id)
-        .expect("restored CLI subagent block should exist")
-        .set_agent_interaction_mode(AgentInteractionMetadata::new(
-            Some("cli-action-1".to_string().into()),
-            conversation_id,
-            Some(task_id),
-            None,
-            false,
-            false,
-        ));
+
+    AIConversation::new_restored(AIConversationId::new(), vec![root_task], None)
+        .expect("ordinary restored conversation should build")
+}
+
+fn serialized_blocks_for_restored_cli_subagent_for_test(
+    conversation: &AIConversation,
+) -> Vec<SerializedBlockListItem> {
+    // 走真实持久化序列化路径，避免测试只验证内存中的临时 view 状态。
+    let serialized_blocks = conversation.to_serialized_blocklist_items();
+    assert_eq!(
+        serialized_blocks.len(),
+        1,
+        "CLI subagent conversation should serialize one command block"
+    );
+    serialized_blocks
+}
+
+fn clear_ai_metadata_for_serialized_blocks_for_test(blocks: &mut [SerializedBlockListItem]) {
+    // 模拟旧历史记录或损坏记录缺少 ai_metadata 的情况，恢复逻辑应安全跳过。
+    for item in blocks {
+        match item {
+            SerializedBlockListItem::Command { block } => block.ai_metadata = None,
+        }
+    }
 }
 
 #[test]
-fn restores_cli_subagent_view_after_historical_conversation_restore() {
+fn restores_cli_subagent_view_from_serialized_history_blocks() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
 
@@ -158,16 +246,10 @@ fn restores_cli_subagent_view_after_historical_conversation_restore() {
             block_id.clone(),
             task_id.clone(),
         );
-        let conversation_id = conversation.id();
+        let serialized_blocks = serialized_blocks_for_restored_cli_subagent_for_test(&conversation);
 
-        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal = add_window_with_terminal(&mut app, Some(&serialized_blocks));
         terminal.update(&mut app, |view, ctx| {
-            create_restored_cli_subagent_block_for_test(
-                view,
-                block_id.clone(),
-                conversation_id,
-                task_id,
-            );
             view.restore_conversation_after_view_creation(
                 RestoredAIConversation::new(conversation),
                 true,
@@ -179,6 +261,71 @@ fn restores_cli_subagent_view_after_historical_conversation_restore() {
             assert!(
                 view.cli_subagent_views.contains_key(&block_id),
                 "restored CLI subagent view should be keyed by its command block id"
+            );
+        });
+    });
+}
+
+#[test]
+fn skips_cli_subagent_view_restore_without_matching_ai_metadata() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let block_id = BlockId::from("cli-block-1".to_string());
+        let task_id = TaskId::new("cli-task-1".to_string());
+        let conversation = build_restored_conversation_with_cli_subagent_for_test(
+            block_id.clone(),
+            task_id,
+        );
+        let mut serialized_blocks =
+            serialized_blocks_for_restored_cli_subagent_for_test(&conversation);
+        clear_ai_metadata_for_serialized_blocks_for_test(&mut serialized_blocks);
+
+        let terminal = add_window_with_terminal(&mut app, Some(&serialized_blocks));
+        terminal.update(&mut app, |view, ctx| {
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                !view.cli_subagent_views.contains_key(&block_id),
+                "missing metadata should not restore a CLI subagent view"
+            );
+            assert!(
+                !view.rich_content_views.is_empty(),
+                "normal /agent blocks should still restore without CLI metadata"
+            );
+        });
+    });
+}
+
+#[test]
+fn ordinary_agent_restore_does_not_create_cli_subagent_views() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let conversation = build_restored_conversation_without_cli_subagent_for_test();
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.is_empty(),
+                "ordinary /agent restore should not create CLI subagent views"
+            );
+            assert!(
+                !view.rich_content_views.is_empty(),
+                "ordinary /agent block should still restore"
             );
         });
     });

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -446,6 +446,52 @@ fn restores_cli_subagent_terminal_output_from_persisted_snapshot() {
 }
 
 #[test]
+fn restores_cli_subagent_snapshot_when_history_blocks_are_not_preloaded() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let conversation_id = AIConversationId::new();
+        let block_id = BlockId::from("cli-block-missing-preload".to_string());
+        let task_id = TaskId::new("cli-task-missing-preload".to_string());
+        let conversation = build_restored_conversation_with_cli_subagent_snapshot_for_test(
+            conversation_id,
+            block_id.clone(),
+            task_id,
+            b"ssh jump\r\ndocker ps -a\r\nanalyzer-runtime\r\n",
+        );
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            // 历史列表进入已有 terminal 时不会像新 pane 初始化那样预置 restored blocks；
+            // restore_conversation_after_view_creation 必须自己补回 CLI subagent 的终端快照。
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "未预置 restored blocks 时也应恢复 CLI subagent 只读卡片"
+            );
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("CLI subagent snapshot block should be restored into the terminal model");
+            let serialized_block = SerializedBlock::from(block);
+            let output = String::from_utf8_lossy(&serialized_block.stylized_output);
+            assert!(
+                output.contains("analyzer-runtime"),
+                "历史入口恢复时应显示持久化的 SSH 终端输出: {output}"
+            );
+        });
+    });
+}
+
+#[test]
 fn exiting_restored_cli_subagent_agent_view_inserts_entry_card() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -446,6 +446,112 @@ fn restores_cli_subagent_terminal_output_from_persisted_snapshot() {
 }
 
 #[test]
+fn exiting_restored_cli_subagent_agent_view_inserts_entry_card() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let conversation_id = AIConversationId::new();
+        let block_id = BlockId::from("cli-block-agent-view-exit".to_string());
+        let task_id = TaskId::new("cli-task-agent-view-exit".to_string());
+        let conversation = build_restored_conversation_with_cli_subagent_snapshot_for_test(
+            conversation_id,
+            block_id.clone(),
+            task_id,
+            b"ssh jump\r\ndocker ps -a\r\nanalyzer-runtime\r\n",
+        );
+        let serialized_blocks = serialized_blocks_for_restored_cli_subagent_for_test(&conversation);
+
+        let terminal = add_window_with_terminal(&mut app, Some(&serialized_blocks));
+        terminal.update(&mut app, |view, ctx| {
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+            view.enter_agent_view_for_conversation(
+                None,
+                AgentViewEntryOrigin::AgentViewBlock,
+                conversation_id,
+                ctx,
+            );
+            view.handle_action(&TerminalAction::ExitAgentView, ctx);
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.last_visible_item_is_agent_view_block_for_conversation(conversation_id),
+                "ESC 返回终端后应保留 restored CLI subagent 的折叠入口卡片"
+            );
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "CLI subagent 只读卡片仍应可展开"
+            );
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("snapshot-restored command block should exist after exiting agent view");
+            let serialized_block = SerializedBlock::from(block);
+            let output = String::from_utf8_lossy(&serialized_block.stylized_output);
+            assert!(
+                output.contains("analyzer-runtime"),
+                "退出 AgentView 后仍应保留 SSH snapshot 输出: {output}"
+            );
+        });
+    });
+}
+
+fn assert_exiting_restored_ordinary_agent_view_inserts_entry_card(
+    origin: AgentViewEntryOrigin,
+) {
+    App::test((), move |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let conversation = build_restored_conversation_without_cli_subagent_for_test();
+        let conversation_id = conversation.id();
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            // 普通 restored 会话只是在 AgentView 中查看，没有新增 exchange；
+            // ESC 回到 terminal 后仍需要保留一个可再次进入的折叠入口。
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+            view.enter_agent_view_for_conversation(None, origin, conversation_id, ctx);
+            view.handle_action(&TerminalAction::ExitAgentView, ctx);
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.last_visible_item_is_agent_view_block_for_conversation(conversation_id),
+                "ESC 返回 terminal 后应保留普通 restored /agent 会话的折叠入口卡片"
+            );
+            assert!(
+                view.cli_subagent_views.is_empty(),
+                "普通 restored /agent 会话不应创建 CLI subagent view"
+            );
+        });
+    });
+}
+
+#[test]
+fn exiting_restored_ordinary_agent_view_inserts_entry_card_from_history() {
+    assert_exiting_restored_ordinary_agent_view_inserts_entry_card(
+        AgentViewEntryOrigin::ConversationListView,
+    );
+}
+
+#[test]
+fn exiting_restored_ordinary_agent_view_inserts_entry_card_from_entry_block() {
+    assert_exiting_restored_ordinary_agent_view_inserts_entry_card(
+        AgentViewEntryOrigin::AgentViewBlock,
+    );
+}
+
+#[test]
 fn skips_cli_subagent_view_restore_without_matching_ai_metadata() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
@@ -3834,6 +3940,72 @@ fn inline_agent_view_persists_across_transfer_takeover_for_monitored_long_runnin
 }
 
 #[test]
+fn exiting_lrc_user_takeover_does_not_insert_agent_view_entry_card() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.simulate_long_running_block("ssh localhost", "Password:");
+            }
+
+            let conversation_id = view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller
+                    .try_enter_inline_agent_view(
+                        None,
+                        AgentViewEntryOrigin::LongRunningCommand,
+                        ctx,
+                    )
+                    .expect("inline agent view should create a conversation")
+            });
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_is_agent_tagged_in(true);
+
+            let task_id = TaskId::new("test-task".to_owned());
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+                .expect("tagged-in command should transition to agent-monitored");
+
+            view.cli_subagent_controller.update(ctx, |controller, ctx| {
+                controller.switch_control_to_user(
+                    UserTakeOverReason::TransferFromAgent {
+                        reason: "Enter your password".to_owned(),
+                    },
+                    ctx,
+                );
+            });
+
+            view.agent_view_controller()
+                .update(ctx, |controller, ctx| controller.exit_agent_view(ctx));
+
+            assert!(
+                !view.has_agent_view_entry_block_for_conversation(conversation_id),
+                "LRC 用户接管退出时不应重复插入 AgentView 入口卡片"
+            );
+        });
+    })
+}
+
+#[test]
 fn use_agent_footer_renders_for_transfer_handoff_even_when_user_command_footer_setting_disabled() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
@@ -3983,6 +4155,13 @@ fn exiting_agent_view_removes_empty_conversations() {
             history.conversation(&conversation_id).is_some()
         });
         assert!(!exists_after_exit);
+        let has_entry_card_after_exit = terminal.read(&app, |view, _| {
+            view.has_agent_view_entry_block_for_conversation(conversation_id)
+        });
+        assert!(
+            !has_entry_card_after_exit,
+            "新建但未修改的空会话退出后不应留下 restored 入口卡片"
+        );
     })
 }
 

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -6,9 +6,11 @@ use std::sync::Arc;
 
 use crate::ai::agent::conversation::ConversationStatus;
 use parking_lot::FairMutex;
+use warp_multi_agent_api as api;
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
 use warpui::{notification::UserNotification, Presenter, WindowInvalidation};
 
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
 use warpui::App;
@@ -46,10 +48,17 @@ use crate::terminal::block_list_viewport::{ClampingMode, ScrollLines};
 use crate::terminal::session_settings::AgentToolbarChipSelection;
 use crate::view_components::find::FindWithinBlockState;
 
-use crate::terminal::model::ansi::{self, InitShellValue};
+use crate::terminal::model::ansi::{self, InitShellValue, PrecmdValue};
 use crate::terminal::model::ansi::{BootstrappedValue, PreexecValue};
+use crate::terminal::model::block::AgentInteractionMetadata;
+use crate::terminal::model::block::BlockId;
 use crate::terminal::model::blocks::{insert_block, TotalIndex};
+use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::terminal_model::WithinBlock;
+use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
+use crate::test_util::ai_agent_tasks::{
+    create_api_subtask, create_api_task, create_message, create_subagent_tool_call_message,
+};
 
 use crate::terminal::{MockTerminalManager, TerminalManager, TerminalModel};
 use crate::test_util::terminal::initialize_app_for_terminal_view;
@@ -78,6 +87,101 @@ impl TerminalManager for TestTerminalManager {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+}
+
+fn build_restored_conversation_with_cli_subagent_for_test(
+    block_id: BlockId,
+    task_id: TaskId,
+) -> AIConversation {
+    // 构造包含 CLI subagent tool call 的历史 conversation，模拟普通 /agent 历史恢复数据。
+    let root_task_id = "root-task";
+    let task_id_string = String::from(task_id);
+    let root_task = create_api_task(
+        root_task_id,
+        vec![create_subagent_tool_call_message(
+            "cli-subagent-call",
+            root_task_id,
+            &task_id_string,
+            Some(api::message::tool_call::subagent::Metadata::Cli(
+                api::message::tool_call::subagent::CliSubagent {
+                    command_id: String::from(block_id),
+                },
+            )),
+        )],
+    );
+    let subtask = create_api_subtask(
+        &task_id_string,
+        root_task_id,
+        vec![create_message("cli-subagent-output", &task_id_string)],
+    );
+
+    AIConversation::new_restored(AIConversationId::new(), vec![root_task, subtask], None)
+        .expect("restored CLI subagent conversation should build")
+}
+
+fn create_restored_cli_subagent_block_for_test(
+    view: &mut TerminalView,
+    block_id: BlockId,
+    conversation_id: AIConversationId,
+    task_id: TaskId,
+) {
+    // 恢复路径只依赖 block id 和 AI metadata；这里避免创建完整命令输出，让测试聚焦接线。
+    let mut model = view.model.lock();
+    let block_list = model.block_list_mut();
+    block_list.create_new_block_with_local_status(
+        block_id.clone(),
+        BootstrapStage::RestoreBlocks,
+        Some(PrecmdValue::default()),
+        true,
+    );
+    block_list
+        .mut_block_from_id(&block_id)
+        .expect("restored CLI subagent block should exist")
+        .set_agent_interaction_mode(AgentInteractionMetadata::new(
+            Some("cli-action-1".to_string().into()),
+            conversation_id,
+            Some(task_id),
+            None,
+            false,
+            false,
+        ));
+}
+
+#[test]
+fn restores_cli_subagent_view_after_historical_conversation_restore() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let block_id = BlockId::from("cli-block-1".to_string());
+        let task_id = TaskId::new("cli-task-1".to_string());
+        let conversation = build_restored_conversation_with_cli_subagent_for_test(
+            block_id.clone(),
+            task_id.clone(),
+        );
+        let conversation_id = conversation.id();
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            create_restored_cli_subagent_block_for_test(
+                view,
+                block_id.clone(),
+                conversation_id,
+                task_id,
+            );
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "restored CLI subagent view should be keyed by its command block id"
+            );
+        });
+    });
 }
 
 /// Test to verify that blocks created through normal execution

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -12,9 +12,11 @@ use warpui::{notification::UserNotification, Presenter, WindowInvalidation};
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::task::TaskId;
-use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
 #[cfg(windows)]
 use crate::ai::blocklist::block::cli::CLISubagentViewEvent;
+use crate::ai::blocklist::block::cli_controller::{
+    LongRunningCommandControlState, UserTakeOverReason,
+};
 use crate::ai::blocklist::SerializedBlockListItem;
 use warpui::App;
 
@@ -51,9 +53,12 @@ use crate::terminal::block_list_viewport::{ClampingMode, ScrollLines};
 use crate::terminal::session_settings::AgentToolbarChipSelection;
 use crate::view_components::find::FindWithinBlockState;
 
+use crate::persistence::model::AgentConversationData;
 use crate::terminal::model::ansi::{self, InitShellValue};
 use crate::terminal::model::ansi::{BootstrappedValue, PreexecValue};
-use crate::terminal::model::block::BlockId;
+use crate::terminal::model::block::{
+    AgentInteractionMetadata, AgentViewVisibility, BlockId, SerializedAIMetadata, SerializedBlock,
+};
 use crate::terminal::model::blocks::{insert_block, TotalIndex};
 use crate::terminal::model::terminal_model::WithinBlock;
 use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
@@ -203,6 +208,127 @@ fn build_restored_conversation_with_cli_subagent_for_test(
         .expect("restored CLI subagent conversation should build")
 }
 
+fn empty_agent_conversation_data_for_test() -> AgentConversationData {
+    AgentConversationData {
+        server_conversation_token: None,
+        conversation_usage_metadata: None,
+        reverted_action_ids: None,
+        forked_from_server_conversation_token: None,
+        artifacts_json: None,
+        parent_agent_id: None,
+        agent_name: None,
+        parent_conversation_id: None,
+        run_id: None,
+        autoexecute_override: None,
+        last_event_sequence: None,
+        compaction_state_json: None,
+        byop_repair_state_json: None,
+        cli_subagent_block_snapshots_json: None,
+    }
+}
+
+fn cli_subagent_snapshot_json_for_test(
+    conversation_id: AIConversationId,
+    task_id: &TaskId,
+    block_id: &BlockId,
+    output: &[u8],
+) -> String {
+    // 模拟关闭标签后随 conversation_data 留存的完整终端 block 快照。
+    let mut block = SerializedBlock::new_for_test(b"ssh jump".to_vec(), output.to_vec());
+    block.id = block_id.clone();
+    block.ai_metadata = serde_json::to_string(&Some(Into::<SerializedAIMetadata>::into(
+        AgentInteractionMetadata::new(
+            None,
+            conversation_id,
+            Some(task_id.clone()),
+            Some(LongRunningCommandControlState::Agent {
+                is_blocked: false,
+                should_hide_responses: false,
+            }),
+            false,
+            false,
+        ),
+    )))
+    .ok();
+    block.agent_view_visibility =
+        Some(AgentViewVisibility::new_from_conversation(conversation_id).into());
+
+    serde_json::to_string(&vec![serde_json::json!({
+        "task_id": String::from(task_id.clone()),
+        "block_id": block_id.as_str(),
+        "block": block,
+    })])
+    .expect("CLI subagent snapshot JSON should serialize")
+}
+
+#[allow(deprecated)]
+fn build_restored_conversation_with_cli_subagent_snapshot_for_test(
+    conversation_id: AIConversationId,
+    block_id: BlockId,
+    task_id: TaskId,
+    snapshot_output: &[u8],
+) -> AIConversation {
+    let mut conversation_data = empty_agent_conversation_data_for_test();
+    conversation_data.cli_subagent_block_snapshots_json = Some(
+        cli_subagent_snapshot_json_for_test(conversation_id, &task_id, &block_id, snapshot_output),
+    );
+
+    // task result 故意保留短输出，确保测试验证的是 snapshot 恢复而不是 task fallback。
+    let root_task_id = "root-task";
+    let block_id_string = String::from(block_id);
+    let task_id_string = String::from(task_id);
+    let root_task = create_api_task(
+        root_task_id,
+        vec![
+            tool_call_message_with_tool_for_test(
+                "run-shell-call",
+                "run-shell-call-1",
+                run_shell_command_tool_for_test("ssh jump"),
+            ),
+            tool_call_result_message_with_result_for_test(
+                "run-shell-result",
+                "run-shell-call-1",
+                api::message::tool_call_result::Result::RunShellCommand(
+                    api::RunShellCommandResult {
+                        command: "ssh jump".to_string(),
+                        output: String::new(),
+                        exit_code: 0,
+                        result: Some(api::run_shell_command_result::Result::CommandFinished(
+                            api::ShellCommandFinished {
+                                command_id: block_id_string.clone(),
+                                output: "short task output".to_string(),
+                                exit_code: 0,
+                            },
+                        )),
+                    },
+                ),
+            ),
+            create_subagent_tool_call_message(
+                "cli-subagent-call",
+                root_task_id,
+                &task_id_string,
+                Some(api::message::tool_call::subagent::Metadata::Cli(
+                    api::message::tool_call::subagent::CliSubagent {
+                        command_id: block_id_string,
+                    },
+                )),
+            ),
+        ],
+    );
+    let subtask = create_api_subtask(
+        &task_id_string,
+        root_task_id,
+        vec![create_message("cli-subagent-output", &task_id_string)],
+    );
+
+    AIConversation::new_restored(
+        conversation_id,
+        vec![root_task, subtask],
+        Some(conversation_data),
+    )
+    .expect("restored CLI subagent conversation with snapshot should build")
+}
+
 fn build_restored_conversation_without_cli_subagent_for_test() -> AIConversation {
     // 构造普通 /agent 历史 conversation，用于确认没有 CLI subagent 时不会误建浮窗。
     let root_task_id = "root-task";
@@ -263,6 +389,57 @@ fn restores_cli_subagent_view_from_serialized_history_blocks() {
             assert!(
                 view.cli_subagent_views.contains_key(&block_id),
                 "restored CLI subagent view should be keyed by its command block id"
+            );
+        });
+    });
+}
+
+#[test]
+fn restores_cli_subagent_terminal_output_from_persisted_snapshot() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let conversation_id = AIConversationId::new();
+        let block_id = BlockId::from("cli-block-snapshot".to_string());
+        let task_id = TaskId::new("cli-task-snapshot".to_string());
+        let snapshot_output =
+            b"* Documentation: https://help.ubuntu.com\r\nCONTAINER ID   IMAGE\r\nanalyzer-runtime\r\n";
+        let conversation = build_restored_conversation_with_cli_subagent_snapshot_for_test(
+            conversation_id,
+            block_id.clone(),
+            task_id,
+            snapshot_output,
+        );
+        let serialized_blocks = serialized_blocks_for_restored_cli_subagent_for_test(&conversation);
+
+        let terminal = add_window_with_terminal(&mut app, Some(&serialized_blocks));
+        terminal.update(&mut app, |view, ctx| {
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "snapshot-restored CLI subagent view should still be expandable"
+            );
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("snapshot-restored command block should exist");
+            let serialized_block = SerializedBlock::from(block);
+            let output = String::from_utf8_lossy(&serialized_block.stylized_output);
+            assert!(
+                output.contains("analyzer-runtime"),
+                "restored terminal block should contain persisted SSH output: {output}"
+            );
+            assert!(
+                !output.contains("short task output"),
+                "task fallback output should not replace persisted terminal snapshot"
             );
         });
     });

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -15,7 +15,7 @@ use crate::ai::agent::task::TaskId;
 #[cfg(windows)]
 use crate::ai::blocklist::block::cli::CLISubagentViewEvent;
 use crate::ai::blocklist::block::cli_controller::{
-    LongRunningCommandControlState, UserTakeOverReason,
+    CLISubagentEvent, LongRunningCommandControlState, UserTakeOverReason,
 };
 use crate::ai::blocklist::SerializedBlockListItem;
 use warpui::App;
@@ -505,6 +505,104 @@ fn ordinary_agent_restore_does_not_create_cli_subagent_views() {
             assert!(
                 !view.rich_content_views.is_empty(),
                 "ordinary /agent block should still restore"
+            );
+        });
+    });
+}
+
+#[test]
+fn finished_cli_subagent_keeps_read_only_card_when_metadata_matches() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        // FinishedSubagent 会触发 sidecar 持久化，需要 GlobalResourceHandlesProvider。
+        let global_resource_handles = crate::GlobalResourceHandles::mock(&mut app);
+        app.add_singleton_model(|_| crate::GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        // 先恢复一个带 CLI subagent 的历史会话，建立带匹配 metadata 的 command block
+        // 和一个 RestoredReadOnly 视图，模拟 SSH 会话在 agent view 里展开后的状态。
+        // 用带 snapshot 的构造函数，确保 conversation_id 可控且与 block metadata 一致。
+        let block_id = BlockId::from("cli-block-finished".to_string());
+        let task_id = TaskId::new("cli-task-finished".to_string());
+        let conversation_id = AIConversationId::new();
+        let conversation = build_restored_conversation_with_cli_subagent_snapshot_for_test(
+            conversation_id,
+            block_id.clone(),
+            task_id.clone(),
+            b"ssh session output",
+        );
+        let serialized_blocks = serialized_blocks_for_restored_cli_subagent_for_test(&conversation);
+
+        let terminal = add_window_with_terminal(&mut app, Some(&serialized_blocks));
+        terminal.update(&mut app, |view, ctx| {
+            view.restore_conversation_after_view_creation(
+                RestoredAIConversation::new(conversation),
+                true,
+                ctx,
+            );
+        });
+
+        // 恢复后应存在 CLI subagent 视图。
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "restored CLI subagent view should exist before FinishedSubagent"
+            );
+        });
+
+        // 模拟 SSH 会话结束触发的 FinishedSubagent 事件。
+        // 修复前：live 视图被 remove 后不再重建，卡片消失；
+        // 修复后：在 block 仍持有匹配 metadata 时以 RestoredReadOnly 重建折叠卡片。
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_cli_subagent_controller_event(
+                view.cli_subagent_controller.clone(),
+                &CLISubagentEvent::FinishedSubagent {
+                    block_id: block_id.clone(),
+                    task_id: task_id.clone(),
+                    conversation_id: Some(conversation_id),
+                    initial_requested_command_action_id: None,
+                },
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                view.cli_subagent_views.contains_key(&block_id),
+                "FinishedSubagent should keep a read-only CLI subagent card when metadata matches"
+            );
+        });
+    });
+}
+
+#[test]
+fn finished_cli_subagent_skips_rebuild_when_block_missing() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        // 用一个不存在于 block_list 的 block_id 触发 FinishedSubagent，
+        // 模拟 block 已被回收 / metadata 无法匹配的情况，重建前置检查应不通过。
+        let block_id = BlockId::from("cli-block-gone".to_string());
+        let task_id = TaskId::new("cli-task-gone".to_string());
+        let conversation_id = AIConversationId::new();
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_cli_subagent_controller_event(
+                view.cli_subagent_controller.clone(),
+                &CLISubagentEvent::FinishedSubagent {
+                    block_id: block_id.clone(),
+                    task_id: task_id.clone(),
+                    conversation_id: Some(conversation_id),
+                    initial_requested_command_action_id: None,
+                },
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(
+                !view.cli_subagent_views.contains_key(&block_id),
+                "FinishedSubagent should not rebuild a card when the block no longer exists"
             );
         });
     });

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -13,6 +13,8 @@ use warpui::{notification::UserNotification, Presenter, WindowInvalidation};
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
+#[cfg(windows)]
+use crate::ai::blocklist::block::cli::CLISubagentViewEvent;
 use crate::ai::blocklist::SerializedBlockListItem;
 use warpui::App;
 
@@ -328,6 +330,57 @@ fn ordinary_agent_restore_does_not_create_cli_subagent_views() {
                 "ordinary /agent block should still restore"
             );
         });
+    });
+}
+
+#[cfg(windows)]
+#[test]
+fn restored_cli_subagent_windows_ctrl_c_does_not_write_to_pty() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            // 让 Ctrl-C 的 live 路径具备可观察副作用：如果被转发，会写 ETX 到 PTY。
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 10", "running");
+
+            view.handle_cli_subagent_view_event(
+                view.view_id,
+                &CLISubagentViewEvent::WindowsCtrlC,
+                false,
+                ctx,
+            );
+        });
+        assert!(
+            pty_writes.borrow().is_empty(),
+            "restored CLI subagent Ctrl-C should not reach the live terminal"
+        );
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_cli_subagent_view_event(
+                view.view_id,
+                &CLISubagentViewEvent::WindowsCtrlC,
+                true,
+                ctx,
+            );
+        });
+        assert_eq!(
+            pty_writes.borrow().as_slice(),
+            &[vec![warp_terminal::model::escape_sequences::C0::ETX]],
+            "live CLI subagent Ctrl-C should still forward to the active terminal"
+        );
     });
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1013,6 +1013,9 @@ pub struct AgentConversationData {
     /// Opaque serialized BYOP repair sidecar. The app layer owns validation semantics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub byop_repair_state_json: Option<String>,
+    /// CLI subagent 终端 block 快照 sidecar。具体 JSON schema 由 app 层负责。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli_subagent_block_snapshots_json: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1320,6 +1323,7 @@ mod tests {
             last_event_sequence: Some(42),
             compaction_state_json: None,
             byop_repair_state_json: None,
+            cli_subagent_block_snapshots_json: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
@@ -1335,6 +1339,7 @@ mod tests {
             serde_json::from_str(legacy_json).expect("legacy rows must deserialize");
         assert_eq!(data.last_event_sequence, None);
         assert_eq!(data.byop_repair_state_json, None);
+        assert_eq!(data.cli_subagent_block_snapshots_json, None);
     }
 
     #[test]
@@ -1353,10 +1358,15 @@ mod tests {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json: None,
+            cli_subagent_block_snapshots_json: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         assert!(
             !json.contains("last_event_sequence"),
+            "None should be skipped in serialized output: {json}"
+        );
+        assert!(
+            !json.contains("cli_subagent_block_snapshots_json"),
             "None should be skipped in serialized output: {json}"
         );
     }
@@ -1377,6 +1387,7 @@ mod tests {
             last_event_sequence: None,
             compaction_state_json: None,
             byop_repair_state_json: Some(r#"{"version":1,"records":[]}"#.to_string()),
+            cli_subagent_block_snapshots_json: None,
         };
 
         let json = serde_json::to_string(&data).expect("serialize");
@@ -1385,6 +1396,36 @@ mod tests {
         assert_eq!(
             roundtripped.byop_repair_state_json.as_deref(),
             Some(r#"{"version":1,"records":[]}"#)
+        );
+    }
+
+    #[test]
+    fn agent_conversation_data_roundtrips_cli_subagent_block_snapshots_sidecar() {
+        let data = AgentConversationData {
+            server_conversation_token: None,
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: None,
+            agent_name: None,
+            parent_conversation_id: None,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            compaction_state_json: None,
+            byop_repair_state_json: None,
+            cli_subagent_block_snapshots_json: Some(
+                r#"[{"task_id":"cli-task","block_id":"cli-block","block":{}}]"#.to_string(),
+            ),
+        };
+
+        let json = serde_json::to_string(&data).expect("serialize");
+        let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(
+            roundtripped.cli_subagent_block_snapshots_json,
+            data.cli_subagent_block_snapshots_json
         );
     }
 }


### PR DESCRIPTION
## 问题

SSH 跳板机等 CLI subagent 会话结束后，终端交互输出原本只保存在 live `TerminalModel` block 中。关闭对话标签或重启 Zap 后，历史会话只能从 task messages 重建，因此会丢失真实终端输出，只剩 `/agent ...` 附近的对话内容。

另外，用户从历史或 restored AgentView 中按 ESC 返回终端层时，部分只读 restored 会话不会产生新的 exchange，退出逻辑不会插入 `AgentViewEntryBlock`，导致返回后看不到可展开的折叠卡片。这个问题在 SSH/CLI subagent 和普通 restored agent 会话中都会出现。

## 修改

- 为 CLI subagent 终端 block 增加随 conversation 持久化的快照 sidecar，保存 `task_id`、`block_id` 和 `SerializedBlock`。
- 恢复历史会话时优先使用持久化的 terminal block snapshot，避免用截断的 task output 覆盖真实 SSH 终端输出。
- 为 restored CLI subagent 使用只读视图，保留历史展开能力，但不恢复 Ctrl-C / PTY 写入等 live 控制能力。
- 在 CLI subagent 结束后保留折叠的只读卡片，避免 SSH 会话断开后卡片消失。
- 修复普通 restored AgentView 退出后没有折叠入口的问题：已存在的 restored/unmodified conversation 在 ESC 返回 terminal 时会补一个 restored 入口卡片。
- 修复恢复会话时间可能回退到 Unix epoch 的问题，缺少消息时间时使用 DB `last_modified_at` 兜底。

## 验证

已在本地运行：

```bash
cargo test -p warp restored_cli_subagent --lib
cargo test -p warp exiting_restored_ordinary_agent_view_inserts_entry_card --lib
cargo test -p warp exiting_agent_view_removes_empty_conversations --lib
cargo test -p warp exiting_lrc_user_takeover_does_not_insert_agent_view_entry_card --lib
cargo check
git diff --check upstream/main..HEAD
```

## 说明

本 PR 基于最新 `upstream/main`，只包含从原 `ca654d96` 开始的 11 个 SSH/CLI subagent 历史恢复相关提交；之前已经合入上游的 CLI 浮窗滚动/脱敏等提交没有重复带入。
