### PR TITLE
BYOP Provider Routing fix for issue #302

### DIFF
--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -2808,13 +2808,11 @@ fn adapter_kind_for(api_type: AgentProviderApiType) -> AdapterKind {
     }
 }
 
-/// OpenAI 官方 gpt-5 / codex / pro 系在带 function tools + reasoning_effort 时
+/// OpenAI 官方 gpt-5 / codex 系在带 function tools + reasoning_effort 时
 /// 只接受 `/v1/responses`,`/v1/chat/completions` 会 400。
 fn openai_model_requires_responses_api(model_id: &str) -> bool {
     let id = model_id.to_ascii_lowercase();
-    id.starts_with("gpt-5")
-        || (id.starts_with("gpt") && (id.contains("codex") || id.contains("pro")))
-        || id.starts_with("codex")
+    id.starts_with("gpt-5") || id.starts_with("codex")
 }
 
 /// Claude model id 启发式(容忍 `anthropic/claude-sonnet-4-6` 等 namespace 前缀)。
@@ -2832,9 +2830,19 @@ fn is_anthropic_api_host(base_url: &str) -> bool {
         .is_some_and(|host| host == "api.anthropic.com" || host.ends_with(".anthropic.com"))
 }
 
+/// `base_url` 是否指向 OpenAI 官方 API host。自动升级 `/v1/responses` 只对官方
+/// host 生效:one-api / LiteLLM 等 chat-completions-only 中转常保留官方 model id,
+/// 强制切 Responses API 会 404。
+fn is_openai_api_host(base_url: &str) -> bool {
+    url::Url::parse(base_url.trim())
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_ascii_lowercase))
+        .is_some_and(|host| host == "api.openai.com" || host.ends_with(".openai.com"))
+}
+
 /// 按用户配置的 `api_type`、model id 与 `base_url` 解析实际应使用的 genai adapter。
 ///
