### PR TITLE
Fix CJK glyph artifacts at fractional UI scale

### DIFF
--- a/app/src/terminal/grid_renderer_test.rs
+++ b/app/src/terminal/grid_renderer_test.rs
@@ -1,17 +1,20 @@
-use super::{active_or_next_match, CachedBackgroundColor};
+use super::{CachedBackgroundColor, active_or_next_match};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
-use crate::terminal::{grid_renderer, SizeInfo};
+use crate::terminal::{SizeInfo, grid_renderer};
 use anyhow::Result;
 use futures::FutureExt as _;
 use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::vector::{vec2f, Vector2F, Vector2I};
+use pathfinder_geometry::vector::{Vector2F, Vector2I, vec2f};
 use std::any::Any;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use warpui::fonts::{Cache as FontCache, FamilyId, FontId, GlyphId, Metrics, Properties};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use warpui::fonts::{
+    Cache as FontCache, FamilyId, FontId, GlyphId, Metrics, Properties, SubpixelAlignment,
+};
 use warpui::platform::{self, LoadedSystemFonts, TextLayoutSystem};
+use warpui::scene::GlyphKey;
 use warpui::text_layout::{ClipConfig, Line, TextAlignment, TextFrame};
 use warpui::units::{IntoLines, Lines, Pixels};
 
