### PR TITLE
fix(editor): add Linux compensating Ctrl+V binding for EditorView paste

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -261,7 +261,7 @@ pub fn init(ctx: &mut AppContext) {
             EditorAction::Paste,
             id!("EditorView") & !id!("IMEOpen"),
         ),
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         FixedBinding::custom(
             CustomAction::WindowsPaste,
             EditorAction::Paste,

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -112,7 +112,9 @@ pub enum CustomAction {
     NewPersonalNotebook,
     NewPersonalEnvVars,
     SearchDrive,
-    #[cfg(windows)]
+    // Also used on Linux: `EditorView` only binds Paste to `ctrl-shift-v` by default (see
+    // `cmd_or_ctrl_shift`), so Linux needs the same plain `ctrl-v` compensating binding as Windows.
+    #[cfg(any(windows, target_os = "linux"))]
     WindowsPaste,
     #[cfg(windows)]
     WindowsCopy,
@@ -263,7 +265,7 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
         CustomAction::Cut => Keystroke::parse("cmdorctrl-x").ok(),
         CustomAction::Copy => Keystroke::parse(cmd_or_ctrl_shift("c")).ok(),
         CustomAction::Paste => Keystroke::parse(cmd_or_ctrl_shift("v")).ok(),
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "linux"))]
         CustomAction::WindowsPaste => Keystroke::parse("ctrl-v").ok(),
         #[cfg(windows)]
         CustomAction::WindowsCopy => Keystroke::parse("ctrl-c").ok(),

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -10,6 +10,9 @@ use crate::{
     workspace::WorkspaceAction,
 };
 
+#[cfg(any(windows, target_os = "linux"))]
+use crate::util::bindings::{custom_tag_to_keystroke, CustomAction};
+
 #[test]
 fn test_keybinding_name_to_display_string() {
     App::test((), |mut app| async move {
@@ -96,4 +99,16 @@ fn test_terminal_page_scroll_bindings_are_editable() {
             assert_eq!(page_down, Keystroke::parse("pagedown").ok());
         });
     });
+}
+
+// Regression test for https://github.com/zerx-lab/zap/issues/303: `EditorView`'s default Paste
+// binding is `ctrl-shift-v` on non-Mac (see `cmd_or_ctrl_shift`), so Linux (like Windows) needs a
+// compensating plain `ctrl-v` binding via `CustomAction::WindowsPaste`.
+#[test]
+#[cfg(any(windows, target_os = "linux"))]
+fn test_windows_paste_custom_action_binds_to_plain_ctrl_v() {
+    assert_eq!(
+        custom_tag_to_keystroke(CustomAction::WindowsPaste.into()),
+        Keystroke::parse("ctrl-v").ok()
+    );
 }

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -107,8 +107,9 @@ fn test_terminal_page_scroll_bindings_are_editable() {
 #[test]
 #[cfg(any(windows, target_os = "linux"))]
 fn test_windows_paste_custom_action_binds_to_plain_ctrl_v() {
+    let expected = Keystroke::parse("ctrl-v").expect("\"ctrl-v\" should be a valid keystroke");
     assert_eq!(
         custom_tag_to_keystroke(CustomAction::WindowsPaste.into()),
-        Keystroke::parse("ctrl-v").ok()
+        Some(expected)
     );
 }


### PR DESCRIPTION
## Description

Part of #303.

**Root cause**: on Linux, `EditorView` (the shared text-editing widget Settings uses for its fields, e.g. `app/src/settings_view/mod.rs:1043`) only binds Paste through `CustomAction::Paste` / `StandardAction::Paste`, both of which resolve via `cmd_or_ctrl_shift("v")` (`app/src/util/bindings.rs:861-885`) to **`ctrl-shift-v`**, not plain `ctrl-v`. A compensating plain-`ctrl-v` binding already exists for this exact problem on Windows, via `CustomAction::WindowsPaste` (enum variant: `app/src/util/bindings.rs:115-116`; keystroke mapping: `app/src/util/bindings.rs:266-267`; registration: `app/src/editor/view/mod.rs:264-270`) — but it was gated `#[cfg(windows)]` only, with no Linux equivalent.

This change broadens those two existing `#[cfg(windows)]` gates to `#[cfg(any(windows, target_os = "linux"))]`, extending the same, already-proven fix to Linux. Because Settings reuses the shared `EditorView`, this makes `Ctrl+V` paste work in Settings' text fields (API keys, base URLs, model ids, etc.) on Linux, matching the existing Windows behavior.

**Out of scope**: the same issue also reports that Settings' right-click menu lacks Cut/Copy/Paste entries. That's a separate, non-platform-specific root cause (`SettingsView::context_menu_items`, `app/src/settings_view/mod.rs:1381-1447`, identical on every OS, no existing per-field context-menu precedent to follow) that needs a broader design decision, so it is intentionally not addressed here.

## Testing

Added a regression test, `test_windows_paste_custom_action_binds_to_plain_ctrl_v` (`app/src/util/bindings_tests.rs`), asserting `custom_tag_to_keystroke(CustomAction::WindowsPaste.into())` resolves to `ctrl-v`.

Verification run (Linux, rustc 1.94.1 toolchain — the repo-pinned 1.92.0 toolchain currently can't build this workspace due to an unrelated `aws-smithy-*` MSRV mismatch, reproduced identically on a clean `main` checkout before any of these changes):

```
$ cargo check -p warp --lib
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 01s
(0 errors; only 32 pre-existing warnings unrelated to this change)

$ cargo test -p warp --lib util::bindings
running 3 tests
test util::bindings::tests::test_windows_paste_custom_action_binds_to_plain_ctrl_v ... ok
test util::bindings::tests::test_keybinding_name_to_display_string ... ok
test util::bindings::tests::test_terminal_page_scroll_bindings_are_editable ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3646 filtered out
```

## Scale / impact

- Files changed: 3 (`app/src/util/bindings.rs`, `app/src/editor/view/mod.rs`, `app/src/util/bindings_tests.rs`)
- Lines changed: 20 insertions / 3 deletions
- No new dependencies, no public API/schema/protocol changes, no concurrency/auth/crypto paths touched.
- 86 files call `EditorView::single_line`/`EditorView::new` app-wide (search box, AI provider fields, network settings, MCP servers, keybindings page, notebooks, code review, etc.) and all inherit the fix automatically with zero changes to them — the shared widget's own keybinding registration is the only place that needed editing.
- `code/editor/view/actions.rs` and `notebooks/editor/view.rs` (2 other, separate consumers of the same `CustomAction::WindowsPaste`/`WindowsCopy` pattern) are intentionally left untouched — out of scope for the reported Settings bug.

## Server API dependencies
N/A — no server-side changes.

## Agent Mode
- [x] Zap Agent Mode - This PR was created via Zap's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: {{Fixed Ctrl+V paste not working in Settings text fields (API keys, base URLs, model ids) on Linux}}


---
_Generated by [Claude Code](https://claude.ai/code/session_011nWE5E65GHNfNgqLgeBR4N)_