-/// - `OpenAi` + gpt-5.4 等 → `OpenAIResp`(`/v1/responses`)
+/// - `OpenAi` + 官方 host + gpt-5.4 等 → `OpenAIResp`(`/v1/responses`)
 /// - `OpenAi` + `api.anthropic.com` + claude 模型 → `Anthropic`(`/v1/messages`)
 fn effective_adapter_kind_for(
     api_type: AgentProviderApiType,
@@ -2846,7 +2854,7 @@ fn effective_adapter_kind_for(
         if is_anthropic_api_host(base_url) && is_claude_model(model_id) {
             return AdapterKind::Anthropic;
         }
-        if openai_model_requires_responses_api(model_id) {
+        if is_openai_api_host(base_url) && openai_model_requires_responses_api(model_id) {
             return AdapterKind::OpenAIResp;
         }
     }
@@ -2930,9 +2938,7 @@ pub(super) fn build_client(
     api_key: String,
 ) -> Client {
     let endpoint_url = normalize_endpoint_url(api_type, base_url);
-    log::info!(
-        "[byop] build_client: api_type={api_type:?} endpoint_url={endpoint_url}"
-    );
+    log::info!("[byop] build_client: api_type={api_type:?} endpoint_url={endpoint_url}");
     let key_for_resolver = api_key.clone();
     let resolver = ServiceTargetResolver::from_resolver_fn(
         move |service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
@@ -2941,17 +2947,13 @@ pub(super) fn build_client(
             let auth = AuthData::from_single(key_for_resolver.clone());
             let model_name = model.model_name.as_str();
             let adapter_kind = effective_adapter_kind_for(api_type, model_name, &endpoint_url);
-            if api_type == AgentProviderApiType::OpenAi
-                && adapter_kind == AdapterKind::OpenAIResp
-            {
+            if api_type == AgentProviderApiType::OpenAi && adapter_kind == AdapterKind::OpenAIResp {
                 log::info!(
                     "[byop] auto-upgrade OpenAi → OpenAIResp for model={model_name} \
                      (function tools + reasoning_effort require /v1/responses)"
                 );
             }
-            if api_type == AgentProviderApiType::OpenAi
-                && adapter_kind == AdapterKind::Anthropic
-            {
+            if api_type == AgentProviderApiType::OpenAi && adapter_kind == AdapterKind::Anthropic {
                 log::info!(
                     "[byop] auto-upgrade OpenAi → Anthropic for model={model_name} \
                      (official Anthropic host requires /v1/messages)"
@@ -3347,7 +3349,23 @@ pub async fn generate_byop_output(
     // 仅对已知把 reasoning 夹在 <think> 标签里的模型(如 MiniMax M3)激活流式提取。
     // 其他模型保持原始 Chunk 输出行为,避免误吞含字面量 <think> 的正常文本。
     let use_think_extraction = super::reasoning::model_uses_think_tags_in_content(&model_id);
-    let chat_req = build_chat_request(&params, force_echo_reasoning, api_type, attachment_caps)?;
+    // Zap:请求 shaping(Anthropic cache_control / system-in-messages 布局)必须跟随
+    // 实际出线的 adapter 而非用户配置的 api_type——OpenAi + 官方 Anthropic host + claude
+    // 模型会被 effective_adapter_kind_for 路由到 Anthropic adapter,若仍按 OpenAi shaping
+    // 则丢掉全部 prompt cache breakpoint,agentic 多轮成本显著上升。对 Ollama 等其余
+    // api_type,effective adapter 恒等于原始 adapter,shaping_api_type == api_type。
+    let shaping_api_type =
+        if effective_adapter_kind_for(api_type, &model_id, &base_url) == AdapterKind::Anthropic {
+            AgentProviderApiType::Anthropic
+        } else {
+            api_type
+        };
+    let chat_req = build_chat_request(
+        &params,
+        force_echo_reasoning,
+        shaping_api_type,
+        attachment_caps,
+    )?;
     let conversation_id = params
         .conversation_token
         .as_ref()
@@ -3410,7 +3428,7 @@ pub async fn generate_byop_output(
     // 推到 messages[0] 以便打 `cache_control`，所以 `chat_req.system` 会是 None、`system_len`
     // 显示为 0；实际 system 内容仍然在 messages[0] 里(看下面逐条报告)。为避免误
     // 导诊断者，这里加上 `system_in_messages_head` 提示。
-    log_chat_request_details(&chat_req, &model_id, api_type, &base_url);
+    log_chat_request_details(&chat_req, &model_id, shaping_api_type, &base_url);
 
     // 诊断:构造包含 system / messages / tools 的完整 ChatRequest JSON dump,保存到
     // stream 闭包。真实 Anthropic wire body 会由 genai adapter 再转换一层,但这里已经
@@ -5666,11 +5684,7 @@ mod adapter_routing_tests {
     #[test]
     fn openai_resp_api_type_unchanged() {
         assert_eq!(
-            effective_adapter_kind_for(
-                AgentProviderApiType::OpenAiResp,
-                "gpt-5.4",
-                OPENAI_HOST
-            ),
+            effective_adapter_kind_for(AgentProviderApiType::OpenAiResp, "gpt-5.4", OPENAI_HOST),
             AdapterKind::OpenAIResp
         );
     }
@@ -5695,6 +5709,16 @@ mod adapter_routing_tests {
                 "anthropic/claude-sonnet-4-6",
                 OPENROUTER_HOST
             ),
+            AdapterKind::OpenAI
+        );
+    }
+
+    #[test]
+    fn openai_gpt54_on_relay_host_stays_on_chat_completions() {
+        // one-api / LiteLLM 等 chat-completions-only 中转会保留官方 model id,
+        // 自动升级 Responses API 必须只对官方 host 生效,否则 404。
+        assert_eq!(
+            effective_adapter_kind_for(AgentProviderApiType::OpenAi, "gpt-5.4", OPENROUTER_HOST),
             AdapterKind::OpenAI
         );
     }
@@ -5743,6 +5767,37 @@ mod anthropic_endpoint_tests {
                 "https://api.anthropic.com/v1/messages"
             ),
             "https://api.anthropic.com/v1/"
+        );
+    }
+}
+
+#[cfg(test)]
+mod ollama_endpoint_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_v1_default_base_url_is_rescued() {
+        // 历史 default_base_url 曾是 `http://localhost:11434/v1/` 并已持久化到存量
+        // settings;normalize 必须把 `/v1` 剥回 host 根,否则拼成 `/v1/api/chat` 404。
+        assert_eq!(
+            normalize_endpoint_url(AgentProviderApiType::Ollama, "http://localhost:11434/v1/"),
+            "http://localhost:11434/"
+        );
+    }
+
+    #[test]
+    fn host_only_passes_through_with_trailing_slash() {
+        assert_eq!(
+            normalize_endpoint_url(AgentProviderApiType::Ollama, "http://localhost:11434"),
+            "http://localhost:11434/"
+        );
+    }
+
+    #[test]
+    fn custom_path_is_preserved() {
+        assert_eq!(
+            normalize_endpoint_url(AgentProviderApiType::Ollama, "http://box:11434/ollama"),
+            "http://box:11434/ollama/"
         );
     }
 }

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -14,7 +14,7 @@
 //! | OpenAi         | OpenAI       | https://api.openai.com/v1                      |
 //! | OpenAiResp     | OpenAIResp   | https://api.openai.com/v1 (走 /v1/responses)   |
 //! | Gemini         | Gemini       | https://generativelanguage.googleapis.com/v1beta |
-//! | Anthropic      | Anthropic    | https://api.anthropic.com                      |
+//! | Anthropic      | Anthropic    | https://api.anthropic.com/v1 (走 /v1/messages) |
 //! | Ollama         | Ollama       | http://localhost:11434                         |
 //!
 //! 用户填的 `base_url` 始终覆盖默认。这样:
@@ -1832,6 +1832,7 @@ fn log_chat_request_details(
     chat_req: &ChatRequest,
     model_id: &str,
     api_type: AgentProviderApiType,
+    base_url: &str,
 ) {
     let system_in_head = matches!(api_type, AgentProviderApiType::Anthropic)
         && chat_req
@@ -1849,7 +1850,7 @@ fn log_chat_request_details(
         "[byop-diag] request summary: adapter={:?} model={} system_len={} \
          system_in_messages_head={} messages={} tools={} tool_names={:?} \
          previous_response_id_present={} store={:?} system_snippet={:?}",
-        adapter_kind_for(api_type),
+        effective_adapter_kind_for(api_type, model_id, base_url),
         model_id,
         chat_req.system.as_deref().map(str::len).unwrap_or(0),
         system_in_head,
@@ -2807,6 +2808,51 @@ fn adapter_kind_for(api_type: AgentProviderApiType) -> AdapterKind {
     }
 }
 
+/// OpenAI 官方 gpt-5 / codex / pro 系在带 function tools + reasoning_effort 时
+/// 只接受 `/v1/responses`,`/v1/chat/completions` 会 400。
+fn openai_model_requires_responses_api(model_id: &str) -> bool {
+    let id = model_id.to_ascii_lowercase();
+    id.starts_with("gpt-5")
+        || (id.starts_with("gpt") && (id.contains("codex") || id.contains("pro")))
+        || id.starts_with("codex")
+}
+
+/// Claude model id 启发式(容忍 `anthropic/claude-sonnet-4-6` 等 namespace 前缀)。
+fn is_claude_model(model_id: &str) -> bool {
+    let id = model_id.to_ascii_lowercase();
+    let bare = id.rsplit('/').next().unwrap_or(&id);
+    bare.contains("claude-") || bare.starts_with("claude")
+}
+
+/// `base_url` 是否指向 Anthropic 官方 Messages API host。
+fn is_anthropic_api_host(base_url: &str) -> bool {
+    url::Url::parse(base_url.trim())
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_ascii_lowercase))
+        .is_some_and(|host| host == "api.anthropic.com" || host.ends_with(".anthropic.com"))
+}
+
+/// 按用户配置的 `api_type`、model id 与 `base_url` 解析实际应使用的 genai adapter。
+///
+/// - `OpenAi` + gpt-5.4 等 → `OpenAIResp`(`/v1/responses`)
+/// - `OpenAi` + `api.anthropic.com` + claude 模型 → `Anthropic`(`/v1/messages`)
+fn effective_adapter_kind_for(
+    api_type: AgentProviderApiType,
+    model_id: &str,
+    base_url: &str,
+) -> AdapterKind {
+    let base = adapter_kind_for(api_type);
+    if api_type == AgentProviderApiType::OpenAi {
+        if is_anthropic_api_host(base_url) && is_claude_model(model_id) {
+            return AdapterKind::Anthropic;
+        }
+        if openai_model_requires_responses_api(model_id) {
+            return AdapterKind::OpenAIResp;
+        }
+    }
+    base
+}
+
 /// 规范化用户填写的 `base_url`,产出供 genai adapter 拼接 service path 的 endpoint URL。
 ///
 /// genai 0.6.x 所有 adapter 都假设 endpoint 以 `/` 结尾、且已经包含版本路径段:
@@ -2821,6 +2867,9 @@ fn adapter_kind_for(api_type: AgentProviderApiType) -> AdapterKind {
 ///    Gemini→`/v1beta/`,Ollama 不补)。
 /// 2. 完整带版本路径(`https://ai.zerx.dev/v1`)— 仅补尾 `/`,不动 path。
 /// 3. 留空 — 用 [`AgentProviderApiType::default_base_url`]。
+///
+/// Anthropic 额外容错:用户若粘贴完整 endpoint(`…/v1/messages`),剥掉尾部的
+/// `messages` 段,避免 genai 再拼一次变成 `…/messages/messages`。
 fn normalize_endpoint_url(api_type: AgentProviderApiType, base_url: &str) -> String {
     let trimmed = base_url.trim();
     if trimmed.is_empty() {
@@ -2828,13 +2877,32 @@ fn normalize_endpoint_url(api_type: AgentProviderApiType, base_url: &str) -> Str
     }
 
     // 解析失败(用户填了畸形 URL)→ 退化到原"补尾 /"行为,让上游报错而不是这里 panic。
-    let parsed = match url::Url::parse(trimmed) {
+    let mut parsed = match url::Url::parse(trimmed) {
         Ok(u) => u,
         Err(_) => {
             let stripped = trimmed.trim_end_matches('/');
             return format!("{stripped}/");
         }
     };
+
+    if api_type == AgentProviderApiType::Anthropic || is_anthropic_api_host(trimmed) {
+        let path = parsed.path().trim_end_matches('/');
+        if let Some(prefix) = path.strip_suffix("/messages") {
+            let new_path = if prefix.is_empty() { "/" } else { prefix };
+            parsed.set_path(&format!("{new_path}/"));
+        }
+    }
+
+    // Ollama 原生 API 在 host 根 `/api/chat`,没有 `/v1/` 前缀。历史 default_base_url
+    // 误填 `/v1/` 或用户从 OpenAI 习惯带入的 `/v1` 在这里剥掉,避免拼成 `/v1/api/chat`。
+    if api_type == AgentProviderApiType::Ollama {
+        let path = parsed.path().trim_end_matches('/');
+        if path.is_empty() || path == "/" || path == "/v1" {
+            let mut normalized = parsed.clone();
+            normalized.set_path("/");
+            return normalized.to_string();
+        }
+    }
 
     // path == "/" 或为空 → 用户只填了 host,自动补上 api_type 默认版本路径段。
     if parsed.path() == "/" || parsed.path().is_empty() {
@@ -2848,7 +2916,8 @@ fn normalize_endpoint_url(api_type: AgentProviderApiType, base_url: &str) -> Str
     }
 
     // 用户已自带 path → 仅确保尾随 `/`(genai format!/Url::join 都依赖)。
-    let stripped = trimmed.trim_end_matches('/');
+    let normalized = parsed.to_string();
+    let stripped = normalized.trim_end_matches('/');
     format!("{stripped}/")
 }
 
@@ -2857,18 +2926,37 @@ fn normalize_endpoint_url(api_type: AgentProviderApiType, base_url: &str) -> Str
 /// 都强制路由到指定 AdapterKind,完全绕过 genai 默认的"按模型名识别"。
 pub(super) fn build_client(
     api_type: AgentProviderApiType,
-    base_url: String,
+    base_url: &str,
     api_key: String,
 ) -> Client {
-    let adapter_kind = adapter_kind_for(api_type);
-    let endpoint_url = normalize_endpoint_url(api_type, &base_url);
-    log::info!("[byop] build_client: adapter={adapter_kind:?} endpoint_url={endpoint_url}");
+    let endpoint_url = normalize_endpoint_url(api_type, base_url);
+    log::info!(
+        "[byop] build_client: api_type={api_type:?} endpoint_url={endpoint_url}"
+    );
     let key_for_resolver = api_key.clone();
     let resolver = ServiceTargetResolver::from_resolver_fn(
         move |service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
             let ServiceTarget { model, .. } = service_target;
             let endpoint = Endpoint::from_owned(endpoint_url.clone());
             let auth = AuthData::from_single(key_for_resolver.clone());
+            let model_name = model.model_name.as_str();
+            let adapter_kind = effective_adapter_kind_for(api_type, model_name, &endpoint_url);
+            if api_type == AgentProviderApiType::OpenAi
+                && adapter_kind == AdapterKind::OpenAIResp
+            {
+                log::info!(
+                    "[byop] auto-upgrade OpenAi → OpenAIResp for model={model_name} \
+                     (function tools + reasoning_effort require /v1/responses)"
+                );
+            }
+            if api_type == AgentProviderApiType::OpenAi
+                && adapter_kind == AdapterKind::Anthropic
+            {
+                log::info!(
+                    "[byop] auto-upgrade OpenAi → Anthropic for model={model_name} \
+                     (official Anthropic host requires /v1/messages)"
+                );
+            }
             // 用我们指定的 AdapterKind 覆盖 genai 的"按模型名"识别结果,
             // 但保留 model_name 以便上游服务正确寻址模型。
             let model = ModelIden::new(adapter_kind, model.model_name);
@@ -3277,7 +3365,7 @@ pub async fn generate_byop_output(
             Some(conversation_id.as_str())
         },
     );
-    let client = build_client(api_type, base_url, api_key);
+    let client = build_client(api_type, &base_url, api_key);
     let request_id = Uuid::new_v4().to_string();
     let mcp_context = params.mcp_context.clone();
     let tool_names_for_extract = available_tool_names(&params);
@@ -3322,7 +3410,7 @@ pub async fn generate_byop_output(
     // 推到 messages[0] 以便打 `cache_control`，所以 `chat_req.system` 会是 None、`system_len`
     // 显示为 0；实际 system 内容仍然在 messages[0] 里(看下面逐条报告)。为避免误
     // 导诊断者，这里加上 `system_in_messages_head` 提示。
-    log_chat_request_details(&chat_req, &model_id, api_type);
+    log_chat_request_details(&chat_req, &model_id, api_type, &base_url);
 
     // 诊断:构造包含 system / messages / tools 的完整 ChatRequest JSON dump,保存到
     // stream 闭包。真实 Anthropic wire body 会由 genai adapter 再转换一层,但这里已经
@@ -5547,6 +5635,115 @@ mod build_chat_options_off_tests {
         // gpt-4o 不在 reasoning 名单,Off 也跳过
         let o = opts(AgentProviderApiType::OpenAi, "gpt-4o", R::Off);
         assert!(o.reasoning_effort.is_none());
+    }
+}
+
+#[cfg(test)]
+mod adapter_routing_tests {
+    use super::*;
+    use genai::adapter::AdapterKind;
+
+    const OPENAI_HOST: &str = "https://api.openai.com/v1/";
+    const ANTHROPIC_HOST: &str = "https://api.anthropic.com/v1/";
+    const OPENROUTER_HOST: &str = "https://openrouter.ai/api/v1/";
+
+    #[test]
+    fn openai_gpt54_auto_upgrades_to_responses_api() {
+        assert_eq!(
+            effective_adapter_kind_for(AgentProviderApiType::OpenAi, "gpt-5.4", OPENAI_HOST),
+            AdapterKind::OpenAIResp
+        );
+    }
+
+    #[test]
+    fn openai_gpt4o_stays_on_chat_completions() {
+        assert_eq!(
+            effective_adapter_kind_for(AgentProviderApiType::OpenAi, "gpt-4o", OPENAI_HOST),
+            AdapterKind::OpenAI
+        );
+    }
+
+    #[test]
+    fn openai_resp_api_type_unchanged() {
+        assert_eq!(
+            effective_adapter_kind_for(
+                AgentProviderApiType::OpenAiResp,
+                "gpt-5.4",
+                OPENAI_HOST
+            ),
+            AdapterKind::OpenAIResp
+        );
+    }
+
+    #[test]
+    fn openai_claude_on_anthropic_host_auto_upgrades() {
+        assert_eq!(
+            effective_adapter_kind_for(
+                AgentProviderApiType::OpenAi,
+                "claude-sonnet-4-6",
+                ANTHROPIC_HOST
+            ),
+            AdapterKind::Anthropic
+        );
+    }
+
+    #[test]
+    fn openai_claude_on_openrouter_stays_openai() {
+        assert_eq!(
+            effective_adapter_kind_for(
+                AgentProviderApiType::OpenAi,
+                "anthropic/claude-sonnet-4-6",
+                OPENROUTER_HOST
+            ),
+            AdapterKind::OpenAI
+        );
+    }
+
+    #[test]
+    fn anthropic_api_type_unchanged() {
+        assert_eq!(
+            effective_adapter_kind_for(
+                AgentProviderApiType::Anthropic,
+                "claude-opus-4-7",
+                ANTHROPIC_HOST
+            ),
+            AdapterKind::Anthropic
+        );
+    }
+}
+
+#[cfg(test)]
+mod anthropic_endpoint_tests {
+    use super::*;
+
+    #[test]
+    fn host_only_gets_v1_prefix() {
+        assert_eq!(
+            normalize_endpoint_url(AgentProviderApiType::Anthropic, "https://api.anthropic.com"),
+            "https://api.anthropic.com/v1/"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_messages_path() {
+        assert_eq!(
+            normalize_endpoint_url(
+                AgentProviderApiType::Anthropic,
+                "https://api.anthropic.com/v1/messages"
+            ),
+            "https://api.anthropic.com/v1/"
+        );
+    }
+
+    #[test]
+    fn strips_messages_even_when_api_type_openai_but_host_is_anthropic() {
+        assert_eq!(
+            normalize_endpoint_url(
+                AgentProviderApiType::OpenAi,
+                "https://api.anthropic.com/v1/messages"
+            ),
+            "https://api.anthropic.com/v1/"
+        );
     }
 }
 

--- a/app/src/ai/agent_providers/oneshot.rs
+++ b/app/src/ai/agent_providers/oneshot.rs
@@ -98,7 +98,7 @@ pub async fn byop_oneshot_completion(
     user: &str,
     opts: &OneshotOptions,
 ) -> anyhow::Result<String> {
-    let client = chat_stream::build_client(cfg.api_type, cfg.base_url.clone(), cfg.api_key.clone());
+    let client = chat_stream::build_client(cfg.api_type, &cfg.base_url, cfg.api_key.clone());
     let (chat_req, chat_opts) = build_oneshot_request(cfg, system, user, opts);
 
     let resp = client
@@ -119,7 +119,7 @@ pub async fn byop_oneshot_streaming_completion(
     user: &str,
     opts: &OneshotOptions,
 ) -> anyhow::Result<String> {
-    let client = chat_stream::build_client(cfg.api_type, cfg.base_url.clone(), cfg.api_key.clone());
+    let client = chat_stream::build_client(cfg.api_type, &cfg.base_url, cfg.api_key.clone());
     let (chat_req, chat_opts) = build_oneshot_request(cfg, system, user, opts);
     let mut resp = client
         .exec_chat_stream(&cfg.model_id, chat_req, Some(&chat_opts))

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -785,7 +785,7 @@ impl AgentProviderApiType {
             Self::OpenAiResp => "https://api.openai.com/v1/",
             Self::Gemini => "https://generativelanguage.googleapis.com/v1beta/",
             Self::Anthropic => "https://api.anthropic.com/v1/",
-            Self::Ollama => "http://localhost:11434/v1/",
+            Self::Ollama => "http://localhost:11434/",
             Self::DeepSeek => "https://api.deepseek.com/v1/",
         }
     }

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -814,7 +814,7 @@ pub struct AgentProvider {
     #[serde(default)]
     pub api_type: AgentProviderApiType,
 
-    /// API base URL,例如 `https://api.deepseek.com/v1`、`http://localhost:11434/v1`。
+    /// API base URL,例如 `https://api.deepseek.com/v1`、`http://localhost:11434`。
     /// 不要带尾随斜杠,但代码侧会做容错。
     pub base_url: String,
 
@@ -1154,7 +1154,11 @@ impl PerAgentSettings {
             agent,
             CLIAgent::Claude | CLIAgent::Codex | CLIAgent::Gemini | CLIAgent::Antigravity
         );
-        Self { toolbar: true, tabmenu: true, titlebar }
+        Self {
+            toolbar: true,
+            tabmenu: true,
+            titlebar,
+        }
     }
 }
 
@@ -2457,7 +2461,10 @@ impl AISettings {
         let mut map = self.cli_agent_per_agent_settings.clone();
         map.entry(key)
             .and_modify(|s| s.toolbar = enabled)
-            .or_insert_with(|| PerAgentSettings { toolbar: enabled, ..PerAgentSettings::default_for(agent) });
+            .or_insert_with(|| PerAgentSettings {
+                toolbar: enabled,
+                ..PerAgentSettings::default_for(agent)
+            });
         report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
     }
 
@@ -2472,7 +2479,10 @@ impl AISettings {
         let mut map = self.cli_agent_per_agent_settings.clone();
         map.entry(key)
             .and_modify(|s| s.tabmenu = enabled)
-            .or_insert_with(|| PerAgentSettings { tabmenu: enabled, ..PerAgentSettings::default_for(agent) });
+            .or_insert_with(|| PerAgentSettings {
+                tabmenu: enabled,
+                ..PerAgentSettings::default_for(agent)
+            });
         report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
     }
 
@@ -2487,7 +2497,10 @@ impl AISettings {
         let mut map = self.cli_agent_per_agent_settings.clone();
         map.entry(key)
             .and_modify(|s| s.titlebar = enabled)
-            .or_insert_with(|| PerAgentSettings { titlebar: enabled, ..PerAgentSettings::default_for(agent) });
+            .or_insert_with(|| PerAgentSettings {
+                titlebar: enabled,
+                ..PerAgentSettings::default_for(agent)
+            });
         report_if_error!(self.cli_agent_per_agent_settings.set_value(map, ctx));
     }
 

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -668,7 +668,7 @@ pub enum AgentProviderApiType {
     OpenAiResp,
     /// Google Gemini 原生协议(generativelanguage.googleapis.com)。
     Gemini,
-    /// Anthropic Messages API 原生协议(api.anthropic.com)。
+    /// Anthropic Messages API 原生协议(`POST /v1/messages`,默认 `api.anthropic.com/v1/`)。
     Anthropic,
     /// Ollama 原生协议(本地或自建 Ollama)。
     Ollama,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes BYOP provider adapter and endpoint routing for OpenAI gpt-5.x, Anthropic Messages API, and Ollama native API. Agent Mode requests with tools were failing with HTTP 400/404 or malformed URLs on `upstream/main` @ `5c145ccd`.

Fixes #302

**Stacked on:** PR for #300 (`jeremyb.dev/fix/byop-agent-tool-execution`). Both are required for end-to-end BYOP Agent Mode on Ollama and OpenAI.

### Changes

**Adapter selection (`effective_adapter_kind_for`)**
- Add `effective_adapter_kind_for` in [`chat_stream.rs`](app/src/ai/agent_providers/chat_stream.rs) to resolve the genai adapter from `api_type`, model id, and `base_url`
- When `api_type=OpenAi` and model is `gpt-5*` / codex / pro, auto-upgrade to `OpenAIResp` so requests use `/v1/responses` instead of `/v1/chat/completions`
- When `api_type=OpenAi` and `base_url` points at `api.anthropic.com` with a Claude model id, route to `Anthropic` adapter
- Log auto-upgrade in `build_client`; update request diagnostics to show the effective adapter

**Endpoint normalization (`normalize_endpoint_url`)**
- Anthropic: strip trailing `/messages` to avoid `…/messages/messages` double-path
- Ollama: strip erroneous `/v1/` prefix so requests hit `/api/chat` not `/v1/api/chat`
- Correct `AgentProviderApiType::Ollama` default `base_url` in [`settings/ai.rs`](app/src/settings/ai.rs) from `http://localhost:11434/v1/` to `http://localhost:11434/`

**Tests**
- Unit tests in `adapter_routing_tests` (`gpt-5.4` upgrades, `gpt-4o` unchanged, explicit `OpenAiResp` unchanged)
- Endpoint normalization tests for Anthropic and Ollama URLs

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Zap-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

**Automated:**
```bash
cargo test -p warp adapter_routing_tests
./script/presubmit
```

**Manual (OpenAI BYOP, `gpt-5.4`):**
1. Configure provider: `api_type=OpenAi` (default), `base_url=https://api.openai.com/v1/`, model `gpt-5.4`
2. Agent prompt with tool use (e.g. run a shell command)
   - Expect: no HTTP 400 about `reasoning_effort` on `/v1/chat/completions`
   - Logs: `[byop] auto-upgrade OpenAi → OpenAIResp for model=gpt-5.4`

**Manual (Ollama 404):**
1. Configure provider: `api_type=Ollama`, default or `http://localhost:11434/v1/` base URL
2. Agent prompt
   - Expect: no 404 on `/v1/api/chat`; logs show `endpoint_url=http://localhost:11434/`

Anthropic routing was not manually tested in Agent Mode; changes are defensive hardening based on existing adapter support.

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

N/A — BYOP provider path only; no Warp cloud server changes.

## Agent Mode
- [x] Zap Agent Mode - This PR was created via Zap's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-BUG-FIX: BYOP OpenAI gpt-5.x and codex models configured with default OpenAi api_type now auto-route to the Responses API, fixing HTTP 400 errors when Agent mode sends tools with reasoning effort.
CHANGELOG-BUG-FIX: BYOP Anthropic and Ollama providers now normalize base URLs correctly (Messages API path, strip erroneous /v1/ on Ollama), fixing 404 and double-path request failures.