@@ -23,6 +26,7 @@ fn rect_from_points(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> RectF {
 struct FontLookupCounts {
     select_font: AtomicUsize,
     glyph_for_char: AtomicUsize,
+    glyph_raster_bounds: AtomicUsize,
 }
 
 struct CountingFontDb {
@@ -98,8 +102,12 @@ impl platform::FontDB for CountingFontDb {
         _size: f32,
         _glyph_id: GlyphId,
         _scale: Vector2F,
+        _subpixel_alignment: SubpixelAlignment,
         _glyph_config: &warpui::rendering::GlyphConfig,
     ) -> Result<pathfinder_geometry::rect::RectI> {
+        self.counts
+            .glyph_raster_bounds
+            .fetch_add(1, Ordering::Relaxed);
         Ok(pathfinder_geometry::rect::RectI::default())
     }
 
@@ -117,7 +125,7 @@ impl platform::FontDB for CountingFontDb {
         _size: f32,
         _glyph_id: GlyphId,
         _scale: Vector2F,
-        _subpixel_alignment: warpui::fonts::SubpixelAlignment,
+        _subpixel_alignment: SubpixelAlignment,
         _glyph_config: &warpui::rendering::GlyphConfig,
         _format: warpui::fonts::canvas::RasterFormat,
     ) -> Result<warpui::fonts::RasterizedGlyph> {
@@ -140,6 +148,35 @@ impl platform::FontDB for CountingFontDb {
     fn text_layout_system(&self) -> &dyn TextLayoutSystem {
         self
     }
+}
+
+#[test]
+fn glyph_raster_bounds_are_cached_per_subpixel_alignment() {
+    let counts = Arc::new(FontLookupCounts::default());
+    let font_cache = FontCache::new(Box::new(CountingFontDb {
+        counts: Arc::clone(&counts),
+    }));
+    let glyph = GlyphKey {
+        glyph_id: 0,
+        font_id: FontId(0),
+        font_size: 12.0.into(),
+    };
+    let glyph_config = warpui::rendering::GlyphConfig::default();
+    let scale = Vector2F::splat(1.0);
+    let aligned = SubpixelAlignment::new(vec2f(0.0, 0.0));
+    let offset = SubpixelAlignment::new(vec2f(1.0 / 3.0, 0.0));
+
+    font_cache
+        .glyph_raster_bounds(glyph, scale, aligned, &glyph_config)
+        .unwrap();
+    font_cache
+        .glyph_raster_bounds(glyph, scale, aligned, &glyph_config)
+        .unwrap();
+    font_cache
+        .glyph_raster_bounds(glyph, scale, offset, &glyph_config)
+        .unwrap();
+
+    assert_eq!(counts.glyph_raster_bounds.load(Ordering::Relaxed), 2);
 }
 
 impl TextLayoutSystem for CountingFontDb {

--- a/crates/warpui/src/fonts/font_kit.rs
+++ b/crates/warpui/src/fonts/font_kit.rs
@@ -9,7 +9,7 @@ use font_kit::font::Font;
 use font_kit::hinting::HintingOptions;
 use pathfinder_geometry::rect::RectI;
 use pathfinder_geometry::transform2d::Transform2F;
-use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
+use pathfinder_geometry::vector::{Vector2F, Vector2I, vec2i};
 use warpui_core::fonts::canvas::RasterFormat;
 use warpui_core::fonts::{
     FontId, GlyphId, Properties, RasterizedGlyph, Style, SubpixelAlignment, Weight,
@@ -45,6 +45,7 @@ impl Rasterizer {
         point_size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        _subpixel_alignment: SubpixelAlignment,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI> {
         let raw_raster_bounds = self.font_for_id(font_id).raster_bounds(
@@ -100,8 +101,14 @@ impl Rasterizer {
         #[cfg(target_os = "macos")]
         let _pool = AutoreleasePoolGuard::new();
 
-        let bounds =
-            self.glyph_raster_bounds(font_id, point_size, glyph_id, scale, glyph_config)?;
+        let bounds = self.glyph_raster_bounds(
+            font_id,
+            point_size,
+            glyph_id,
+            scale,
+            subpixel_alignment,
+            glyph_config,
+        )?;
         let mut canvas = Canvas::new(bounds.size(), raster_format_to_font_kit(format));
 
         let base_transform = Transform2F::from_scale(scale).translate(-bounds.origin().to_f32());

--- a/crates/warpui/src/platform/mac/fonts.rs
+++ b/crates/warpui/src/platform/mac/fonts.rs
@@ -1,24 +1,24 @@
 use super::text_layout::{layout_line, layout_text};
-use crate::fonts::font_kit::{properties_to_font_kit, Rasterizer};
-use anyhow::{anyhow, bail, Result};
+use crate::fonts::font_kit::{Rasterizer, properties_to_font_kit};
+use anyhow::{Result, anyhow, bail};
 use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::base::{CFType, ItemRef, TCFType};
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::{CFString, CFStringRef, UniChar};
 use core_graphics::display::CGSize;
 use core_graphics::font::CGGlyph;
-use core_text::font::{cascade_list_for_languages as ct_cascade_list_for_languages, CTFont};
+use core_text::font::{CTFont, cascade_list_for_languages as ct_cascade_list_for_languages};
 use core_text::font_descriptor::{
+    CTFontDescriptor, CTFontDescriptorCopyAttribute, SymbolicTraitAccessors, TraitAccessors,
     kCTFontFamilyNameAttribute, kCTFontLanguagesAttribute, kCTFontNameAttribute,
-    kCTFontOrientationHorizontal, CTFontDescriptor, CTFontDescriptorCopyAttribute,
-    SymbolicTraitAccessors, TraitAccessors,
+    kCTFontOrientationHorizontal,
 };
 use core_text::{font, font_collection, font_descriptor};
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::{DashMap, mapref::entry::Entry};
 use font_kit::font::Font;
 use font_kit::loaders::core_text::NativeFont;
-use futures::future::BoxFuture;
 use futures::FutureExt as _;
+use futures::future::BoxFuture;
 use itertools::Itertools as _;
 use ordered_float::OrderedFloat;
 use pathfinder_geometry::rect::RectI;
@@ -27,12 +27,12 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 use warpui_core::fonts::{
-    canvas::RasterFormat, FamilyId, FontId, FontInfo, GlyphId, Metrics, Properties,
-    RasterizedGlyph, SubpixelAlignment,
+    FamilyId, FontId, FontInfo, GlyphId, Metrics, Properties, RasterizedGlyph, SubpixelAlignment,
+    canvas::RasterFormat,
 };
 use warpui_core::platform::{self, FontDB as _, LineStyle, TextLayoutSystem};
 use warpui_core::rendering;
@@ -573,10 +573,17 @@ impl crate::platform::FontDB for FontDB {
         point_size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI> {
-        self.rasterizer
-            .glyph_raster_bounds(font_id, point_size, glyph_id, scale, glyph_config)
+        self.rasterizer.glyph_raster_bounds(
+            font_id,
+            point_size,
+            glyph_id,
+            scale,
+            subpixel_alignment,
+            glyph_config,
+        )
     }
 
     fn glyph_typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<RectI> {

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -1,5 +1,5 @@
 use crate::rendering::atlas::{AllocatedRegion, TextureId};
-use crate::rendering::{get_best_dash_gap, GlyphCache, GlyphRasterBoundsFn, RasterizeGlyphFn};
+use crate::rendering::{GlyphCache, GlyphRasterBoundsFn, RasterizeGlyphFn, get_best_dash_gap};
 use warpui_core::{
     fonts::{self, SubpixelAlignment},
     rendering::{self, texture_cache::TextureCache},
@@ -19,9 +19,9 @@ use warpui_core::platform::CapturedFrame;
 use pathfinder_color::{ColorF, ColorU};
 use pathfinder_geometry::{
     rect::RectF,
-    vector::{vec2f, Vector2F},
+    vector::{Vector2F, vec2f},
 };
-use warpui_core::fonts::{canvas, RasterizedGlyph};
+use warpui_core::fonts::{RasterizedGlyph, canvas};
 use warpui_core::scene::{CornerRadius, GlyphFade, Icon, Image, Layer, Scene};
 
 use std::collections::HashMap;
@@ -633,8 +633,9 @@ impl<'a> Frame<'a> {
                 subpixel_alignment,
                 &|atlas_size| create_new_texture_atlas(atlas_size, self.ctx.device),
                 &insert_glyph_into_texture,
-                &|glyph_key, scale, alignment| {
-                    self.ctx.glyph_raster_bounds(glyph_key, scale, alignment)
+                &|glyph_key, scale, subpixel_alignment, alignment| {
+                    self.ctx
+                        .glyph_raster_bounds(glyph_key, scale, subpixel_alignment, alignment)
                 },
                 &|glyph_key, scale, subpixel_alignment, glyph_config, format| {
                     self.ctx.rasterize_glyph(
@@ -940,9 +941,10 @@ impl MetalDrawContext<'_> {
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &rendering::GlyphConfig,
     ) -> anyhow::Result<RectI> {
-        (self.glyph_raster_bounds_fn)(glyph_key, scale, glyph_config)
+        (self.glyph_raster_bounds_fn)(glyph_key, scale, subpixel_alignment, glyph_config)
     }
 }
 
@@ -979,8 +981,8 @@ impl super::super::Renderer for Renderer {
                     format,
                 )
             },
-            glyph_raster_bounds_fn: &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            glyph_raster_bounds_fn: &|glyph_key, scale, subpixel_alignment, alignment| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, subpixel_alignment, alignment)
             },
         };
 

--- a/crates/warpui/src/platform/mac/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/wgpu/renderer.rs
@@ -1,7 +1,7 @@
 use crate::platform::mac::rendering::Device;
 use crate::platform::mac::window::WindowState;
 use crate::rendering::wgpu::{Renderer, Resources};
-use crate::{fonts, Scene};
+use crate::{Scene, fonts};
 
 impl super::super::Renderer for Renderer {
     fn render(&mut self, scene: &Scene, window: &WindowState, font_cache: &fonts::Cache) {
@@ -18,8 +18,8 @@ impl super::super::Renderer for Renderer {
                     format,
                 )
             },
-            &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            &|glyph_key, scale, subpixel_alignment, alignment| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, subpixel_alignment, alignment)
             },
             window.physical_size(),
             None,

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -1,4 +1,4 @@
-use crate::fonts::{canvas, RasterizedGlyph};
+use crate::fonts::{RasterizedGlyph, canvas};
 use crate::rendering::atlas::{self, AllocatedRegion, TextureId};
 use crate::{fonts::SubpixelAlignment, rendering, scene::GlyphKey};
 use anyhow::Result;
@@ -21,7 +21,7 @@ type InsertIntoTextureCallback<'a, T> = dyn Fn(AllocatedRegion, &RasterizedGlyph
 
 /// Callback to compute the bounds of a glyph when rasterized.
 pub(crate) type GlyphRasterBoundsFn<'a> =
-    dyn Fn(GlyphKey, Vector2F, &rendering::GlyphConfig) -> Result<RectI> + 'a;
+    dyn Fn(GlyphKey, Vector2F, SubpixelAlignment, &rendering::GlyphConfig) -> Result<RectI> + 'a;
 
 /// Callback to rasterize a glyph.
 pub(crate) type RasterizeGlyphFn<'a> = dyn Fn(
@@ -110,8 +110,12 @@ impl<Texture> GlyphCache<Texture> {
 
         match self.cache.get(&cache_key) {
             None => {
-                let bounds =
-                    raster_bounds_fn(glyph_key, Vector2F::splat(scale_factor), &self.glyph_config)?;
+                let bounds = raster_bounds_fn(
+                    glyph_key,
+                    Vector2F::splat(scale_factor),
+                    subpixel_alignment,
+                    &self.glyph_config,
+                )?;
 
                 if bounds.size() == Vector2I::zero() {
                     return Ok(None);

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -917,6 +917,7 @@ impl platform::FontDB for FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
         let fonts = self
@@ -925,8 +926,14 @@ impl platform::FontDB for FontDB {
         for font in fonts {
             self.load_font_kit_font(font)?
         }
-        self.font_kit_rasterizer
-            .glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)
+        self.font_kit_rasterizer.glyph_raster_bounds(
+            font_id,
+            size,
+            glyph_id,
+            scale,
+            subpixel_alignment,
+            glyph_config,
+        )
     }
 
     #[cfg(not(feature = "fontkit-rasterizer"))]
@@ -936,9 +943,18 @@ impl platform::FontDB for FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
-        Self::glyph_raster_bounds(self, font_id, size, glyph_id, scale, glyph_config)
+        Self::glyph_raster_bounds(
+            self,
+            font_id,
+            size,
+            glyph_id,
+            scale,
+            subpixel_alignment,
+            glyph_config,
+        )
     }
 
     #[cfg(feature = "fontkit-rasterizer")]

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -5,10 +5,10 @@ use crate::fonts::{FontId, GlyphId, RasterizedGlyph, SubpixelAlignment};
 use crate::platform::FontDB as _;
 use crate::rendering::GlyphConfig;
 use crate::windowing::winit::fonts::FontDB;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use cosmic_text::{CacheKey, CacheKeyFlags};
 use pathfinder_geometry::rect::RectI;
-use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
+use pathfinder_geometry::vector::{Vector2F, Vector2I, vec2i};
 
 impl FontDB {
     pub(super) fn glyph_raster_bounds(
@@ -17,6 +17,7 @@ impl FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         _glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
         let Ok(_typographic_bounds) = self
@@ -45,7 +46,7 @@ impl FontDB {
                     id,
                     glyph_id as u16,
                     size * scale.x(),
-                    (0., 0.),
+                    (subpixel_alignment.to_offset().x(), 0.),
                     CacheKeyFlags::empty(),
                 )
                 .0,
@@ -69,8 +70,14 @@ impl FontDB {
         glyph_config: &GlyphConfig,
         requested_format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
-        let raster_bounds =
-            self.glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)?;
+        let raster_bounds = self.glyph_raster_bounds(
+            font_id,
+            size,
+            glyph_id,
+            scale,
+            subpixel_alignment,
+            glyph_config,
+        )?;
 
         let id = *self
             .text_layout_system

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::vector::{vec2f, Vector2F};
+use pathfinder_geometry::vector::{Vector2F, vec2f};
 use wgpu::rwh::HasDisplayHandle;
 use wgpu::{AdapterInfo, CompositeAlphaMode};
 use winit::dpi::PhysicalPosition;
@@ -41,20 +41,20 @@ use crate::platform::{
     WindowOptions, WindowStyle,
 };
 use crate::rendering::{
-    wgpu::{
-        adapter_has_rendering_offset_bug, from_wgpu_backend, renderer, to_wgpu_backend, Renderer,
-        Resources,
-    },
     GPUPowerPreference, GlyphConfig, OnGPUDeviceSelected,
+    wgpu::{
+        Renderer, Resources, adapter_has_rendering_offset_bug, from_wgpu_backend, renderer,
+        to_wgpu_backend,
+    },
 };
 use crate::windowing::WindowCallbacks;
-use crate::{fonts, geometry, Scene};
 use crate::{DisplayId, DisplayIdx, OptionalPlatformWindow, WindowId};
+use crate::{Scene, fonts, geometry};
 
 use super::app::CustomEvent;
 
 #[cfg(windows)]
-use super::windows::{get_system_caption_button_bounds, set_window_attribute, WindowAttributeErr};
+use super::windows::{WindowAttributeErr, get_system_caption_button_bounds, set_window_attribute};
 #[cfg(windows)]
 use windows::Win32::Graphics::Dwm;
 
@@ -900,8 +900,8 @@ impl Window {
                     format,
                 )
             },
-            &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            &|glyph_key, scale, subpixel_alignment, alignment| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, subpixel_alignment, alignment)
             },
             inner.surface_size,
             Some(Box::new(|| {

--- a/crates/warpui_core/src/fonts.rs
+++ b/crates/warpui_core/src/fonts.rs
@@ -7,11 +7,11 @@ pub use text_layout_system::TextLayoutSystem;
 
 use std::hash::Hash;
 
-use crate::{platform, rendering, scene::GlyphKey, SingletonEntity};
+use crate::{SingletonEntity, platform, rendering, scene::GlyphKey};
 use anyhow::{Error, Result};
 use dashmap::{
-    mapref::{entry::Entry, one::Ref},
     DashMap,
+    mapref::{entry::Entry, one::Ref},
 };
 
 use enum_iterator::Sequence;
@@ -20,7 +20,7 @@ use ordered_float::OrderedFloat;
 use pathfinder_geometry::vector::Vector2I;
 use pathfinder_geometry::{
     rect::{RectF, RectI},
-    vector::{vec2f, Vector2F},
+    vector::{Vector2F, vec2f},
 };
 use serde::{Deserialize, Serialize};
 
@@ -128,7 +128,7 @@ impl CustomWeightConversion for CustomWeight {
 }
 
 #[cfg(not(target_family = "wasm"))]
-use {futures_util::future::BoxFuture, futures_util::FutureExt};
+use {futures_util::FutureExt, futures_util::future::BoxFuture};
 
 pub(crate) use external_fallback::{FontBytes, RequestedFallbackFontSource};
 
@@ -207,7 +207,11 @@ pub struct FontInfo {
     pub is_monospace: bool,
 }
 
-type RasterBoundsKey = (GlyphKey, (OrderedFloat<f32>, OrderedFloat<f32>));
+type RasterBoundsKey = (
+    GlyphKey,
+    (OrderedFloat<f32>, OrderedFloat<f32>),
+    SubpixelAlignment,
+);
 type AvailableSystemFonts = Vec<(Option<FamilyId>, FontInfo)>;
 type AvailableSystemFontsSender = futures::channel::oneshot::Sender<AvailableSystemFonts>;
 
@@ -422,11 +426,14 @@ impl Cache {
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI> {
-        let entry = self
-            .raster_bounds
-            .entry((glyph_key, (scale.x().into(), scale.y().into())));
+        let entry = self.raster_bounds.entry((
+            glyph_key,
+            (scale.x().into(), scale.y().into()),
+            subpixel_alignment,
+        ));
         let bounds = match entry {
             Entry::Occupied(entry) => entry.into_ref(),
             Entry::Vacant(entry) => entry.insert(self.platform.glyph_raster_bounds(
@@ -434,6 +441,7 @@ impl Cache {
                 glyph_key.font_size.into(),
                 glyph_key.glyph_id,
                 scale,
+                subpixel_alignment,
                 glyph_config,
             )),
         };

--- a/crates/warpui_core/src/platform/mod.rs
+++ b/crates/warpui_core/src/platform/mod.rs
@@ -410,6 +410,7 @@ pub trait FontDB: 'static {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        subpixel_alignment: SubpixelAlignment,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI>;
 

--- a/crates/warpui_core/src/platform/test/delegate.rs
+++ b/crates/warpui_core/src/platform/test/delegate.rs
@@ -4,23 +4,22 @@ use crate::geometry;
 use crate::keymap::Keystroke;
 use crate::modals::{AlertDialog, ModalId};
 use crate::platform::{
-    self,
-    file_picker::{FilePickerCallback, FilePickerConfiguration},
-    Cursor, RequestNotificationPermissionsCallback, SendNotificationErrorCallback,
+    self, Cursor, RequestNotificationPermissionsCallback, SendNotificationErrorCallback,
     WindowFocusBehavior, WindowOptions,
+    file_picker::{FilePickerCallback, FilePickerConfiguration},
 };
 use crate::platform::{MicrophoneAccessState, TerminationMode, TextLayoutSystem};
 use crate::text_layout::TextAlignment;
 use crate::windowing::WindowCallbacks;
-use crate::{accessibility::AccessibilityContent, notification::UserNotification, Scene, WindowId};
 use crate::{ApplicationBundleInfo, DisplayId, DisplayIdx, OptionalPlatformWindow};
+use crate::{Scene, WindowId, accessibility::AccessibilityContent, notification::UserNotification};
 use anyhow::Result;
 use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectI;
-use pathfinder_geometry::vector::{vec2i, Vector2I};
+use pathfinder_geometry::vector::{Vector2I, vec2i};
 use pathfinder_geometry::{
     rect::RectF,
-    vector::{vec2f, Vector2F},
+    vector::{Vector2F, vec2f},
 };
 use std::any::Any;
 use std::collections::HashMap;
@@ -588,6 +587,7 @@ impl platform::FontDB for FontDB {
         _size: f32,
         _glyph_id: crate::fonts::GlyphId,
         _scale: Vector2F,
+        _subpixel_alignment: crate::fonts::SubpixelAlignment,
         _glyph_config: &crate::rendering::GlyphConfig,
     ) -> Result<pathfinder_geometry::rect::RectI> {
         Ok(pathfinder_geometry::rect::RectI::default())


### PR DESCRIPTION
## Description

Fixes #268.

On the Winit/Swash path, glyph bitmaps are rasterized at a quantized fractional x-offset, but their atlas regions were allocated from bounds calculated at offset `0`. At fractional display/UI scaling (for example 110%), the two placements can produce different bitmap bounds. The upload then uses the stale allocation dimensions, which can render adjacent rows of the bitmap as stray CJK strokes.

This change passes `SubpixelAlignment` through the glyph-bounds path and includes it in the raster-bounds cache key. The atlas allocation and uploaded raster now always use the same glyph placement.

## Testing

- Added `glyph_raster_bounds_are_cached_per_subpixel_alignment`, covering the cache-key distinction between subpixel placements.
- `git diff --check` passes.
- Attempted `cargo test -p app glyph_raster_bounds_are_cached_per_subpixel_alignment --no-default-features`; this environment stalls during Cargo toolchain probing (`rustc -vV`) and times out before compilation begins, with no compiler diagnostic.

CHANGELOG-BUG-FIX: Fixed Linux text-rendering artifacts that could affect CJK glyphs at fractional UI scaling.