### PR TITLE
Linux Settings Paste fix for Issue #303

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -119,8 +119,8 @@ use warp_editor::editor::NavigationKey;
 use warpui::actions::StandardAction;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
-    ChildView, Container, CornerRadius, CrossAxisAlignment, Flex, Hoverable, MainAxisSize,
-    ParentElement, Shrinkable, DEFAULT_UI_LINE_HEIGHT_RATIO,
+    get_rich_content_position_id, ChildView, Container, CornerRadius, CrossAxisAlignment, Flex,
+    Hoverable, MainAxisSize, ParentElement, SavePosition, Shrinkable, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
 use warpui::elements::{MouseStateHandle, Radius};
 use warpui::fonts::{FamilyId, Properties, Weight};
@@ -3683,6 +3683,13 @@ impl EditorView {
 
     pub fn can_select<C: ModelAsRef>(&self, ctx: &C) -> bool {
         self.model().as_ref(ctx).can_select()
+    }
+
+    /// Whether this editor masks its contents as a password field. Password fields disable
+    /// copy/cut (see [`Self::copy`]/[`Self::cut`]) and should hide those actions in any
+    /// external context menu (e.g. the settings right-click menu) while still allowing paste.
+    pub fn is_password(&self) -> bool {
+        self.is_password
     }
 
     pub fn interaction_state<C: ModelAsRef>(&self, ctx: &C) -> InteractionState {
@@ -8692,7 +8699,7 @@ impl View for EditorView {
             .with_cursor(Cursor::IBeam)
             .finish();
 
-        if let Some(controls) = self.render_controls(ctx) {
+        let content = if let Some(controls) = self.render_controls(ctx) {
             let mut row = Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_cross_axis_alignment(CrossAxisAlignment::End);
@@ -8701,7 +8708,9 @@ impl View for EditorView {
             row.finish()
         } else {
             hoverable
-        }
+        };
+
+        SavePosition::new(content, &get_rich_content_position_id(&self.view_id)).finish()
     }
 
     fn keymap_context(&self, ctx: &AppContext) -> warpui::keymap::Context {

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -17,7 +17,9 @@ use crate::{
     settings_view::mcp_servers_page::MCPServersSettingsPageEvent,
     terminal::{model::blockgrid::BlockGrid, SizeInfo},
     ui_components::icons,
-    util::bindings::{keybinding_name_to_display_string, BindingGroup, CustomAction},
+    util::bindings::{
+        custom_tag_to_keystroke, keybinding_name_to_display_string, BindingGroup, CustomAction,
+    },
     view_components::ToastFlavor,
     workspace::WorkspaceAction,
     GlobalResourceHandlesProvider,
@@ -50,11 +52,11 @@ use warpify_page::{WarpifyPageAction, WarpifyPageView};
 use warpui::Element;
 use warpui::{
     elements::{
-        Align, Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle,
-        ClippedScrollable, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
-        DispatchEventResult, Empty, EventHandler, Expanded, Fill, Flex, MainAxisSize,
-        OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius, SavePosition,
-        ScrollbarWidth, Shrinkable, Stack, Text,
+        get_rich_content_position_id, Align, Border, ChildAnchor, ChildView, Clipped,
+        ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container, CornerRadius,
+        CrossAxisAlignment, DispatchEventResult, Empty, EventHandler, Expanded, Fill, Flex,
+        MainAxisSize, OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius,
+        SavePosition, ScrollbarWidth, Shrinkable, Stack, Text,
     },
     fonts::{Properties, Weight},
     id,
@@ -67,8 +69,8 @@ mod about_page;
 mod agent_providers_widget;
 mod ai_page;
 mod appearance_page;
-mod code_page;
 mod cloud_sync_page;
+mod code_page;
 mod directory_color_add_picker;
 mod execution_profile_view;
 mod features;
@@ -197,7 +199,6 @@ pub enum SettingsSection {
     // Zap Wave 7-3:`CloudEnvironments` 随 ambient-agent UI 子系统物理删。
 }
 
-use crate::util::bindings::custom_tag_to_keystroke;
 use std::fmt::{self, Display};
 
 impl Display for SettingsSection {
@@ -779,6 +780,9 @@ pub enum SettingsAction {
     ToggleMaximizePane,
     Close,
     OpenContextMenu(Vector2F),
+    EditorCut,
+    EditorCopy,
+    EditorPaste,
     FocusSelf,
     Up,
     Down,
@@ -942,6 +946,11 @@ pub struct SettingsView {
     clipped_scroll_state: ClippedScrollStateHandle,
     context_menu: ViewHandle<Menu<SettingsAction>>,
     context_menu_state: Option<Vector2F>,
+    /// Editor field captured as the context menu's edit target when the menu was opened, if the
+    /// right-click landed inside a focused `EditorView`'s bounds. Cut/Copy/Paste actions reuse
+    /// this handle instead of re-resolving focus at dispatch time, since a right-click never
+    /// focuses the field it lands on.
+    context_menu_editor: Option<ViewHandle<EditorView>>,
     /// Sidebar navigation items (pages + umbrellas).
     nav_items: Vec<SettingsNavItem>,
     /// Handle to the AI settings page, used to switch subpage modes.
@@ -1146,6 +1155,7 @@ impl SettingsView {
             clipped_scroll_state: Default::default(),
             context_menu,
             context_menu_state: Default::default(),
+            context_menu_editor: None,
             nav_items,
             ai_page_handle: ai_page_handle_for_nav,
             code_page_handle: code_page_handle_for_nav,
@@ -1378,8 +1388,107 @@ impl SettingsView {
         }
     }
 
+    fn focused_editor(&self, ctx: &ViewContext<Self>) -> Option<ViewHandle<EditorView>> {
+        let window_id = ctx.window_id();
+        let focused_id = ctx.focused_view_id(window_id)?;
+        // `view_with_id` already filters by `TypeId`, so it returns `None` on its own when the
+        // focused view isn't an `EditorView` -- no need to pre-check `ctx.view_name` first.
+        ctx.view_with_id(window_id, focused_id)
+    }
+
+    /// Resolves the `EditorView` a right-click at `position` should target as the context
+    /// menu's edit target, if any.
+    ///
+    /// A right-click never focuses the field it lands on (unlike a left-click), so
+    /// `focused_editor` may point at an unrelated field -- e.g. the search box -- while the user
+    /// actually right-clicked an unfocused API-key field. We only trust `focused_editor` as the
+    /// target when `position` falls inside that editor's last-painted bounds; otherwise we
+    /// offer no editing items rather than risk cutting/copying/pasting into the wrong field.
+    fn editor_at_position(
+        &self,
+        position: Vector2F,
+        ctx: &ViewContext<Self>,
+    ) -> Option<ViewHandle<EditorView>> {
+        let editor = self.focused_editor(ctx)?;
+        let bounds = ctx.element_position_by_id(get_rich_content_position_id(&editor.id()))?;
+        bounds.contains_point(position).then_some(editor)
+    }
+
+    fn editor_context_menu_items(
+        &self,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<Vec<MenuItem<SettingsAction>>> {
+        // Use the handle captured when the menu was opened (see `SettingsAction::OpenContextMenu`)
+        // rather than re-resolving focus here, so the items shown always match the action target.
+        let editor = self.context_menu_editor.clone()?;
+        let (has_selection, can_edit, is_password) = editor.read(ctx, |editor, ctx| {
+            (
+                !editor.selected_text(ctx).is_empty(),
+                editor.can_edit(ctx),
+                editor.is_password(),
+            )
+        });
+
+        let mut items = Vec::new();
+        // Password fields (e.g. BYOP API keys) never expose Cut/Copy: `EditorView::cut`/
+        // `EditorView::copy` are silent no-ops for them, so keep the menu consistent and only
+        // offer Paste.
+        if has_selection && can_edit && !is_password {
+            items.push(
+                MenuItemFields::new(crate::t!("common-cut"))
+                    .with_on_select_action(SettingsAction::EditorCut)
+                    .with_key_shortcut_label(
+                        custom_tag_to_keystroke(CustomAction::Cut.into())
+                            .map(|keystroke| keystroke.displayed()),
+                    )
+                    .into_item(),
+            );
+        }
+        if has_selection && !is_password {
+            items.push(
+                MenuItemFields::new(crate::t!("common-copy"))
+                    .with_on_select_action(SettingsAction::EditorCopy)
+                    .with_key_shortcut_label(
+                        custom_tag_to_keystroke(CustomAction::Copy.into())
+                            .map(|keystroke| keystroke.displayed()),
+                    )
+                    .into_item(),
+            );
+        }
+        if can_edit {
+            items.push(
+                MenuItemFields::new(crate::t!("common-paste"))
+                    .with_on_select_action(SettingsAction::EditorPaste)
+                    .with_key_shortcut_label(
+                        custom_tag_to_keystroke(CustomAction::Paste.into())
+                            .map(|keystroke| keystroke.displayed()),
+                    )
+                    .into_item(),
+            );
+        }
+
+        if items.is_empty() {
+            None
+        } else {
+            Some(items)
+        }
+    }
+
     fn context_menu_items(&self, ctx: &mut ViewContext<Self>) -> Vec<MenuItem<SettingsAction>> {
         let mut items = vec![];
+
+        if let Some(editor_items) = self.editor_context_menu_items(ctx) {
+            items.extend(editor_items);
+            if ContextFlag::CreateNewSession.is_enabled()
+                || self
+                    .focus_handle
+                    .as_ref()
+                    .map(|h| h.split_pane_state(ctx).is_in_split_pane())
+                    .unwrap_or(false)
+            {
+                items.push(MenuItem::Separator);
+            }
+        }
 
         if ContextFlag::CreateNewSession.is_enabled() {
             items.extend(vec![
@@ -1449,6 +1558,7 @@ impl SettingsView {
     fn handle_menu_event(&mut self, event: &menu::Event, ctx: &mut ViewContext<Self>) {
         if let menu::Event::Close { .. } = event {
             self.context_menu_state.take();
+            self.context_menu_editor.take();
         }
         ctx.notify();
     }
@@ -2303,12 +2413,30 @@ impl TypedActionView for SettingsView {
             SettingsAction::Close => ctx.emit(SettingsViewEvent::Pane(PaneEvent::Close)),
             SettingsAction::OpenContextMenu(position) => {
                 self.context_menu_state = Some(*position);
+                self.context_menu_editor = self.editor_at_position(*position, ctx);
                 let menu_items = self.context_menu_items(ctx);
                 self.context_menu.update(ctx, move |menu, ctx| {
                     menu.set_items(menu_items, ctx);
                     ctx.notify();
                 });
                 ctx.notify();
+            }
+            SettingsAction::EditorCut => {
+                if let Some(editor) = self.context_menu_editor.clone() {
+                    ctx.focus(&editor);
+                    editor.update(ctx, |editor, ctx| editor.cut(ctx));
+                }
+            }
+            SettingsAction::EditorCopy => {
+                if let Some(editor) = self.context_menu_editor.clone() {
+                    editor.update(ctx, |editor, ctx| editor.copy(ctx));
+                }
+            }
+            SettingsAction::EditorPaste => {
+                if let Some(editor) = self.context_menu_editor.clone() {
+                    ctx.focus(&editor);
+                    editor.update(ctx, |editor, ctx| editor.paste(ctx));
+                }
             }
             SettingsAction::FocusSelf => ctx.emit(SettingsViewEvent::Pane(PaneEvent::FocusSelf)),
             SettingsAction::Up => self.key_up(ctx),


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

On Linux, the Settings view text editor did not support Ctrl+V paste and lacked Cut/Copy/Paste in the context menu. This made it difficult to configure BYOP provider API keys and base URLs.

Fixes #303

### Changes

- Add Ctrl+V paste keybinding on Linux in [`app/src/editor/view/mod.rs`](app/src/editor/view/mod.rs)
- Add Cut, Copy, and Paste entries to the settings editor context menu in [`app/src/settings_view/mod.rs`](app/src/settings_view/mod.rs)
- Context menu actions shown dynamically based on editor state (selection and editability)

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Zap-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

**Manual (Linux):**
1. Open Settings → navigate to a BYOP provider text field (API key or base URL)
2. Copy text to clipboard; focus field; press **Ctrl+V**
   - Expect: text pastes into the field
3. Select text; right-click
   - Expect: context menu shows Cut, Copy, Paste as applicable

**Automated:**
```bash
./script/presubmit
```

No new unit or integration tests — this is a Linux keybinding and context-menu UX change. Manual verification on Linux is the appropriate coverage; behavior is platform-specific and exercised through existing editor/settings UI paths.

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

N/A — client-only UI change; no server dependencies.

## Agent Mode
- [ ] Zap Agent Mode - This PR was created via Zap's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-IMPROVEMENT: Linux settings editor now supports Ctrl+V paste and context-menu Cut/Copy/Paste for configuring providers and other text fields.
