### PR TITLE
Fix Unix Epoch '56 years ago' timestamp bug in agent activity list. I…

### DIFF
--- a/app/src/ai/blocklist/agent_view/zero_state_block.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block.rs
@@ -842,7 +842,11 @@ fn render_recent_conversations_section(
                         .with_margin_right(8.)
                         .finish(),
                         Text::new_inline(
-                            format_approx_duration_from_now_utc(last_updated.to_utc()),
+                            if last_updated.timestamp() <= 0 {
+                                "Never".to_owned()
+                            } else {
+                                format_approx_duration_from_now_utc(last_updated.to_utc())
+                            },
                             appearance.ui_font_family(),
                             appearance.monospace_font_size() - 1.,
                         )


### PR DESCRIPTION
… replaced it with a fall back to 'Never' for uninitialized activity timestamps. I built and ran the project with applied changes to make sure if it works as intended. The build in macOS 15.7.5 M1 Mac mini completed successfully and the bug was fixed.

## Description
This PR fixes a Unix Epoch calculation bug in the "Recent Activity" sidebar layout where uninitialized conversation tracker files or new local commands default back to the late 1960s/1970, resulting in a display showing "56 years ago". 
<img width="1916" height="972" alt="Lightshot Screenshot 2026-07-03 17 39 22" src="https://github.com/user-attachments/assets/872503aa-2434-40ff-8138-428d16880238" />


## Changes Made
- **UI Fallback Protection:** Added an inline expression directly into `zero_state_block.rs` to detect any historical timestamp values evaluating to `<= 0` and format them as a clean `"Never"` layout string instead of attempting epoch duration math.
<img width="961" height="331" alt="Lightshot Screenshot 2026-07-03 19 16 18" src="https://github.com/user-attachments/assets/1d07af9e-1c96-4f7b-9824-5fc5b156346e" />


## Architectural Note for Maintainers (Root Cause Analysis)
While this UI change effectively solves the display symptom, during deep-tracing I discovered that the true root cause stems from the data layer in `app/src/ai/conversation_navigation/mod.rs` inside `from_historical_conversation_metadata`. 

When local shell history events (like terminal actions) are automatically indexed into the persistence layer, the background data wrapper initializes `AIConversationMetadata` rows with an empty or uninitialized placeholder state. Because of this, the `last_modified_at` column defaults to `0` inside the SQLite schema mapping layer. 

I chose not to alter the database migrations or internal persistence hooks directly to avoid risking data drift or synchronization edge-cases across crates. Not to mention that I am not a very experienced Rust developer, let alone working on a massive codebase like this. However, it would be ideal if the backend team could trace the background indexing controller to ensure a valid `chrono::Local::now()` timestamp property gets saved to `last_modified_at` during the initial write pass.

I hope this is helpful. Much respect to you for doing this work!

## Testing
<!--
I built and ran the project with applied changes to make sure if it works as intended. The build in macOS 15.7.5 M1 Mac mini completed successfully and the bug was fixed.

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Zap-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->


## Changelog Entries for Stable
<!--
* BUG-FIX: for fixes related to known bugs or regressions.
-->

CHANGELOG-BUG-FIX: {{Recent activity view timestamp Epoch bug removed and a fallback added instead}}